### PR TITLE
feat: remove selection plan ref from presentation when a category is removed from a category group

### DIFF
--- a/app/Models/Foundation/Summit/Events/Presentations/PresentationCategory.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/PresentationCategory.php
@@ -680,6 +680,28 @@ SQL;
     }
 
     /**
+     * @param int[] $selection_plan_ids
+     * @return Presentation[]
+     */
+    public function getPresentationsBySelectionPlanIds(array $selection_plan_ids): array
+    {
+        if (empty($selection_plan_ids)) return [];
+
+        $query = <<<DQL
+SELECT p
+FROM models\summit\Presentation p
+WHERE p.category = :track
+AND p.selection_plan IN (:selection_plan_ids)
+DQL;
+
+        return $this->getEM()
+            ->createQuery($query)
+            ->setParameter('track', $this)
+            ->setParameter('selection_plan_ids', $selection_plan_ids)
+            ->getResult();
+    }
+
+    /**
      * @return SummitEvent[]
      */
     public function getRelatedPublishedSummitEvents(){

--- a/app/Models/Foundation/Summit/Events/Presentations/PresentationCategoryGroup.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/PresentationCategoryGroup.php
@@ -13,6 +13,7 @@
  **/
 
 use App\Models\Foundation\Summit\ScheduleEntity;
+use App\Models\Foundation\Summit\SelectionPlan;
 use Doctrine\Common\Collections\Criteria;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -70,6 +71,13 @@ class PresentationCategoryGroup extends SilverstripeBaseModel
     protected $max_attendee_votes;
 
 
+    /**
+     * inverse side
+     * @var SelectionPlan[]
+     */
+    #[ORM\ManyToMany(targetEntity: \App\Models\Foundation\Summit\SelectionPlan::class, mappedBy: 'category_groups', fetch: 'EXTRA_LAZY')]
+    protected $selection_plans;
+
     public function __construct()
     {
         parent::__construct();
@@ -77,6 +85,29 @@ class PresentationCategoryGroup extends SilverstripeBaseModel
         $this->end_attendee_voting_period_date = null;
         $this->max_attendee_votes = 0;
         $this->categories = new ArrayCollection;
+        $this->selection_plans = new ArrayCollection;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getSelectionPlanIds(): array
+    {
+        return $this->selection_plans->map(function ($sp) {
+            return $sp->getId();
+        })->toArray();
+    }
+
+    public function addSelectionPlan(SelectionPlan $selection_plan): void
+    {
+        if ($this->selection_plans->contains($selection_plan)) return;
+        $this->selection_plans->add($selection_plan);
+    }
+
+    public function removeSelectionPlan(SelectionPlan $selection_plan): void
+    {
+        if (!$this->selection_plans->contains($selection_plan)) return;
+        $this->selection_plans->removeElement($selection_plan);
     }
 
 

--- a/app/Models/Foundation/Summit/SelectionPlan.php
+++ b/app/Models/Foundation/Summit/SelectionPlan.php
@@ -169,7 +169,7 @@ class SelectionPlan extends SilverstripeBaseModel
     #[ORM\JoinTable(name: 'SelectionPlan_CategoryGroups')]
     #[ORM\JoinColumn(name: 'SelectionPlanID', referencedColumnName: 'ID')]
     #[ORM\InverseJoinColumn(name: 'PresentationCategoryGroupID', referencedColumnName: 'ID')]
-    #[ORM\ManyToMany(targetEntity: \models\summit\PresentationCategoryGroup::class, fetch: 'EXTRA_LAZY')]
+    #[ORM\ManyToMany(targetEntity: \models\summit\PresentationCategoryGroup::class, inversedBy: 'selection_plans', fetch: 'EXTRA_LAZY')]
     private $category_groups;
 
     /**
@@ -596,6 +596,7 @@ class SelectionPlan extends SilverstripeBaseModel
     {
         if ($this->category_groups->contains($track_group)) return;
         $this->category_groups->add($track_group);
+        $track_group->addSelectionPlan($this);
     }
 
     /**
@@ -605,6 +606,7 @@ class SelectionPlan extends SilverstripeBaseModel
     {
         if (!$this->category_groups->contains($track_group)) return;
         $this->category_groups->removeElement($track_group);
+        $track_group->removeSelectionPlan($this);
     }
 
     public function addEventType(SummitEventType $eventType)

--- a/app/Services/Model/Imp/PresentationCategoryGroupService.php
+++ b/app/Services/Model/Imp/PresentationCategoryGroupService.php
@@ -262,6 +262,7 @@ final class PresentationCategoryGroupService
             // been called yet at this point.
             foreach ($presentations as $presentation) {
                 $selection_plan = $presentation->getSelectionPlan();
+                if (is_null($selection_plan)) continue;
                 $track_reachable_via_another_group = $selection_plan->getCategoryGroups()->exists(
                     function ($key, $group) use ($track, $track_group) {
                         return $group->getId() !== $track_group->getId()

--- a/app/Services/Model/Imp/PresentationCategoryGroupService.php
+++ b/app/Services/Model/Imp/PresentationCategoryGroupService.php
@@ -252,6 +252,27 @@ final class PresentationCategoryGroupService
                 );
             }
 
+            $presentations = $track->getPresentationsBySelectionPlanIds($track_group->getSelectionPlanIds());
+
+            // Only clear the selection plan if no other category group in that plan
+            // still contains $track. A selection plan can span multiple groups, so
+            // removing $track from $track_group does not necessarily invalidate the
+            // plan for presentations under $track — another group may still cover it.
+            // We exclude $track_group from the check because removeCategory has not
+            // been called yet at this point.
+            foreach ($presentations as $presentation) {
+                $selection_plan = $presentation->getSelectionPlan();
+                $track_reachable_via_another_group = $selection_plan->getCategoryGroups()->exists(
+                    function ($key, $group) use ($track, $track_group) {
+                        return $group->getId() !== $track_group->getId()
+                            && $group->hasCategory($track->getId());
+                    }
+                );
+                if (!$track_reachable_via_another_group) {
+                    $presentation->clearSelectionPlan();
+                }
+            }
+
             $track_group->removeCategory($track);
 
         });

--- a/tests/oauth2/OAuth2TrackGroupsApiTest.php
+++ b/tests/oauth2/OAuth2TrackGroupsApiTest.php
@@ -1,4 +1,8 @@
 <?php namespace Tests;
+use LaravelDoctrine\ORM\Facades\Registry;
+use models\summit\Presentation;
+use models\utils\SilverstripeBaseModel;
+
 /**
  * Copyright 2018 OpenStack Foundation
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -341,6 +345,16 @@ final class OAuth2TrackGroupsApiTest extends ProtectedApiTestCase
 
         $this->assertResponseStatus(201);
 
+        // verify presentations of defaultTrack have a selection plan before disassociation
+        $presentations = self::$defaultTrack->getPresentationsBySelectionPlanIds(
+            self::$defaultTrackGroup->getSelectionPlanIds()
+        );
+        $this->assertNotEmpty($presentations);
+        foreach ($presentations as $presentation) {
+            $this->assertTrue($presentation->getSelectionPlanId() > 0);
+        }
+        $presentation_ids = array_map(fn($p) => $p->getId(), $presentations);
+
         // now disassociate
         $response = $this->action(
             "DELETE",
@@ -353,6 +367,14 @@ final class OAuth2TrackGroupsApiTest extends ProtectedApiTestCase
         );
 
         $this->assertResponseStatus(204);
+
+        // reset EM (closed after the API transaction) and re-fetch presentations to verify selection plan was cleared
+        self::$em = Registry::resetManager(SilverstripeBaseModel::EntityManager);
+        foreach ($presentation_ids as $id) {
+            $presentation = self::$em->find(Presentation::class, $id);
+            $this->assertNotNull($presentation);
+            $this->assertEquals(0, $presentation->getSelectionPlanId());
+        }
     }
 
     public function testAddPrivateTrackGroup(){

--- a/tests/oauth2/OAuth2TrackGroupsApiTest.php
+++ b/tests/oauth2/OAuth2TrackGroupsApiTest.php
@@ -377,6 +377,67 @@ final class OAuth2TrackGroupsApiTest extends ProtectedApiTestCase
         }
     }
 
+    public function testDisassociateTrackFromTrackGroupPreservesSelectionPlanWhenTrackReachableViaAnotherGroup()
+    {
+        // Set up a second category group (TrackGroupB) that also contains $defaultTrack
+        // and belongs to the same $default_selection_plan as $defaultTrackGroup (TrackGroupA).
+        // Removing $defaultTrack from TrackGroupA should NOT clear the selection plan on
+        // presentations because TrackGroupB still covers the track within the same plan.
+        $track_group_b = new \models\summit\PresentationCategoryGroup();
+        $track_group_b->setName("TRACK GROUP B");
+        $track_group_b->addCategory(self::$defaultTrack);
+        self::$summit->addCategoryGroup($track_group_b);
+        self::$default_selection_plan->addTrackGroup($track_group_b);
+        self::$em->persist($track_group_b);
+        self::$em->flush();
+
+        $headers = [
+            "HTTP_Authorization" => " Bearer " . $this->access_token,
+            "CONTENT_TYPE"       => "application/json"
+        ];
+
+        $params = [
+            'id'             => self::$summit->getId(),
+            'track_group_id' => self::$defaultTrackGroup->getId(),
+            'track_id'       => self::$defaultTrack->getId()
+        ];
+
+        // Only collect presentations that belong to $default_selection_plan — the plan
+        // that has TrackGroupB as a second group covering $defaultTrack.
+        // Presentations of $default_selection_plan2 are intentionally excluded: that plan
+        // only has $defaultTrackGroup, so their selection plan will be correctly cleared.
+        $presentations = self::$defaultTrack->getPresentationsBySelectionPlanIds(
+            [self::$default_selection_plan->getId()]
+        );
+        $this->assertNotEmpty($presentations);
+        foreach ($presentations as $presentation) {
+            $this->assertTrue($presentation->getSelectionPlanId() > 0);
+        }
+        $presentation_ids = array_map(fn($p) => $p->getId(), $presentations);
+
+        // disassociate $defaultTrack from TrackGroupA
+        $response = $this->action(
+            "DELETE",
+            "OAuth2PresentationCategoryGroupController@disassociateTrack2TrackGroup",
+            $params,
+            [],
+            [],
+            [],
+            $headers
+        );
+
+        $this->assertResponseStatus(204);
+
+        // reset EM and re-fetch presentations — selection plan must be preserved
+        // because TrackGroupB still contains $defaultTrack within the same plan
+        self::$em = \LaravelDoctrine\ORM\Facades\Registry::resetManager(\models\utils\SilverstripeBaseModel::EntityManager);
+        foreach ($presentation_ids as $id) {
+            $presentation = self::$em->find(\models\summit\Presentation::class, $id);
+            $this->assertNotNull($presentation);
+            $this->assertGreaterThan(0, $presentation->getSelectionPlanId());
+        }
+    }
+
     public function testAddPrivateTrackGroup(){
         $params = [
             'id' => self::$summit->getId(),


### PR DESCRIPTION
ref https://app.clickup.com/t/86b8rp3vh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Presentations now have their selection-plan association cleared only when a track is truly no longer covered by any category group.

* **Refactor**
  * Category group ↔ selection plan relationships now synchronize more reliably to prevent inconsistent associations.

* **Tests**
  * Added/updated tests verifying selection-plan cleanup on disassociation and preservation when another group still covers the track.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->