### PR TITLE
Added new orders criteria to get tickets endpoints

### DIFF
--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitTicketApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitTicketApiController.php
@@ -165,6 +165,13 @@ final class OAuth2SummitTicketApiController extends OAuth2ProtectedController
                     'owner_name',
                     'owner_first_name',
                     'owner_last_name',
+                    'ticket_type',
+                    'final_amount',
+                    'owner_email',
+                    'promo_code',
+                    'bought_date',
+                    'refunded_amount',
+                    'final_amount_adjusted',
                 ];
             },
             function ($filter) use ($summit) {
@@ -307,6 +314,13 @@ final class OAuth2SummitTicketApiController extends OAuth2ProtectedController
                     'owner_name',
                     'owner_first_name',
                     'owner_last_name',
+                    'ticket_type',
+                    'final_amount',
+                    'owner_email',
+                    'promo_code',
+                    'bought_date',
+                    'refunded_amount',
+                    'final_amount_adjusted',
                 ];
             },
             function ($filter) use ($summit) {

--- a/app/Http/Utils/Order.php
+++ b/app/Http/Utils/Order.php
@@ -78,7 +78,7 @@ final class Order
                         $mapping = "ORD_{$hidden_ord_idx}";
                         ++$hidden_ord_idx;
                     }
-                    if(str_contains(strtoupper($mapping),"COUNT")){
+                    if(str_contains(strtoupper($mapping),"COUNT(")){
                         $selects = $query->getDQLPart("select");
                         $query->addSelect("({$mapping}) AS HIDDEN ORD_{$hidden_ord_idx}");
                         $mapping = "ORD_{$hidden_ord_idx}";

--- a/app/Repositories/DoctrineRepository.php
+++ b/app/Repositories/DoctrineRepository.php
@@ -129,6 +129,16 @@ abstract class DoctrineRepository extends EntityRepository implements IBaseRepos
      */
     protected abstract function applyExtraJoins(QueryBuilder $query, ?Filter $filter = null);
 
+    /**
+     * @param QueryBuilder $query
+     * @param Filter|null $filter
+     * @param Order|null $order
+     * @return QueryBuilder
+     */
+    protected function applyExtraSelects(QueryBuilder $query, ?Filter $filter = null, ?Order $order = null):QueryBuilder{
+        return $query;
+    }
+
 
     /**
      * @param callable $fnQuery
@@ -150,6 +160,8 @@ abstract class DoctrineRepository extends EntityRepository implements IBaseRepos
         $query  = call_user_func($fnQuery);
 
         $query = $this->applyExtraJoins($query, $filter);
+
+        $query = $this->applyExtraSelects($query, $filter, $order);
 
         if(!is_null($filter)){
             $filter->apply2Query($query, $this->getFilterMappings($filter));
@@ -199,6 +211,8 @@ abstract class DoctrineRepository extends EntityRepository implements IBaseRepos
 
         $query = $this->applyExtraJoins($query, $filter);
 
+        $query = $this->applyExtraSelects($query, $filter, $order);
+
         if(!is_null($filter)){
             $filter->apply2Query($query, $this->getFilterMappings($filter));
         }
@@ -233,6 +247,8 @@ abstract class DoctrineRepository extends EntityRepository implements IBaseRepos
             ->from($this->getBaseEntity(), "e");
 
         $query = $this->applyExtraJoins($query, $filter);
+
+        $query = $this->applyExtraSelects($query, $filter, $order);
 
         if(!is_null($filter)){
             $filter->apply2Query($query, $this->getFilterMappings($filter));
@@ -280,6 +296,8 @@ abstract class DoctrineRepository extends EntityRepository implements IBaseRepos
             ->from($this->getBaseEntity(), "e");
 
         $query = $this->applyExtraJoins($query, $filter);
+
+        $query = $this->applyExtraSelects($query, $filter, $order);
 
         if(!is_null($filter)){
             $filter->apply2Query($query, $this->getFilterMappings($filter));

--- a/tests/OAuth2SummitTicketsApiTest.php
+++ b/tests/OAuth2SummitTicketsApiTest.php
@@ -460,16 +460,10 @@ final class OAuth2SummitTicketsApiTest extends ProtectedApiTest
     public function testGetAllTickets()
     {
         $params = [
-            //'id' => self::$summit->getId(),
-            'id' => 13,
+            'id' => self::$summit->getId(),
             'page' => 1,
             'per_page' => 10,
-            'filter' => [
-                'owner_first_name@@A,owner_first_name@@T',
-                'has_badge==1',
-                'has_owner==1',
-            ],
-            'order' => '+id',
+            'order' => '+final_amount_adjusted',
             'expand' => 'owner,order,ticket_type,badge,promo_code'
         ];
 


### PR DESCRIPTION
GET api/v1/summits/{id}/tickets

'ticket_type',
'final_amount',
'owner_email',
'promo_code',
'bought_date',
'refunded_amount',
'final_amount_adjusted',

Change-Id: I56fecb1a5ee53318493df083b4b0fad3d7dcb818