### PR TITLE
fix: return !isEmailSent when there isn't assigned speakers

### DIFF
--- a/app/Models/Foundation/Summit/Registration/PromoCodes/Traits/SpeakersPromoCodeTrait.php
+++ b/app/Models/Foundation/Summit/Registration/PromoCodes/Traits/SpeakersPromoCodeTrait.php
@@ -283,6 +283,8 @@ trait SpeakersPromoCodeTrait
     public function isEmailSent():bool
     {
         try {
+            if(!$this->owners->count()) return false;
+
             $query = $this->createQuery("SELECT COUNT(e.id) from models\summit\AssignedPromoCodeSpeaker e 
             JOIN e.registration_promo_code pc 
             WHERE pc.id = :promo_code_id and e.sent is null");


### PR DESCRIPTION
ref https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskDueDate&view=vertical&task=3585056&stafilter=NotComplete&fileview=grid

Signed-off-by: romanetar <roman_ag@hotmail.com>