### PR TITLE
feat: add missing formatters in config and UT

### DIFF
--- a/app/Audit/ConcreteFormatters/RSVPInvitationAuditLogFormatter.php
+++ b/app/Audit/ConcreteFormatters/RSVPInvitationAuditLogFormatter.php
@@ -29,8 +29,8 @@ class RSVPInvitationAuditLogFormatter extends AbstractAuditLogFormatter
         }
 
         try {
-            $attendeeEmail = $subject->getAttendee()?->getEmail() ?? 'Unknown';
-            $attendeeId = $subject->getAttendee()?->getId() ?? 'unknown';
+            $attendeeEmail = $subject->getInvitee()?->getEmail() ?? 'Unknown';
+            $attendeeId = $subject->getInvitee()?->getId() ?? 'unknown';
             $eventTitle = $subject->getEvent()?->getTitle() ?? 'Unknown Event';
             $eventId = $subject->getEvent()?->getId() ?? 'unknown';
             $id = $subject->getId() ?? 'unknown';

--- a/config/audit_log.php
+++ b/config/audit_log.php
@@ -256,5 +256,37 @@ return [
             'enabled' => true,
             'strategy' => \App\Audit\ConcreteFormatters\ExtraQuestionTypeValueAuditLogFormatter::class,
         ],
+        \models\main\Company::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\CompanyAuditLogFormatter::class,
+        ],
+        \models\summit\PresentationCategory::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\PresentationCategoryAuditLogFormatter::class,
+        ],
+        \models\summit\PresentationCategoryGroup::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\PresentationCategoryGroupAuditLogFormatter::class,
+        ],
+        \models\summit\PresentationType::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\PresentationTypeAuditLogFormatter::class,
+        ],
+        \models\summit\RSVP::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPInvitation::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPInvitationAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPQuestionTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPTemplateAuditLogFormatter::class,
+        ],
     ]
 ];

--- a/config/audit_log.php
+++ b/config/audit_log.php
@@ -228,6 +228,10 @@ return [
             'enabled' => true,
             'strategy' => \App\Audit\ConcreteFormatters\PresentationCategoryGroupAuditLogFormatter::class,
         ],
+        \models\summit\PrivatePresentationCategoryGroup::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\PresentationCategoryGroupAuditLogFormatter::class,
+        ],
         \models\summit\PresentationAttendeeVote::class => [
             'enabled' => true,
             'strategy' => \App\Audit\ConcreteFormatters\PresentationAttendeeVoteAuditLogFormatter::class,
@@ -324,10 +328,6 @@ return [
             'enabled' => true,
             'strategy' => \App\Audit\ConcreteFormatters\PresentationCategoryAuditLogFormatter::class,
         ],
-        \models\summit\PresentationCategoryGroup::class => [
-            'enabled' => true,
-            'strategy' => \App\Audit\ConcreteFormatters\PresentationCategoryGroupAuditLogFormatter::class,
-        ],
         \models\summit\PresentationType::class => [
             'enabled' => true,
             'strategy' => \App\Audit\ConcreteFormatters\PresentationTypeAuditLogFormatter::class,
@@ -340,7 +340,39 @@ return [
             'enabled' => true,
             'strategy' => \App\Audit\ConcreteFormatters\RSVPInvitationAuditLogFormatter::class,
         ],
-        \App\Models\Foundation\Summit\Events\RSVP\RSVPQuestionTemplate::class => [
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPMemberEmailQuestionTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPMemberFirstNameQuestionTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPMemberLastNameQuestionTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPTextBoxQuestionTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPTextAreaQuestionTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPCheckBoxListQuestionTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPRadioButtonListQuestionTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPDropDownQuestionTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPLiteralContentQuestionTemplate::class => [
             'enabled' => true,
             'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
         ],

--- a/config/audit_log.php
+++ b/config/audit_log.php
@@ -316,6 +316,38 @@ return [
             'enabled' => true,
             'strategy' => \App\Audit\ConcreteFormatters\SponsorAuditLogFormatter::class,
         ],
+        \models\main\Company::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\CompanyAuditLogFormatter::class,
+        ],
+        \models\summit\PresentationCategory::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\PresentationCategoryAuditLogFormatter::class,
+        ],
+        \models\summit\PresentationCategoryGroup::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\PresentationCategoryGroupAuditLogFormatter::class,
+        ],
+        \models\summit\PresentationType::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\PresentationTypeAuditLogFormatter::class,
+        ],
+        \models\summit\RSVP::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPInvitation::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPInvitationAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPQuestionTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter::class,
+        ],
+        \App\Models\Foundation\Summit\Events\RSVP\RSVPTemplate::class => [
+            'enabled' => true,
+            'strategy' => \App\Audit\ConcreteFormatters\RSVPTemplateAuditLogFormatter::class,
+        ],
         \models\summit\SummitEventType::class => [
             'enabled' => true,
             'strategy' => \App\Audit\ConcreteFormatters\SummitEventTypeAuditLogFormatter::class,

--- a/tests/OpenTelemetry/Formatters/CompanyAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/CompanyAuditLogFormatterTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\OpenTelemetry\Formatters;
+
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Audit\ConcreteFormatters\CompanyAuditLogFormatter;
+use App\Audit\Interfaces\IAuditStrategy;
+use Tests\OpenTelemetry\Formatters\Support\AuditContextBuilder;
+use Mockery;
+use Tests\TestCase;
+
+class CompanyAuditLogFormatterTest extends TestCase
+{
+    private mixed $mockSubject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockSubject = $this->createMockSubject();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createMockSubject(): mixed
+    {
+        $mock = Mockery::mock('models\main\Company');
+        
+        // Configure return values
+        $mock->shouldReceive('getId')->andReturn(1);
+        $mock->shouldReceive('getName')->andReturn('TechCorp Inc');
+        $mock->shouldReceive('getCity')->andReturn('San Francisco');
+        $mock->shouldReceive('getCountry')->andReturn('USA');
+        $mock->shouldReceive('isDisplayOnSite')->andReturn(true);
+        
+        return $mock;
+    }
+
+    public function testSubjectCreationAuditMessage(): void
+    {
+        $formatter = new CompanyAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('created', $result);
+        $this->assertStringContainsString('TechCorp Inc', $result);
+        $this->assertStringContainsString('San Francisco', $result);
+    }
+
+    public function testSubjectUpdateAuditMessage(): void
+    {
+        $formatter = new CompanyAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $changeSet = [
+            'city' => ['San Francisco', 'Los Angeles'],
+            'country' => ['USA', 'USA']
+        ];
+        
+        $result = $formatter->format($this->mockSubject, $changeSet);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
+    public function testSubjectDeletionAuditMessage(): void
+    {
+        $formatter = new CompanyAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_DELETION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('deleted', $result);
+    }
+
+    public function testFormatterReturnsNullForInvalidSubject(): void
+    {
+        $formatter = new CompanyAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $result = $formatter->format(new \stdClass(), []);
+        $this->assertNull($result);
+    }
+}

--- a/tests/OpenTelemetry/Formatters/CompanyAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/CompanyAuditLogFormatterTest.php
@@ -88,6 +88,16 @@ class CompanyAuditLogFormatterTest extends TestCase
         $this->assertStringContainsString('deleted', $result);
     }
 
+    public function testFormatterHandlesEmptyChangeSet(): void
+    {
+        $formatter = new CompanyAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
     public function testFormatterReturnsNullForInvalidSubject(): void
     {
         $formatter = new CompanyAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);

--- a/tests/OpenTelemetry/Formatters/PresentationCategoryAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/PresentationCategoryAuditLogFormatterTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\OpenTelemetry\Formatters;
+
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Audit\ConcreteFormatters\PresentationCategoryAuditLogFormatter;
+use App\Audit\Interfaces\IAuditStrategy;
+use Tests\OpenTelemetry\Formatters\Support\AuditContextBuilder;
+use Mockery;
+use Tests\TestCase;
+
+class PresentationCategoryAuditLogFormatterTest extends TestCase
+{
+    private mixed $mockSubject;
+    private mixed $mockSummit;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockSummit = $this->createMockSummit();
+        $this->mockSubject = $this->createMockSubject();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createMockSummit(): mixed
+    {
+        $mock = Mockery::mock('models\summit\Summit');
+        $mock->shouldReceive('getName')->andReturn('OpenStack Summit 2024');
+        return $mock;
+    }
+
+    private function createMockSubject(): mixed
+    {
+        $mock = Mockery::mock('models\summit\PresentationCategory');
+        
+        // Configure return values
+        $mock->shouldReceive('getId')->andReturn(10);
+        $mock->shouldReceive('getTitle')->andReturn('Cloud Architecture');
+        $mock->shouldReceive('getCode')->andReturn('CLOUD-ARCH');
+        $mock->shouldReceive('getSummit')->andReturn($this->mockSummit);
+        
+        return $mock;
+    }
+
+    public function testSubjectCreationAuditMessage(): void
+    {
+        $formatter = new PresentationCategoryAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('created', $result);
+        $this->assertStringContainsString('Cloud Architecture', $result);
+        $this->assertStringContainsString('CLOUD-ARCH', $result);
+    }
+
+    public function testSubjectUpdateAuditMessage(): void
+    {
+        $formatter = new PresentationCategoryAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $changeSet = [
+            'title' => ['Cloud Architecture', 'Infrastructure & Architecture']
+        ];
+        
+        $result = $formatter->format($this->mockSubject, $changeSet);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
+    public function testSubjectDeletionAuditMessage(): void
+    {
+        $formatter = new PresentationCategoryAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_DELETION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('deleted', $result);
+    }
+
+    public function testFormatterReturnsNullForInvalidSubject(): void
+    {
+        $formatter = new PresentationCategoryAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $result = $formatter->format(new \stdClass(), []);
+        $this->assertNull($result);
+    }
+}

--- a/tests/OpenTelemetry/Formatters/PresentationCategoryAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/PresentationCategoryAuditLogFormatterTest.php
@@ -95,6 +95,16 @@ class PresentationCategoryAuditLogFormatterTest extends TestCase
         $this->assertStringContainsString('deleted', $result);
     }
 
+    public function testFormatterHandlesEmptyChangeSet(): void
+    {
+        $formatter = new PresentationCategoryAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
     public function testFormatterReturnsNullForInvalidSubject(): void
     {
         $formatter = new PresentationCategoryAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);

--- a/tests/OpenTelemetry/Formatters/PresentationCategoryGroupAuditLogFormatterManyToManyTest.php
+++ b/tests/OpenTelemetry/Formatters/PresentationCategoryGroupAuditLogFormatterManyToManyTest.php
@@ -46,6 +46,7 @@ class PresentationCategoryGroupAuditLogFormatterManyToManyTest extends TestCase
     private const LOG_REMOVED_IDS_PAYLOAD = 'Removed IDs: [10,11,12]';
     private const LOG_REMOVED_IDS_DIFF = 'Removed IDs: [1]';
     private const LOG_ADDED_IDS_DIFF = 'Added IDs: [3]';
+    private const LOG_NO_CHANGES = 'Added IDs: [], Removed IDs: []';
     private const DELETED_IDS_PAYLOAD = [10, 11, 12];
     private const SNAPSHOT_IDS_EMPTY = [];
     private const CURRENT_IDS_EMPTY = [];
@@ -53,6 +54,8 @@ class PresentationCategoryGroupAuditLogFormatterManyToManyTest extends TestCase
     private const CURRENT_IDS_REMOVE_ONE = [2, 3];
     private const SNAPSHOT_IDS_UPDATE = [1, 2];
     private const CURRENT_IDS_UPDATE = [2, 3];
+    private const SNAPSHOT_IDS_NO_CHANGES = [1, 2];
+    private const CURRENT_IDS_NO_CHANGES = [1, 2];
 
     protected function tearDown(): void
     {
@@ -142,6 +145,21 @@ class PresentationCategoryGroupAuditLogFormatterManyToManyTest extends TestCase
         $this->assertStringContainsString(self::LOG_UPDATED_M2M, $result);
         $this->assertStringContainsString(self::LOG_ADDED_IDS_DIFF, $result);
         $this->assertStringContainsString(self::LOG_REMOVED_IDS_DIFF, $result);
+    }
+
+    public function testManyToManyUpdateReturnsNoChangesWhenDiffEmpty(): void
+    {
+        $group = $this->makeGroup();
+        $formatter = $this->makeFormatter(IAuditStrategy::EVENT_COLLECTION_MANYTOMANY_UPDATE);
+        $collection = $this->makeCollection(self::SNAPSHOT_IDS_NO_CHANGES, self::CURRENT_IDS_NO_CHANGES);
+
+        $result = $formatter->format($group, [
+            'collection' => $collection,
+        ]);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString(self::LOG_UPDATED_M2M, $result);
+        $this->assertStringContainsString(self::LOG_NO_CHANGES, $result);
     }
 
     public static function providesNullCasesForManyToMany(): array

--- a/tests/OpenTelemetry/Formatters/PresentationCategoryGroupAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/PresentationCategoryGroupAuditLogFormatterTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\OpenTelemetry\Formatters;
+
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Audit\ConcreteFormatters\PresentationCategoryGroupAuditLogFormatter;
+use App\Audit\Interfaces\IAuditStrategy;
+use Tests\OpenTelemetry\Formatters\Support\AuditContextBuilder;
+use Mockery;
+use Tests\TestCase;
+
+class PresentationCategoryGroupAuditLogFormatterTest extends TestCase
+{
+    private mixed $mockSubject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockSubject = $this->createMockSubject();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createMockSubject(): mixed
+    {
+        $mockSummit = Mockery::mock('models\summit\Summit');
+        $mockSummit->shouldReceive('getName')->andReturn('OpenStack Summit');
+        
+        $mock = Mockery::mock('models\summit\PresentationCategoryGroup');
+        
+        // Configure return values
+        $mock->shouldReceive('getId')->andReturn(5);
+        $mock->shouldReceive('getName')->andReturn('Technical Tracks');
+        $mock->shouldReceive('getDescription')->andReturn('Group for technical presentations');
+        $mock->shouldReceive('getSummit')->andReturn($mockSummit);
+        $mock->shouldReceive('getColor')->andReturn('#FF5733');
+        $mock->shouldReceive('getMaxAttendeeVotes')->andReturn(3);
+        
+        return $mock;
+    }
+
+    public function testSubjectCreationAuditMessage(): void
+    {
+        $formatter = new PresentationCategoryGroupAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('created', $result);
+        $this->assertStringContainsString('Technical Tracks', $result);
+    }
+
+    public function testSubjectUpdateAuditMessage(): void
+    {
+        $formatter = new PresentationCategoryGroupAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $changeSet = [
+            'name' => ['Technical Tracks', 'Core Technical Topics']
+        ];
+        
+        $result = $formatter->format($this->mockSubject, $changeSet);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
+    public function testSubjectDeletionAuditMessage(): void
+    {
+        $formatter = new PresentationCategoryGroupAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_DELETION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('deleted', $result);
+    }
+
+    public function testFormatterReturnsNullForInvalidSubject(): void
+    {
+        $formatter = new PresentationCategoryGroupAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $result = $formatter->format(new \stdClass(), []);
+        $this->assertNull($result);
+    }
+}

--- a/tests/OpenTelemetry/Formatters/PresentationCategoryGroupAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/PresentationCategoryGroupAuditLogFormatterTest.php
@@ -90,6 +90,16 @@ class PresentationCategoryGroupAuditLogFormatterTest extends TestCase
         $this->assertStringContainsString('deleted', $result);
     }
 
+    public function testFormatterHandlesEmptyChangeSet(): void
+    {
+        $formatter = new PresentationCategoryGroupAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
     public function testFormatterReturnsNullForInvalidSubject(): void
     {
         $formatter = new PresentationCategoryGroupAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);

--- a/tests/OpenTelemetry/Formatters/PresentationTypeAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/PresentationTypeAuditLogFormatterTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\OpenTelemetry\Formatters;
+
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Audit\ConcreteFormatters\PresentationTypeAuditLogFormatter;
+use App\Audit\Interfaces\IAuditStrategy;
+use Tests\OpenTelemetry\Formatters\Support\AuditContextBuilder;
+use Mockery;
+use Tests\TestCase;
+
+class PresentationTypeAuditLogFormatterTest extends TestCase
+{
+    private mixed $mockSubject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockSubject = $this->createMockSubject();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createMockSubject(): mixed
+    {
+        $mockSummit = Mockery::mock('models\summit\Summit');
+        $mockSummit->shouldReceive('getName')->andReturn('OpenStack Summit 2024');
+        
+        $mock = Mockery::mock('models\summit\PresentationType');
+        
+        // Configure return values
+        $mock->shouldReceive('getId')->andReturn(2);
+        $mock->shouldReceive('getType')->andReturn('Keynote');
+        $mock->shouldReceive('getSummit')->andReturn($mockSummit);
+        $mock->shouldReceive('getMaxSpeakers')->andReturn(1);
+        $mock->shouldReceive('isUseSpeakers')->andReturn(true);
+        
+        return $mock;
+    }
+
+    public function testSubjectCreationAuditMessage(): void
+    {
+        $formatter = new PresentationTypeAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('created', $result);
+        $this->assertStringContainsString('Keynote', $result);
+    }
+
+    public function testSubjectUpdateAuditMessage(): void
+    {
+        $formatter = new PresentationTypeAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $changeSet = [
+            'name' => ['Keynote', 'Opening Keynote']
+        ];
+        
+        $result = $formatter->format($this->mockSubject, $changeSet);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
+    public function testSubjectDeletionAuditMessage(): void
+    {
+        $formatter = new PresentationTypeAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_DELETION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('deleted', $result);
+    }
+
+    public function testFormatterReturnsNullForInvalidSubject(): void
+    {
+        $formatter = new PresentationTypeAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $result = $formatter->format(new \stdClass(), []);
+        $this->assertNull($result);
+    }
+}

--- a/tests/OpenTelemetry/Formatters/PresentationTypeAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/PresentationTypeAuditLogFormatterTest.php
@@ -89,6 +89,16 @@ class PresentationTypeAuditLogFormatterTest extends TestCase
         $this->assertStringContainsString('deleted', $result);
     }
 
+    public function testFormatterHandlesEmptyChangeSet(): void
+    {
+        $formatter = new PresentationTypeAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
     public function testFormatterReturnsNullForInvalidSubject(): void
     {
         $formatter = new PresentationTypeAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);

--- a/tests/OpenTelemetry/Formatters/PresentationTypeAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/PresentationTypeAuditLogFormatterTest.php
@@ -70,7 +70,7 @@ class PresentationTypeAuditLogFormatterTest extends TestCase
         $formatter = new PresentationTypeAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
         $formatter->setContext(AuditContextBuilder::default()->build());
         $changeSet = [
-            'name' => ['Keynote', 'Opening Keynote']
+            'type' => ['Keynote', 'Opening Keynote']
         ];
         
         $result = $formatter->format($this->mockSubject, $changeSet);

--- a/tests/OpenTelemetry/Formatters/RSVPAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/RSVPAuditLogFormatterTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\OpenTelemetry\Formatters;
+
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Audit\ConcreteFormatters\RSVPAuditLogFormatter;
+use App\Audit\Interfaces\IAuditStrategy;
+use Tests\OpenTelemetry\Formatters\Support\AuditContextBuilder;
+use Mockery;
+use Tests\TestCase;
+
+class RSVPAuditLogFormatterTest extends TestCase
+{
+    private mixed $mockSubject;
+    private mixed $mockEvent;
+    private mixed $mockUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockEvent = $this->createMockEvent();
+        $this->mockUser = $this->createMockUser();
+        $this->mockSubject = $this->createMockSubject();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createMockEvent(): mixed
+    {
+        $mock = Mockery::mock('models\summit\SummitEvent');
+        $mock->shouldReceive('getTitle')->andReturn('Welcome Reception');
+        $mock->shouldReceive('getId')->andReturn(100);
+        return $mock;
+    }
+
+    private function createMockUser(): mixed
+    {
+        $mock = Mockery::mock('models\main\Member');
+        $mock->shouldReceive('getEmail')->andReturn('john@example.com');
+        $mock->shouldReceive('getId')->andReturn(50);
+        return $mock;
+    }
+
+    private function createMockSubject(): mixed
+    {
+        $mock = Mockery::mock('models\summit\RSVP');
+        
+        // Configure return values
+        $mock->shouldReceive('getId')->andReturn(15);
+        $mock->shouldReceive('getEvent')->andReturn($this->mockEvent);
+        $mock->shouldReceive('getOwner')->andReturn($this->mockUser);
+        $mock->shouldReceive('getStatus')->andReturn('confirmed');
+        $mock->shouldReceive('getSeatType')->andReturn('standard');
+        
+        return $mock;
+    }
+
+    public function testSubjectCreationAuditMessage(): void
+    {
+        $formatter = new RSVPAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('created', $result);
+        $this->assertStringContainsString('Welcome Reception', $result);
+    }
+
+    public function testSubjectUpdateAuditMessage(): void
+    {
+        $formatter = new RSVPAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $changeSet = [
+            'is_attending' => [true, false]
+        ];
+        
+        $result = $formatter->format($this->mockSubject, $changeSet);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
+    public function testSubjectDeletionAuditMessage(): void
+    {
+        $formatter = new RSVPAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_DELETION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('deleted', $result);
+    }
+
+    public function testFormatterReturnsNullForInvalidSubject(): void
+    {
+        $formatter = new RSVPAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $result = $formatter->format(new \stdClass(), []);
+        $this->assertNull($result);
+    }
+}

--- a/tests/OpenTelemetry/Formatters/RSVPAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/RSVPAuditLogFormatterTest.php
@@ -106,6 +106,16 @@ class RSVPAuditLogFormatterTest extends TestCase
         $this->assertStringContainsString('deleted', $result);
     }
 
+    public function testFormatterHandlesEmptyChangeSet(): void
+    {
+        $formatter = new RSVPAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
     public function testFormatterReturnsNullForInvalidSubject(): void
     {
         $formatter = new RSVPAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);

--- a/tests/OpenTelemetry/Formatters/RSVPInvitationAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/RSVPInvitationAuditLogFormatterTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\OpenTelemetry\Formatters;
+
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Audit\ConcreteFormatters\RSVPInvitationAuditLogFormatter;
+use App\Audit\Interfaces\IAuditStrategy;
+use Tests\OpenTelemetry\Formatters\Support\AuditContextBuilder;
+use Mockery;
+use Tests\TestCase;
+
+class RSVPInvitationAuditLogFormatterTest extends TestCase
+{
+    private mixed $mockSubject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockSubject = $this->createMockSubject();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createMockEvent(): mixed
+    {
+        $mock = Mockery::mock('models\summit\SummitEvent');
+        $mock->shouldReceive('getTitle')->andReturn('Wedding Event');
+        $mock->shouldReceive('getId')->andReturn(200);
+        return $mock;
+    }
+
+    private function createMockAttendee(): mixed
+    {
+        $mock = Mockery::mock('models\summit\SummitAttendee');
+        $mock->shouldReceive('getEmail')->andReturn('attendee@example.com');
+        $mock->shouldReceive('getId')->andReturn(75);
+        return $mock;
+    }
+
+    private function createMockSubject(): mixed
+    {
+        $mock = Mockery::mock('App\Models\Foundation\Summit\Events\RSVP\RSVPInvitation');
+        
+        // Configure return values
+        $mock->shouldReceive('getId')->andReturn(20);
+        $mock->shouldReceive('getInvitee')->andReturn($this->createMockAttendee());
+        $mock->shouldReceive('getEvent')->andReturn($this->createMockEvent());
+        
+        return $mock;
+    }
+
+    public function testSubjectCreationAuditMessage(): void
+    {
+        $formatter = new RSVPInvitationAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('created', $result);
+        $this->assertStringContainsString('attendee@example.com', $result);
+        $this->assertStringContainsString('Wedding Event', $result);
+    }
+
+    public function testSubjectUpdateAuditMessage(): void
+    {
+        $formatter = new RSVPInvitationAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $changeSet = [
+            'confirmed' => [false, true]
+        ];
+        
+        $result = $formatter->format($this->mockSubject, $changeSet);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+        $this->assertStringContainsString('attendee@example.com', $result);
+    }
+
+    public function testSubjectDeletionAuditMessage(): void
+    {
+        $formatter = new RSVPInvitationAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_DELETION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('deleted', $result);
+    }
+
+    public function testFormatterReturnsNullForInvalidSubject(): void
+    {
+        $formatter = new RSVPInvitationAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $result = $formatter->format(new \stdClass(), []);
+        $this->assertNull($result);
+    }
+}

--- a/tests/OpenTelemetry/Formatters/RSVPInvitationAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/RSVPInvitationAuditLogFormatterTest.php
@@ -102,6 +102,16 @@ class RSVPInvitationAuditLogFormatterTest extends TestCase
         $this->assertStringContainsString('deleted', $result);
     }
 
+    public function testFormatterHandlesEmptyChangeSet(): void
+    {
+        $formatter = new RSVPInvitationAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
     public function testFormatterReturnsNullForInvalidSubject(): void
     {
         $formatter = new RSVPInvitationAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);

--- a/tests/OpenTelemetry/Formatters/RSVPQuestionTemplateAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/RSVPQuestionTemplateAuditLogFormatterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\OpenTelemetry\Formatters;
+
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Audit\ConcreteFormatters\RSVPQuestionTemplateAuditLogFormatter;
+use App\Audit\Interfaces\IAuditStrategy;
+use Tests\OpenTelemetry\Formatters\Support\AuditContextBuilder;
+use Mockery;
+use Tests\TestCase;
+
+class RSVPQuestionTemplateAuditLogFormatterTest extends TestCase
+{
+    private mixed $mockSubject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockSubject = $this->createMockSubject();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createMockTemplate(): mixed
+    {
+        $mock = Mockery::mock('App\Models\Foundation\Summit\Events\RSVP\RSVPTemplate');
+        $mock->shouldReceive('getId')->andReturn(999);
+        return $mock;
+    }
+
+    private function createMockSubject(): mixed
+    {
+        $mock = Mockery::mock('App\Models\Foundation\Summit\Events\RSVP\RSVPQuestionTemplate');
+        
+        // Configure return values
+        $mock->shouldReceive('getId')->andReturn(25);
+        $mock->shouldReceive('getName')->andReturn('attendance_question');
+        $mock->shouldReceive('getLabel')->andReturn('Will you attend?');
+        $mock->shouldReceive('getTemplate')->andReturn($this->createMockTemplate());
+        $mock->shouldReceive('isMandatory')->andReturn(true);
+        $mock->shouldReceive('getOrder')->andReturn(1);
+        
+        return $mock;
+    }
+
+    public function testSubjectCreationAuditMessage(): void
+    {
+        $formatter = new RSVPQuestionTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('created', $result);
+        $this->assertStringContainsString('Will you attend?', $result);
+        $this->assertStringContainsString('required', $result);
+    }
+
+    public function testSubjectUpdateAuditMessage(): void
+    {
+        $formatter = new RSVPQuestionTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $changeSet = [
+            'label' => ['Will you attend?', 'Can you attend?']
+        ];
+        
+        $result = $formatter->format($this->mockSubject, $changeSet);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+        $this->assertStringContainsString('Will you attend?', $result);
+    }
+
+    public function testSubjectDeletionAuditMessage(): void
+    {
+        $formatter = new RSVPQuestionTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_DELETION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('deleted', $result);
+    }
+
+    public function testFormatterReturnsNullForInvalidSubject(): void
+    {
+        $formatter = new RSVPQuestionTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $result = $formatter->format(new \stdClass(), []);
+        $this->assertNull($result);
+    }
+}

--- a/tests/OpenTelemetry/Formatters/RSVPQuestionTemplateAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/RSVPQuestionTemplateAuditLogFormatterTest.php
@@ -96,6 +96,16 @@ class RSVPQuestionTemplateAuditLogFormatterTest extends TestCase
         $this->assertStringContainsString('deleted', $result);
     }
 
+    public function testFormatterHandlesEmptyChangeSet(): void
+    {
+        $formatter = new RSVPQuestionTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
     public function testFormatterReturnsNullForInvalidSubject(): void
     {
         $formatter = new RSVPQuestionTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);

--- a/tests/OpenTelemetry/Formatters/RSVPTemplateAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/RSVPTemplateAuditLogFormatterTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\OpenTelemetry\Formatters;
+
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Audit\ConcreteFormatters\RSVPTemplateAuditLogFormatter;
+use App\Audit\Interfaces\IAuditStrategy;
+use Tests\OpenTelemetry\Formatters\Support\AuditContextBuilder;
+use Mockery;
+use Tests\TestCase;
+
+class RSVPTemplateAuditLogFormatterTest extends TestCase
+{
+    private mixed $mockSubject;
+    private mixed $mockSummit;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockSummit = $this->createMockSummit();
+        $this->mockSubject = $this->createMockSubject();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createMockSummit(): mixed
+    {
+        $mock = Mockery::mock('models\summit\Summit');
+        $mock->shouldReceive('getName')->andReturn('Summit 2024');
+        return $mock;
+    }
+
+    private function createMockSubject(): mixed
+    {
+        $mockQuestions = Mockery::mock('Doctrine\Common\Collections\ArrayCollection');
+        $mockQuestions->shouldReceive('count')->andReturn(3);
+        
+        $mockCreatedBy = Mockery::mock('models\main\Member');
+        $mockCreatedBy->shouldReceive('getFirstName')->andReturn('Admin');
+        $mockCreatedBy->shouldReceive('getLastName')->andReturn('User');
+        
+        $mock = Mockery::mock('App\Models\Foundation\Summit\Events\RSVP\RSVPTemplate');
+        
+        // Configure return values
+        $mock->shouldReceive('getId')->andReturn(30);
+        $mock->shouldReceive('getTitle')->andReturn('Gala Dinner RSVP');
+        $mock->shouldReceive('getSummit')->andReturn($this->mockSummit);
+        $mock->shouldReceive('isEnabled')->andReturn(true);
+        $mock->shouldReceive('getCreatedBy')->andReturn($mockCreatedBy);
+        $mock->shouldReceive('getQuestions')->andReturn($mockQuestions);
+        
+        return $mock;
+    }
+
+    public function testSubjectCreationAuditMessage(): void
+    {
+        $formatter = new RSVPTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('created', $result);
+        $this->assertStringContainsString('Gala Dinner RSVP', $result);
+    }
+
+    public function testSubjectUpdateAuditMessage(): void
+    {
+        $formatter = new RSVPTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $changeSet = [
+            'title' => ['Gala Dinner RSVP', 'Cocktail Dinner RSVP']
+        ];
+        
+        $result = $formatter->format($this->mockSubject, $changeSet);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
+    public function testSubjectDeletionAuditMessage(): void
+    {
+        $formatter = new RSVPTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_DELETION);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+        
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('deleted', $result);
+    }
+
+    public function testFormatterReturnsNullForInvalidSubject(): void
+    {
+        $formatter = new RSVPTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);
+        $result = $formatter->format(new \stdClass(), []);
+        $this->assertNull($result);
+    }
+}

--- a/tests/OpenTelemetry/Formatters/RSVPTemplateAuditLogFormatterTest.php
+++ b/tests/OpenTelemetry/Formatters/RSVPTemplateAuditLogFormatterTest.php
@@ -103,6 +103,16 @@ class RSVPTemplateAuditLogFormatterTest extends TestCase
         $this->assertStringContainsString('deleted', $result);
     }
 
+    public function testFormatterHandlesEmptyChangeSet(): void
+    {
+        $formatter = new RSVPTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_UPDATE);
+        $formatter->setContext(AuditContextBuilder::default()->build());
+        $result = $formatter->format($this->mockSubject, []);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('updated', $result);
+    }
+
     public function testFormatterReturnsNullForInvalidSubject(): void
     {
         $formatter = new RSVPTemplateAuditLogFormatter(IAuditStrategy::EVENT_ENTITY_CREATION);


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b8nemnj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RSVP Invitation audit messages now derive participant identity from the invitee, correcting reported attendee info.

* **New Features**
  * Audit logging enabled for Companies, Presentation Categories, Presentation Types, Presentation Category Groups, and multiple RSVP entities (invitations, templates, question types).

* **Tests**
  * Added comprehensive formatter tests covering create/update/delete, empty change-sets, and many-to-many “no changes” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->