### PR TITLE
Added new filtering/ordering for Endpoint get Tickets

### DIFF
--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitTicketApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitTicketApiController.php
@@ -124,6 +124,8 @@ final class OAuth2SummitTicketApiController extends OAuth2ProtectedController
                     'final_amount' => ['==', '<>', '>=', '>'],
                     'is_printable' => ['=='],
                     'badge_type_id' => ['=='],
+                    'has_badge_prints' => ['=='],
+                    'badge_prints_count' =>  ['==', '>=', '<=', '>', '<'],
                 ];
             },
             function () {
@@ -157,6 +159,8 @@ final class OAuth2SummitTicketApiController extends OAuth2ProtectedController
                     'final_amount' => 'sometimes|numeric',
                     'is_printable' => ['sometimes', new Boolean()],
                     'badge_type_id' => 'sometimes|integer',
+                    'has_badge_prints' => ['sometimes', new Boolean()],
+                    'badge_prints_count' => 'sometimes|integer',
                 ];
             },
             function () {
@@ -177,6 +181,7 @@ final class OAuth2SummitTicketApiController extends OAuth2ProtectedController
                     'final_amount_adjusted',
                     'badge_type_id',
                     'badge_type',
+                    'badge_prints_count',
                 ];
             },
             function ($filter) use ($summit) {
@@ -278,6 +283,8 @@ final class OAuth2SummitTicketApiController extends OAuth2ProtectedController
                     'final_amount' => ['==', '<>', '>=', '>'],
                     'is_printable' => ['=='],
                     'badge_type_id' => ['=='],
+                    'has_badge_prints' => ['=='],
+                    'badge_prints_count' =>  ['==', '>=', '<=', '>', '<'],
                 ];
             },
             function () {
@@ -311,6 +318,8 @@ final class OAuth2SummitTicketApiController extends OAuth2ProtectedController
                     'final_amount' => 'sometimes|numeric',
                     'is_printable' => ['sometimes', new Boolean()],
                     'badge_type_id' => 'sometimes|integer',
+                    'has_badge_prints' => ['sometimes', new Boolean()],
+                    'badge_prints_count' => 'sometimes|integer',
                 ];
             },
             function () {
@@ -331,6 +340,7 @@ final class OAuth2SummitTicketApiController extends OAuth2ProtectedController
                     'final_amount_adjusted',
                     'badge_type_id',
                     'badge_type',
+                    'badge_prints_count',
                 ];
             },
             function ($filter) use ($summit) {

--- a/app/ModelSerializers/Summit/Registration/SummitAttendeeTicketCSVSerializer.php
+++ b/app/ModelSerializers/Summit/Registration/SummitAttendeeTicketCSVSerializer.php
@@ -48,6 +48,7 @@ final class SummitAttendeeTicketCSVSerializer extends SilverStripeSerializer
         'FinalAmount' => 'amount_paid:json_float',
         'RefundedAmount' => 'refunded_amount:json_float',
         'FinalAmountAdjusted' => 'amount_paid_adjusted:json_float',
+        'BadgePrintsCount' => 'badge_prints_count:json_int',
     ];
 
     /**

--- a/app/ModelSerializers/Summit/Registration/SummitAttendeeTicketSerializer.php
+++ b/app/ModelSerializers/Summit/Registration/SummitAttendeeTicketSerializer.php
@@ -19,6 +19,10 @@ use Libs\ModelSerializers\One2ManyExpandSerializer;
 class SummitAttendeeTicketSerializer extends BaseSummitAttendeeTicketSerializer
 {
 
+    protected static $array_mappings = [
+        'BadgePrintsCount' => 'badge_prints_count:json_int',
+    ];
+
     protected static $expand_mappings = [
         'order' => [
             'type' => One2ManyExpandSerializer::class,

--- a/app/Models/Foundation/Summit/Registration/Attendees/SummitAttendeeTicket.php
+++ b/app/Models/Foundation/Summit/Registration/Attendees/SummitAttendeeTicket.php
@@ -1215,4 +1215,9 @@ class SummitAttendeeTicket extends SilverstripeBaseModel
             'ticket_number'  => $fields[1],
         ];
     }
+
+    public function getBadgePrintsCount():int{
+        if(!$this->hasBadge()) return 0;
+        return $this->badge->getPrintedTimes();
+    }
 }

--- a/app/Repositories/Summit/DoctrineSummitAttendeeTicketRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitAttendeeTicketRepository.php
@@ -58,6 +58,7 @@ final class DoctrineSummitAttendeeTicketRepository
         $query = $query->addSelect("(e.raw_cost - e.discount) AS HIDDEN HIDDEN_FINAL_AMOUNT");
         $query = $query->addSelect("COALESCE(SUM(rr.refunded_amount),0) AS HIDDEN HIDDEN_REFUNDED_AMOUNT");
         $query = $query->addSelect("( (e.raw_cost - e.discount) - COALESCE(SUM(rr.refunded_amount),0) ) AS HIDDEN HIDDEN_FINAL_AMOUNT_ADJUSTED");
+        $query = $query->addSelect("COUNT(prt.id) AS HIDDEN HIDDEN_BADGE_PRINTS_COUNT");
         $query->groupBy("e");
         return $query;
     }
@@ -161,6 +162,18 @@ final class DoctrineSummitAttendeeTicketRepository
                     ]
                 ),
             'badge_type_id' => 'bt.id:json_int',
+            'has_badge_prints' =>  new DoctrineSwitchFilterMapping([
+                    '1' => new DoctrineCaseFilterMapping(
+                        'true',
+                        "SIZE(prt) > 0"
+                    ),
+                    '0' => new DoctrineCaseFilterMapping(
+                        'false',
+                        "SIZE(prt) = 0"
+                    ),
+                ]
+            ),
+            'badge_prints_count' => 'SIZE(prt) :operator :value',
         ];
     }
 
@@ -175,6 +188,7 @@ final class DoctrineSummitAttendeeTicketRepository
         $query = $query->leftJoin("o.owner", "ord_m");
         $query = $query->leftJoin("e.owner", "a");
         $query = $query->leftJoin("e.badge", "b");
+        $query = $query->leftJoin("b.prints", "prt");
         $query = $query->leftJoin("b.type", "bt");
         $query = $query->leftJoin("bt.access_levels", "al");
         $query = $query->leftJoin("a.member", "m");
@@ -219,6 +233,7 @@ SQL,
             'final_amount_adjusted' => 'HIDDEN_FINAL_AMOUNT_ADJUSTED',
             'badge_type_id' => 'bt.id',
             'badge_type' => 'bt.name',
+            'badge_prints_count' => 'HIDDEN_BADGE_PRINTS_COUNT',
         ];
     }
 


### PR DESCRIPTION
GET api/v1/summits/{id}/tickets
GET api/v1/summits/{id}/tickets/csv

filtering
has_badge_prints (1|0) ops ['==']
badge_prints_count (int) op ['==', '>=', '<=', '>', '<']

ordering

badge_prints_count

Change-Id: I4197a6e4643d45f5742d76b4bbd2ec8ebfff40b4