### PR TITLE
fix(db): convert SponsorBadgeScan.Notes to utf8mb4

### DIFF
--- a/database/migrations/model/Version20260429160000.php
+++ b/database/migrations/model/Version20260429160000.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Migrations\Model;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+
+class Version20260429160000 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $sql = <<<SQL
+ALTER TABLE `SponsorBadgeScan` MODIFY Notes VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL;
+SQL;
+        $this->addSql($sql);
+    }
+
+    public function down(Schema $schema): void
+    {
+
+    }
+}


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9nvmdj
The Notes column is on utf8 (3-byte), causing 'Incorrect string value' PDOExceptions when users submit 4-byte characters (emoji, supplementary plane). Convert to utf8mb4_general_ci to match the precedent set for SummitAttendee.AdminNotes in Version20221012133111.