### PR TITLE
feat(member): include last finished summit sponsor memberships in getActiveSummitsSponsorMemberships

### DIFF
--- a/app/Models/Foundation/Main/Member.php
+++ b/app/Models/Foundation/Main/Member.php
@@ -1834,18 +1834,35 @@ SQL;
     public function getActiveSummitsSponsorMemberships()
     {
         // Step 1 — use native SQL (needed for JSON_CONTAINS) to collect IDs only.
+        // Also includes sponsors from the last finished summit where this member had
+        // sponsor permissions, so access is retained immediately after a summit ends.
         $idSql = <<<SQL
 SELECT sp.ID
 FROM Sponsor sp
 INNER JOIN Sponsor_Users su ON su.SponsorID = sp.ID
 INNER JOIN Summit s ON s.ID = sp.SummitID
 WHERE su.MemberID = :member_id
-    AND s.SummitEndDate >= :now
+    AND (
+        s.SummitEndDate >= :now
+        OR s.ID = (
+            SELECT s2.ID
+            FROM Summit s2
+            INNER JOIN Sponsor sp2 ON sp2.SummitID = s2.ID
+            INNER JOIN Sponsor_Users su2 ON su2.SponsorID = sp2.ID
+            WHERE su2.MemberID = :member_id
+                AND s2.SummitEndDate < :now
+                AND (
+                    JSON_CONTAINS(COALESCE(su2.Permissions, '[]'), JSON_QUOTE(:slug_sponsors))
+                    OR JSON_CONTAINS(COALESCE(su2.Permissions, '[]'), JSON_QUOTE(:slug_external))
+                )
+            ORDER BY s2.SummitEndDate DESC
+            LIMIT 1
+        )
+    )
     AND (
         JSON_CONTAINS(COALESCE(su.Permissions, '[]'), JSON_QUOTE(:slug_sponsors))
         OR JSON_CONTAINS(COALESCE(su.Permissions, '[]'), JSON_QUOTE(:slug_external))
     )
-ORDER BY s.SummitBeginDate ASC
 SQL;
 
         $stmt = $this->prepareRawSQL($idSql, [


### PR DESCRIPTION
ref https://app.clickup.com/t/86b9vzxfk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sponsors now retain access to their permissions for the immediately preceding finished summit in addition to currently active summits, ensuring continuous access right after a summit concludes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenStackweb/summit-api/pull/544)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->