### PR TITLE
fix(authz): block non-admin members from changing duration on published events

### DIFF
--- a/app/Models/Foundation/Summit/Events/SummitEvent.php
+++ b/app/Models/Foundation/Summit/Events/SummitEvent.php
@@ -1770,6 +1770,12 @@ class SummitEvent extends SilverstripeBaseModel implements IPublishableEvent
         if (!$this->type->isAllowsPublishingDates()) {
             throw new ValidationException("Type does not allows Publishing Period.");
         }
+        // Once an event is published, only summit admins may change its duration.
+        // The published path silently shifts end_date via _setDuration when start_date
+        // is set, which would move a live schedule slot for any non-admin caller.
+        if ($this->isPublished() && !is_null($member) && !$member->isSummitAllowed($this->getSummit())) {
+            throw new ValidationException("Cannot modify duration of a published event.");
+        }
         $this->_setDuration($this->getSummit(), $duration_in_seconds, $skipDatesSetting, $member);
     }
 

--- a/tests/SummitEventModelTest.php
+++ b/tests/SummitEventModelTest.php
@@ -11,11 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+use models\main\Member;
 use models\summit\SummitEvent;
 use models\summit\Presentation;
 use LaravelDoctrine\ORM\Facades\EntityManager;
 use Doctrine\Persistence\ObjectRepository;
 use Illuminate\Support\Facades\DB;
+use models\exceptions\ValidationException;
 use DateTimeZone;
 use DateTime;
 use DateInterval;
@@ -76,5 +78,29 @@ class SummitEventModelTest extends ProtectedApiTestCase
         $presentation->setEndDate($end_date);
         $new_duration = $presentation->getDuration();
         $this->assertTrue($old_duration < $new_duration);
+    }
+
+    public function testNonAdminMemberCannotChangeDurationOnPublishedEvent(){
+        $presentation = self::$presentations[0];
+        $this->assertTrue($presentation->isPublished());
+
+        $member = Mockery::mock(Member::class)->makePartial();
+        $member->shouldReceive('isSummitAllowed')->andReturn(false);
+
+        $this->expectException(ValidationException::class);
+        $presentation->setDuration(864000, false, $member);
+    }
+
+    public function testAdminMemberCanChangeDurationOnPublishedEvent(){
+        $presentation = self::$presentations[0];
+        $this->assertTrue($presentation->isPublished());
+
+        $member = Mockery::mock(Member::class)->makePartial();
+        $member->shouldReceive('isSummitAllowed')->andReturn(true);
+
+        $old_end_date = $presentation->getEndDate();
+        $presentation->setDuration(864000, false, $member);
+        $new_end_date = $presentation->getEndDate();
+        $this->assertTrue($old_end_date < $new_end_date);
     }
 }


### PR DESCRIPTION
## Summary
Move the published-event duration guard into `SummitEvent::setDuration` so the invariant is enforced at the entity boundary, not just in the UI or a single controller.

## Why
For a published event, `SummitEvent::setDuration` → `TimeDurationRestrictedEvent::_setDuration` silently shifts `end_date = start_date + duration` whenever `start_date` is set. The track-chair edit path (`PUT /api/v1/summits/{id}/events/{event_id}` → `OAuth2SummitEventsApiController@updateEvent` → `AbstractPublishService::updateDuration`) calls `setDuration(..., $current_member)` without checking publication state, which means a chair token + curl can move a live schedule slot with no audit and no notification.

Putting the check in the controller would close the chair path but leave the invariant scattered: any future service or controller that calls `setDuration` would need to remember to repeat the check. The setter is the single place every caller must pass through, so the entity should own the rule.

## What changed
- `app/Models/Foundation/Summit/Events/SummitEvent.php` — `setDuration` now throws `ValidationException` when the event is published and the supplied `$member` is non-admin for the summit.
- `tests/SummitEventModelTest.php` — adds two cases against an already-published presentation fixture: a mocked non-admin member is rejected, a mocked admin member succeeds and the end_date shifts as before.

## Compatibility notes
- The check intentionally skips when `$member` is `null`. Trusted internal callers like `SummitService::advanceSummit` (`app/Services/Model/Imp/SummitService.php:2731`) call `setDuration` with no member during bulk schedule shifts and must continue to work. That mirrors the convention used elsewhere where authorization checks are gated on a user being present.
- The existing `testChangeEventDuration` continues to pass because it also calls `setDuration` without a member.
- This is the API-side complement to the UI gate landed in [fntechgit/track-chairs#67](https://github.com/fntechgit/track-chairs/pull/67). They are independent — either alone closes the visible workflow, but the entity guard is what protects against direct API calls.

## Test plan
- [ ] `phpunit tests/SummitEventModelTest.php` — new tests pass; existing tests still pass.
- [ ] Manual: as a track chair, `PUT /api/v1/summits/{id}/events/{published_event_id}` with `{"duration": 1800}` returns a 412 ValidationException response (was: 200 with the slot's end_date silently moved).
- [ ] Manual: as a summit admin, the same call still succeeds.
- [ ] Manual: scheduling/advance-summit bulk operations continue to update durations on published events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced authorization controls for published summit event duration modifications. The system now validates member permissions before allowing duration changes on published events. Non-authorized members cannot modify published event durations and will receive validation errors on attempt. This prevents unauthorized schedule changes while allowing authorized members to adjust event times as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->