### PR TITLE
fix(audit): allow nullable sponsor in SummitSponsorExtraQuestionType::getSponsor

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,6 +59,7 @@ jobs:
                     - { name: "SummitRSVPServiceTest", filter: "--filter SummitRSVPServiceTest" }
                     - { name: "SummitRSVPInvitationServiceTest", filter: "--filter SummitRSVPInvitationServiceTest" }
                     - { name: "EntityModelUnitTests", filter: "tests/Unit/Entities/" }
+                    - { name: "AuditUnitTests", filter: "tests/Unit/Audit/" }
                     - { name: "AuditOtlpStrategyTest", filter: "--filter AuditOtlpStrategyTest" }
                     - { name: "AuditEventTypesTest", filter: "--filter AuditEventTypesTest" }
                     - { name: "GuzzleTracingTest", filter: "--filter GuzzleTracingTest" }

--- a/app/Events/SponsorServices/SummitSponsorshipAddOnCreatedEventDTO.php
+++ b/app/Events/SponsorServices/SummitSponsorshipAddOnCreatedEventDTO.php
@@ -58,6 +58,7 @@ class SummitSponsorshipAddOnCreatedEventDTO
         $sponsorship = $add_on->getSponsorship();
         $summit_sponsorship_type = $sponsorship->getType();
         $sponsorship_type = $summit_sponsorship_type->getType();
+        $sponsor = $sponsorship->getSponsor();
 
         return new self(
             $add_on->getId(),
@@ -67,8 +68,8 @@ class SummitSponsorshipAddOnCreatedEventDTO
             $sponsorship_type->getName(),
             $add_on->getType(),
             $add_on->getName(),
-            $add_on->getSponsorship()->getSponsor()->getId(),
-            $add_on->getSponsorship()->getSponsor()->getSummitId(),
+            $sponsor?->getId() ?? 0,
+            $sponsor?->getSummitId() ?? 0,
         );
     }
 

--- a/app/Events/SponsorServices/SummitSponsorshipCreatedEventDTO.php
+++ b/app/Events/SponsorServices/SummitSponsorshipCreatedEventDTO.php
@@ -50,11 +50,11 @@ class SummitSponsorshipCreatedEventDTO
 
         return new self(
             $sponsorship->getId(),
-            $sponsor->getId(),
+            $sponsor?->getId() ?? 0,
             $summit_sponsorship_type->getId(),
             $sponsorship_type->getId(),
             $sponsorship_type->getName(),
-            $sponsor->getSummitId()
+            $sponsor?->getSummitId() ?? 0
         );
     }
 

--- a/app/Jobs/Emails/Registration/PromoCodes/SponsorPromoCodeEmail.php
+++ b/app/Jobs/Emails/Registration/PromoCodes/SponsorPromoCodeEmail.php
@@ -54,10 +54,10 @@ class SponsorPromoCodeEmail extends AbstractSummitEmailJob
         $summit = $promo_code->getSummit();
         $payload = [];
         $sponsor = $promo_code->getSponsor();
-        $payload[IMailTemplatesConstants::sponsor_tier_name] = implode(',', $sponsor->getSponsorshipTierNames());
+        $payload[IMailTemplatesConstants::sponsor_tier_name] = $sponsor ? implode(',', $sponsor->getSponsorshipTierNames()) : '';
         $payload[IMailTemplatesConstants::promo_code] = $promo_code->getCode();
         $payload[IMailTemplatesConstants::company_name] = '';
-        $company = $sponsor->getCompany();
+        $company = $sponsor?->getCompany();
         if (!is_null($company))
             $payload[IMailTemplatesConstants::company_name] = $company->getName();
 

--- a/app/ModelSerializers/Summit/Registration/PromoCodes/SponsorSummitRegistrationDiscountCodeSerializer.php
+++ b/app/ModelSerializers/Summit/Registration/PromoCodes/SponsorSummitRegistrationDiscountCodeSerializer.php
@@ -62,7 +62,9 @@ class SponsorSummitRegistrationDiscountCodeSerializer
                     }
                         break;
                     case 'sponsor_name':{
-                        $values['sponsor_name'] = $code->getSponsor()->getCompany()->getName();
+                        if($code->hasSponsor()) {
+                            $values['sponsor_name'] = $code->getSponsor()->getCompany()->getName();
+                        }
                     }
                         break;
                 }

--- a/app/ModelSerializers/Summit/Registration/PromoCodes/SponsorSummitRegistrationPromoCodeSerializer.php
+++ b/app/ModelSerializers/Summit/Registration/PromoCodes/SponsorSummitRegistrationPromoCodeSerializer.php
@@ -63,7 +63,9 @@ extends SummitRegistrationPromoCodeSerializer
                     }
                         break;
                     case 'sponsor_name':{
-                        $values['sponsor_name'] = $code->getSponsor()->getCompany()->getName();
+                        if($code->hasSponsor()) {
+                            $values['sponsor_name'] = $code->getSponsor()->getCompany()->getName();
+                        }
                     }
                     break;
                 }

--- a/app/ModelSerializers/Summit/Registration/SponsorBadgeScanCSVSerializer.php
+++ b/app/ModelSerializers/Summit/Registration/SponsorBadgeScanCSVSerializer.php
@@ -65,6 +65,10 @@ final class SponsorBadgeScanCSVSerializer extends AbstractSerializer
         if (!$scan instanceof SponsorBadgeScan) return [];
         $values = parent::serialize($expand, $fields, $relations, $params);
         $sponsor = $scan->getSponsor();
+
+        //There are no sponsor questions to process without a sponsor
+        if (is_null($sponsor)) return $values;
+
         $sponsor_questions = $sponsor->getExtraQuestions();
         $setting = $sponsor->getSummit()->getLeadReportSettingFor($sponsor);
         $setting_columns = $setting->getColumns();

--- a/app/ModelSerializers/Summit/Registration/SponsorUserInfoGrantCSVSerializer.php
+++ b/app/ModelSerializers/Summit/Registration/SponsorUserInfoGrantCSVSerializer.php
@@ -51,10 +51,13 @@ class SponsorUserInfoGrantCSVSerializer extends SponsorUserInfoGrantSerializer
         $values['notes'] = 'VIRTUAL';
 
         $sponsor = $grant->getSponsor();
+
+        //There are no sponsor questions to process without a sponsor
+        if (is_null($sponsor)) return $values;
+
         $sponsor_questions = $sponsor->getExtraQuestions();
         $setting = $sponsor->getSummit()->getLeadReportSettingFor($sponsor);
         $setting_columns = $setting->getColumns();
-
 
         // remove not allowed string columns and sort them by setting columns order
         $new_values = [];

--- a/app/Models/Foundation/Summit/ExtraQuestions/SummitSponsorExtraQuestionType.php
+++ b/app/Models/Foundation/Summit/ExtraQuestions/SummitSponsorExtraQuestionType.php
@@ -35,7 +35,7 @@ class SummitSponsorExtraQuestionType extends ExtraQuestionType
     ];
 
     /**
-     * @var Sponsor
+     * @var Sponsor|null
      */
     #[ORM\JoinColumn(name: 'SponsorID', referencedColumnName: 'ID', onDelete: 'CASCADE')]
     #[ORM\ManyToOne(targetEntity: \models\summit\Sponsor::class, inversedBy: 'extra_questions')]

--- a/app/Models/Foundation/Summit/ExtraQuestions/SummitSponsorExtraQuestionType.php
+++ b/app/Models/Foundation/Summit/ExtraQuestions/SummitSponsorExtraQuestionType.php
@@ -42,9 +42,9 @@ class SummitSponsorExtraQuestionType extends ExtraQuestionType
     private $sponsor;
 
     /**
-     * @return Sponsor
+     * @return Sponsor|null
      */
-    public function getSponsor(): Sponsor
+    public function getSponsor(): ?Sponsor
     {
         return $this->sponsor;
     }

--- a/app/Models/Foundation/Summit/Registration/PromoCodes/Traits/SponsorPromoCodeTrait.php
+++ b/app/Models/Foundation/Summit/Registration/PromoCodes/Traits/SponsorPromoCodeTrait.php
@@ -71,9 +71,9 @@ trait SponsorPromoCodeTrait
     }
 
     /**
-     * @return Sponsor
+     * @return Sponsor|null
      */
-    public function getSponsor():Sponsor
+    public function getSponsor(): ?Sponsor
     {
         return $this->sponsor;
     }

--- a/app/Models/Foundation/Summit/Registration/SponsorUserInfoGrant.php
+++ b/app/Models/Foundation/Summit/Registration/SponsorUserInfoGrant.php
@@ -29,7 +29,7 @@ class SponsorUserInfoGrant extends SilverstripeBaseModel
 
     const ClassName = 'SponsorUserInfoGrant';
     /**
-     * @var Sponsor
+     * @var Sponsor|null
      */
     #[ORM\JoinColumn(name: 'SponsorID', referencedColumnName: 'ID')]
     #[ORM\ManyToOne(targetEntity: \models\summit\Sponsor::class, inversedBy: 'user_info_grants')]
@@ -53,9 +53,9 @@ class SponsorUserInfoGrant extends SilverstripeBaseModel
     ];
 
     /**
-     * @return Sponsor
+     * @return Sponsor|null
      */
-    public function getSponsor(): Sponsor
+    public function getSponsor(): ?Sponsor
     {
         return $this->sponsor;
     }

--- a/app/Models/Foundation/Summit/SponsorMaterial.php
+++ b/app/Models/Foundation/Summit/SponsorMaterial.php
@@ -53,7 +53,7 @@ class SponsorMaterial extends SilverstripeBaseModel
     private $order;
 
     /**
-     * @var Sponsor
+     * @var Sponsor|null
      */
     #[ORM\JoinColumn(name: 'SponsorID', referencedColumnName: 'ID', onDelete: 'CASCADE')]
     #[ORM\ManyToOne(targetEntity: \Sponsor::class, inversedBy: 'materials', fetch: 'EXTRA_LAZY')]
@@ -144,9 +144,9 @@ class SponsorMaterial extends SilverstripeBaseModel
     }
 
     /**
-     * @return Sponsor
+     * @return Sponsor|null
      */
-    public function getSponsor(): Sponsor
+    public function getSponsor(): ?Sponsor
     {
         return $this->sponsor;
     }

--- a/app/Models/Foundation/Summit/SponsorStatistics.php
+++ b/app/Models/Foundation/Summit/SponsorStatistics.php
@@ -27,7 +27,7 @@ class SponsorStatistics extends SilverstripeBaseModel
     use One2ManyPropertyTrait;
 
     /**
-     * @var Sponsor
+     * @var Sponsor|null
      */
     #[ORM\JoinColumn(name: 'SponsorID', referencedColumnName: 'ID', onDelete: 'CASCADE')]
     #[ORM\OneToOne(targetEntity: Sponsor::class, inversedBy: 'sponsorservices_statistics', fetch: 'EXTRA_LAZY')]
@@ -66,7 +66,7 @@ class SponsorStatistics extends SilverstripeBaseModel
         $this->documentsQty = 0;
     }
 
-    public function getSponsor(): Sponsor
+    public function getSponsor(): ?Sponsor
     {
         return $this->sponsor;
     }

--- a/app/Models/Foundation/Summit/SummitLeadReportSetting.php
+++ b/app/Models/Foundation/Summit/SummitLeadReportSetting.php
@@ -29,7 +29,7 @@ class SummitLeadReportSetting extends SilverstripeBaseModel
     const SponsorExtraQuestionsKey = 'extra_questions';
 
     /**
-     * @var Sponsor
+     * @var Sponsor|null
      */
     #[ORM\JoinColumn(name: 'SponsorID', referencedColumnName: 'ID', onDelete: 'SET NULL')]
     #[ORM\OneToOne(targetEntity: \models\summit\Sponsor::class, inversedBy: 'lead_report_setting')]
@@ -51,9 +51,9 @@ class SummitLeadReportSetting extends SilverstripeBaseModel
     }
 
     /**
-     * @return Sponsor
+     * @return Sponsor|null
      */
-    public function getSponsor(): Sponsor
+    public function getSponsor(): ?Sponsor
     {
         return $this->sponsor;
     }

--- a/app/Models/Foundation/Summit/SummitSponsorship.php
+++ b/app/Models/Foundation/Summit/SummitSponsorship.php
@@ -39,7 +39,7 @@ class SummitSponsorship extends SilverstripeBaseModel
     ];
 
     /**
-     * @var Sponsor
+     * @var Sponsor|null
      */
     #[ORM\JoinColumn(name: 'SponsorID', referencedColumnName: 'ID')]
     #[ORM\ManyToOne(targetEntity: Sponsor::class)]
@@ -64,7 +64,7 @@ class SummitSponsorship extends SilverstripeBaseModel
         $this->add_ons = new ArrayCollection();
     }
 
-    public function getSponsor(): Sponsor
+    public function getSponsor(): ?Sponsor
     {
         return $this->sponsor;
     }

--- a/tests/Unit/Audit/SummitSponsorExtraQuestionTypeAuditLogFormatterTest.php
+++ b/tests/Unit/Audit/SummitSponsorExtraQuestionTypeAuditLogFormatterTest.php
@@ -1,0 +1,216 @@
+<?php namespace Tests\Unit\Audit;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Audit\ConcreteFormatters\SummitSponsorExtraQuestionTypeAuditLogFormatter;
+use App\Audit\Interfaces\IAuditStrategy;
+use App\Models\Foundation\ExtraQuestions\ExtraQuestionTypeConstants;
+use App\Models\Foundation\Summit\ExtraQuestions\SummitSponsorExtraQuestionType;
+use models\main\Company;
+use models\summit\Sponsor;
+use Tests\TestCase;
+
+/**
+ * Regression tests for SummitSponsorExtraQuestionTypeAuditLogFormatter.
+ *
+ * Reproduces the production TypeError that occurred when deleting a
+ * SummitSponsorExtraQuestionType:
+ *
+ *   Sponsor::removeExtraQuestion() calls $extra_question->clearSponsor(),
+ *   which nulls the sponsor in-memory. On flush, AuditEventListener invokes
+ *   this formatter, which calls $subject->getSponsor(). Before the fix,
+ *   that method was typed `: Sponsor` (non-nullable) and threw TypeError
+ *   because PHP refused to return null under a non-null return type.
+ *
+ *   TypeError escaped the formatter's try/catch because it catches
+ *   \Exception, but TypeError extends \Error (not \Exception), so the
+ *   500 reached the user.
+ *
+ * The fix widens getSponsor() to `: ?Sponsor`. These tests lock in that
+ * behavior: after clearSponsor() the formatter must return a non-null
+ * string without throwing, and fall back to the "Unknown Sponsor" label.
+ *
+ * @package Tests\Unit\Audit
+ */
+final class SummitSponsorExtraQuestionTypeAuditLogFormatterTest extends TestCase
+{
+    private const LABEL       = 'What is your T-shirt size?';
+    private const QUESTION_ID = 950;
+    private const SPONSOR_ID  = 610;
+
+    /**
+     * Build a SummitSponsorExtraQuestionType with the sponsor explicitly
+     * cleared - mirroring what Sponsor::removeExtraQuestion() does on the
+     * deletion path that caused the original production TypeError.
+     */
+    private function makeQuestionWithClearedSponsor(): SummitSponsorExtraQuestionType
+    {
+        $company = new Company();
+        $company->setName('Acme Corp');
+
+        $sponsor = new Sponsor();
+        $sponsor->setCompany($company);
+        $this->setProtectedId($sponsor, self::SPONSOR_ID);
+
+        $question = new SummitSponsorExtraQuestionType();
+        $question->setName('tshirt_size');
+        $question->setType(ExtraQuestionTypeConstants::TextQuestionType);
+        $question->setLabel(self::LABEL);
+        $question->setSponsor($sponsor);
+        $this->setProtectedId($question, self::QUESTION_ID);
+
+        // Simulate what Sponsor::removeExtraQuestion() does: it calls
+        // clearSponsor() on the extra question to cut the bidirectional link
+        // BEFORE the flush reaches the audit listener.
+        $question->clearSponsor();
+
+        return $question;
+    }
+
+    /**
+     * Build a SummitSponsorExtraQuestionType with an attached sponsor
+     * (happy path - sanity check that the formatter still works).
+     */
+    private function makeQuestionWithSponsor(): SummitSponsorExtraQuestionType
+    {
+        $company = new Company();
+        $company->setName('Acme Corp');
+
+        $sponsor = new Sponsor();
+        $sponsor->setCompany($company);
+        $this->setProtectedId($sponsor, self::SPONSOR_ID);
+
+        $question = new SummitSponsorExtraQuestionType();
+        $question->setName('tshirt_size');
+        $question->setType(ExtraQuestionTypeConstants::TextQuestionType);
+        $question->setLabel(self::LABEL);
+        $question->setSponsor($sponsor);
+        $this->setProtectedId($question, self::QUESTION_ID);
+
+        return $question;
+    }
+
+    /**
+     * BaseEntity::$id is protected with no public setter; use reflection
+     * so the formatter sees a stable numeric id in its output.
+     */
+    private function setProtectedId(object $entity, int $id): void
+    {
+        $rc = new \ReflectionClass($entity);
+        while ($rc !== false && !$rc->hasProperty('id')) {
+            $rc = $rc->getParentClass();
+        }
+        if ($rc === false) {
+            self::fail('Could not locate $id property on ' . get_class($entity));
+        }
+        $prop = $rc->getProperty('id');
+        $prop->setAccessible(true);
+        $prop->setValue($entity, $id);
+    }
+
+    /**
+     * Reproduces the exact production failure: deletion flow where
+     * clearSponsor() has been invoked before the audit listener runs.
+     *
+     * Before the fix: TypeError from getSponsor() escaped through the
+     * try/catch(\Exception) and propagated up to the HTTP handler.
+     *
+     * After the fix: formatter returns a non-null string with the
+     * "Unknown Sponsor" fallback.
+     */
+    public function test_deletion_format_does_not_crash_when_sponsor_is_cleared(): void
+    {
+        $question  = $this->makeQuestionWithClearedSponsor();
+        $formatter = new SummitSponsorExtraQuestionTypeAuditLogFormatter(
+            IAuditStrategy::EVENT_ENTITY_DELETION
+        );
+
+        $result = $formatter->format($question, []);
+
+        self::assertIsString($result, 'Formatter must not throw or return null on deletion with cleared sponsor');
+        self::assertStringContainsString(self::LABEL, $result);
+        self::assertStringContainsString('(ID: ' . self::QUESTION_ID . ')', $result);
+        self::assertStringContainsString('Unknown Sponsor', $result);
+        self::assertStringContainsString('deleted by user', $result);
+    }
+
+    /**
+     * The audit formatter is also invoked on updates; ensure the same
+     * null-safe path is taken there.
+     */
+    public function test_update_format_does_not_crash_when_sponsor_is_cleared(): void
+    {
+        $question  = $this->makeQuestionWithClearedSponsor();
+        $formatter = new SummitSponsorExtraQuestionTypeAuditLogFormatter(
+            IAuditStrategy::EVENT_ENTITY_UPDATE
+        );
+
+        $result = $formatter->format($question, []);
+
+        self::assertIsString($result);
+        self::assertStringContainsString(self::LABEL, $result);
+        self::assertStringContainsString('Unknown Sponsor', $result);
+        self::assertStringContainsString('updated', $result);
+    }
+
+    /**
+     * Defensive: creation formatting must also tolerate a null sponsor.
+     */
+    public function test_creation_format_does_not_crash_when_sponsor_is_cleared(): void
+    {
+        $question  = $this->makeQuestionWithClearedSponsor();
+        $formatter = new SummitSponsorExtraQuestionTypeAuditLogFormatter(
+            IAuditStrategy::EVENT_ENTITY_CREATION
+        );
+
+        $result = $formatter->format($question, []);
+
+        self::assertIsString($result);
+        self::assertStringContainsString(self::LABEL, $result);
+        self::assertStringContainsString('Unknown Sponsor', $result);
+        self::assertStringContainsString('created by user', $result);
+    }
+
+    /**
+     * Happy-path sanity: when the sponsor is attached the formatter
+     * renders the company name and sponsor id (proves the null-safety
+     * fix didn't regress the normal output format).
+     */
+    public function test_deletion_format_includes_company_and_sponsor_id_when_sponsor_present(): void
+    {
+        $question  = $this->makeQuestionWithSponsor();
+        $formatter = new SummitSponsorExtraQuestionTypeAuditLogFormatter(
+            IAuditStrategy::EVENT_ENTITY_DELETION
+        );
+
+        $result = $formatter->format($question, []);
+
+        self::assertIsString($result);
+        self::assertStringContainsString('Acme Corp', $result);
+        self::assertStringContainsString('(ID: ' . self::SPONSOR_ID . ')', $result);
+        self::assertStringNotContainsString('Unknown Sponsor', $result);
+    }
+
+    /**
+     * Guards the early-return: formatter must ignore subjects of other
+     * types without throwing.
+     */
+    public function test_format_returns_null_for_unrelated_subject(): void
+    {
+        $formatter = new SummitSponsorExtraQuestionTypeAuditLogFormatter(
+            IAuditStrategy::EVENT_ENTITY_DELETION
+        );
+
+        self::assertNull($formatter->format(new \stdClass(), []));
+    }
+}

--- a/tests/oauth2/OAuth2SummitLocationsApiTest.php
+++ b/tests/oauth2/OAuth2SummitLocationsApiTest.php
@@ -665,7 +665,10 @@ final class OAuth2SummitLocationsApiTest extends ProtectedApiTestCase
             'venue_id' => self::$mainVenue->getId()
         ];
 
-        $number = rand(0,1000);
+        // Collision-free floor number: start above the seed floor (number=1 in InsertSummitTestData)
+        // and monotonically increment to guarantee uniqueness across calls in the same process.
+        static $floor_number_seq = 1000;
+        $number = ++$floor_number_seq;
         $name = str_random(16).'_floor';
         $data = [
            'name'        => $name,


### PR DESCRIPTION
ref https://app.clickup.com/t/86b9ca05g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a sponsor is missing or removed across emails, serializers, CSV exports and event payloads to prevent errors and provide sensible defaults.
* **Tests**
  * Added unit coverage for audit log formatting when sponsor data is absent; made a test deterministic by replacing randomness.
* **Chores**
  * Extended CI test matrix to include additional audit unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->