### PR TITLE
fix(sponsors): dispatch SponsorshipCreated/Removed when sponsorships are attached inline via addSponsor or updateSponsor

### DIFF
--- a/app/Jobs/SponsorServices/PublishSponsorServiceDomainEventsJob.php
+++ b/app/Jobs/SponsorServices/PublishSponsorServiceDomainEventsJob.php
@@ -35,9 +35,19 @@ final class PublishSponsorServiceDomainEventsJob implements ShouldQueue
     private $event_type;
 
     public function __construct(array $payload, string $event_type){
-        $this->payload = $payload;
+        $this->payload    = $payload;
         $this->event_type = $event_type;
         Log::debug(sprintf("PublishSponsorServiceDomainEventsJob::__construct payload %s event_type %s ", json_encode($payload), $event_type));
+    }
+
+    public function getEventType(): string
+    {
+        return $this->event_type;
+    }
+
+    public function getPayload(): array
+    {
+        return $this->payload;
     }
 
     public function handle(): void

--- a/app/Services/Model/Imp/SummitSponsorService.php
+++ b/app/Services/Model/Imp/SummitSponsorService.php
@@ -203,7 +203,7 @@ final class SummitSponsorService
      */
     public function updateSponsor(Summit $summit, int $sponsor_id, array $payload): Sponsor
     {
-        [$sponsor, $added_sponsorships, $removed_sponsorships] = $this->tx_service->transaction(function () use ($summit, $sponsor_id, $payload) {
+        [$sponsor, $added_sponsorships, $removed_sponsorships, $updated_sponsorships] = $this->tx_service->transaction(function () use ($summit, $sponsor_id, $payload) {
             Log::debug
             (
                 sprintf
@@ -251,6 +251,7 @@ final class SummitSponsorService
 
             $added_sponsorships = [];
             $removed_sponsorships = [];
+            $updated_sponsorships = [];
 
             if(isset($payload['sponsorship_id'])) {
                 $type_id = intval($payload['sponsorship_id']);
@@ -272,7 +273,9 @@ final class SummitSponsorService
                         )
                     );
                     // update the first
-                    $summit_sponsor->getSponsorships()->first()->setType($summit_sponsorship_type);
+                    $sponsorship = $summit_sponsor->getSponsorships()->first();
+                    $sponsorship->setType($summit_sponsorship_type);
+                    $updated_sponsorships[] = $sponsorship;
                 }
                 else {
                     Log::debug
@@ -358,7 +361,7 @@ final class SummitSponsorService
              SummitSponsorCreatedEventDTO::fromSummitSponsor($sponsor)->serialize(),
                 SponsorDomainEvents::SponsorUpdated);
 
-            return [$sponsor, $added_sponsorships, $removed_sponsorships];
+            return [$sponsor, $added_sponsorships, $removed_sponsorships, $updated_sponsorships];
         });
 
         foreach ($removed_sponsorships as $sponsorship) {
@@ -383,6 +386,18 @@ final class SummitSponsorService
             PublishSponsorServiceDomainEventsJob::dispatch(
                 SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
                 SponsorDomainEvents::SponsorshipCreated);
+        }
+
+        foreach ($updated_sponsorships as $sponsorship) {
+            Log::debug(sprintf(
+                "SummitSponsorService::updateSponsor dispatching SponsorshipUpdated for sponsorship %s type %s sponsor %s",
+                $sponsorship->getId(),
+                $sponsorship->getType()->getId(),
+                $sponsor_id
+            ));
+            PublishSponsorServiceDomainEventsJob::dispatch(
+                SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
+                SponsorDomainEvents::SponsorshipUpdated);
         }
 
         return $sponsor;

--- a/app/Services/Model/Imp/SummitSponsorService.php
+++ b/app/Services/Model/Imp/SummitSponsorService.php
@@ -14,6 +14,7 @@
 
 use App\Events\SponsorServices\SponsorDomainEvents;
 use App\Events\SponsorServices\SummitSponsorCreatedEventDTO;
+use App\Events\SponsorServices\SummitSponsorshipCreatedEventDTO;
 use App\Events\SponsorServices\DeletedEventDTO;
 use App\Http\Utils\IFileUploader;
 use App\Jobs\SponsorServices\PublishSponsorServiceDomainEventsJob;
@@ -114,7 +115,9 @@ final class SummitSponsorService
      */
     public function addSponsor(Summit $summit, array $payload): Sponsor
     {
-        $sponsor = $this->tx_service->transaction(function () use ($summit, $payload) {
+        $new_sponsorships = [];
+
+        $sponsor = $this->tx_service->transaction(function () use ($summit, $payload, &$new_sponsorships) {
             $company_id = intval($payload['company_id']);
             $featured_event_id = isset($payload['featured_event_id']) ? intval($payload['featured_event_id']) : 0;
 
@@ -150,6 +153,7 @@ final class SummitSponsorService
                 $sponsorship = new SummitSponsorship();
                 $sponsorship->setType($summit_sponsorship_type);
                 $sponsor->addSponsorship($sponsorship);
+                $new_sponsorships[] = $sponsorship;
             } else if(isset($payload['sponsorships'])) {
                 foreach ($payload['sponsorships'] as $sponsorship_payload) {
                     $type_id = isset($sponsorship_payload['type_id']) ?
@@ -162,6 +166,7 @@ final class SummitSponsorService
                     $sponsorship = new SummitSponsorship();
                     $sponsorship->setType($summit_sponsorship_type);
                     $sponsor->addSponsorship($sponsorship);
+                    $new_sponsorships[] = $sponsorship;
                 }
             }
 
@@ -173,6 +178,12 @@ final class SummitSponsorService
         PublishSponsorServiceDomainEventsJob::dispatch(
              SummitSponsorCreatedEventDTO::fromSummitSponsor($sponsor)->serialize(),
             SponsorDomainEvents::SponsorCreated);
+
+        foreach ($new_sponsorships as $sponsorship) {
+            PublishSponsorServiceDomainEventsJob::dispatch(
+                SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
+                SponsorDomainEvents::SponsorshipCreated);
+        }
 
         return $sponsor;
     }
@@ -187,7 +198,10 @@ final class SummitSponsorService
      */
     public function updateSponsor(Summit $summit, int $sponsor_id, array $payload): Sponsor
     {
-        return $this->tx_service->transaction(function () use ($summit, $sponsor_id, $payload) {
+        $added_sponsorships = [];
+        $removed_sponsorships = [];
+
+        $sponsor = $this->tx_service->transaction(function () use ($summit, $sponsor_id, $payload, &$added_sponsorships, &$removed_sponsorships) {
             Log::debug
             (
                 sprintf
@@ -270,6 +284,7 @@ final class SummitSponsorService
                     $sponsorship = new SummitSponsorship();
                     $sponsorship->setType($summit_sponsorship_type);
                     $summit_sponsor->addSponsorship($sponsorship);
+                    $added_sponsorships[] = $sponsorship;
                 }
 
             } else if(isset($payload['sponsorships'])) {
@@ -308,6 +323,7 @@ final class SummitSponsorService
                 foreach ($current_sponsorships as $type_id => $sponsorship) {
                     if (!$new_sponsorship_types->contains($sponsorship->getType())) {
                         $summit_sponsor->removeSponsorship($sponsorship);
+                        $removed_sponsorships[] = $sponsorship;
                     }
                 }
 
@@ -317,6 +333,7 @@ final class SummitSponsorService
                         $sponsorship = new SummitSponsorship();
                         $sponsorship->setType($type);
                         $summit_sponsor->addSponsorship($sponsorship);
+                        $added_sponsorships[] = $sponsorship;
                     }
                 }
 
@@ -338,6 +355,20 @@ final class SummitSponsorService
 
             return $sponsor;
         });
+
+        foreach ($added_sponsorships as $sponsorship) {
+            PublishSponsorServiceDomainEventsJob::dispatch(
+                SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
+                SponsorDomainEvents::SponsorshipCreated);
+        }
+
+        foreach ($removed_sponsorships as $sponsorship) {
+            PublishSponsorServiceDomainEventsJob::dispatch(
+                DeletedEventDTO::fromEntity($sponsorship)->serialize(),
+                SponsorDomainEvents::SponsorshipRemoved);
+        }
+
+        return $sponsor;
     }
 
     /**

--- a/app/Services/Model/Imp/SummitSponsorService.php
+++ b/app/Services/Model/Imp/SummitSponsorService.php
@@ -174,9 +174,13 @@ final class SummitSponsorService
             return [$sponsor, $new_sponsorships];
         });
 
-        PublishSponsorServiceDomainEventsJob::dispatch(
-             SummitSponsorCreatedEventDTO::fromSummitSponsor($sponsor)->serialize(),
-            SponsorDomainEvents::SponsorCreated);
+        try {
+            PublishSponsorServiceDomainEventsJob::dispatch(
+                SummitSponsorCreatedEventDTO::fromSummitSponsor($sponsor)->serialize(),
+                SponsorDomainEvents::SponsorCreated);
+        } catch (\Exception $e) {
+            Log::error(sprintf("SummitSponsorService::addSponsor failed to dispatch SponsorCreated for sponsor %s: %s", $sponsor->getId(), $e->getMessage()));
+        }
 
         foreach ($new_sponsorships as $sponsorship) {
             Log::debug(sprintf(
@@ -185,9 +189,13 @@ final class SummitSponsorService
                 $sponsorship->getType()->getId(),
                 $sponsor->getId()
             ));
-            PublishSponsorServiceDomainEventsJob::dispatch(
-                SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
-                SponsorDomainEvents::SponsorshipCreated);
+            try {
+                PublishSponsorServiceDomainEventsJob::dispatch(
+                    SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
+                    SponsorDomainEvents::SponsorshipCreated);
+            } catch (\Exception $e) {
+                Log::error(sprintf("SummitSponsorService::addSponsor failed to dispatch SponsorshipCreated for sponsorship %s: %s", $sponsorship->getId(), $e->getMessage()));
+            }
         }
 
         return $sponsor;
@@ -203,7 +211,7 @@ final class SummitSponsorService
      */
     public function updateSponsor(Summit $summit, int $sponsor_id, array $payload): Sponsor
     {
-        [$sponsor, $added_sponsorships, $removed_sponsorships, $updated_sponsorships] = $this->tx_service->transaction(function () use ($summit, $sponsor_id, $payload) {
+        [$sponsor, $added_sponsorships, $removed_sponsorship_ids, $updated_sponsorships] = $this->tx_service->transaction(function () use ($summit, $sponsor_id, $payload) {
             Log::debug
             (
                 sprintf
@@ -250,7 +258,7 @@ final class SummitSponsorService
             }
 
             $added_sponsorships = [];
-            $removed_sponsorships = [];
+            $removed_sponsorship_ids = [];
             $updated_sponsorships = [];
 
             if(isset($payload['sponsorship_id'])) {
@@ -330,8 +338,8 @@ final class SummitSponsorService
                 // Remove types not in the new list
                 foreach ($current_sponsorships as $type_id => $sponsorship) {
                     if (!$new_sponsorship_types->contains($sponsorship->getType())) {
+                        $removed_sponsorship_ids[] = $sponsorship->getId(); // capture id before Doctrine clears it on DELETE
                         $summit_sponsor->removeSponsorship($sponsorship);
-                        $removed_sponsorships[] = $sponsorship;
                     }
                 }
 
@@ -357,23 +365,30 @@ final class SummitSponsorService
                 $summit->recalculateSummitSponsorOrder($sponsor, $payload['order']);
             }
 
-            PublishSponsorServiceDomainEventsJob::dispatch(
-             SummitSponsorCreatedEventDTO::fromSummitSponsor($sponsor)->serialize(),
-                SponsorDomainEvents::SponsorUpdated);
-
-            return [$sponsor, $added_sponsorships, $removed_sponsorships, $updated_sponsorships];
+            return [$sponsor, $added_sponsorships, $removed_sponsorship_ids, $updated_sponsorships];
         });
 
-        foreach ($removed_sponsorships as $sponsorship) {
+        try {
+            PublishSponsorServiceDomainEventsJob::dispatch(
+                SummitSponsorCreatedEventDTO::fromSummitSponsor($sponsor)->serialize(),
+                SponsorDomainEvents::SponsorUpdated);
+        } catch (\Exception $e) {
+            Log::error(sprintf("SummitSponsorService::updateSponsor failed to dispatch SponsorUpdated for sponsor %s: %s", $sponsor_id, $e->getMessage()));
+        }
+
+        foreach ($removed_sponsorship_ids as $sponsorship_id) {
             Log::debug(sprintf(
-                "SummitSponsorService::updateSponsor dispatching SponsorshipRemoved for sponsorship %s type %s sponsor %s",
-                $sponsorship->getId(),
-                $sponsorship->getType()->getId(),
+                "SummitSponsorService::updateSponsor dispatching SponsorshipRemoved for sponsorship %s sponsor %s",
+                $sponsorship_id,
                 $sponsor_id
             ));
-            PublishSponsorServiceDomainEventsJob::dispatch(
-                DeletedEventDTO::fromEntity($sponsorship)->serialize(),
-                SponsorDomainEvents::SponsorshipRemoved);
+            try {
+                PublishSponsorServiceDomainEventsJob::dispatch(
+                    ['id' => $sponsorship_id],
+                    SponsorDomainEvents::SponsorshipRemoved);
+            } catch (\Exception $e) {
+                Log::error(sprintf("SummitSponsorService::updateSponsor failed to dispatch SponsorshipRemoved for sponsorship %s: %s", $sponsorship_id, $e->getMessage()));
+            }
         }
 
         foreach ($added_sponsorships as $sponsorship) {
@@ -383,9 +398,13 @@ final class SummitSponsorService
                 $sponsorship->getType()->getId(),
                 $sponsor_id
             ));
-            PublishSponsorServiceDomainEventsJob::dispatch(
-                SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
-                SponsorDomainEvents::SponsorshipCreated);
+            try {
+                PublishSponsorServiceDomainEventsJob::dispatch(
+                    SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
+                    SponsorDomainEvents::SponsorshipCreated);
+            } catch (\Exception $e) {
+                Log::error(sprintf("SummitSponsorService::updateSponsor failed to dispatch SponsorshipCreated for sponsorship %s: %s", $sponsorship->getId(), $e->getMessage()));
+            }
         }
 
         foreach ($updated_sponsorships as $sponsorship) {
@@ -395,9 +414,13 @@ final class SummitSponsorService
                 $sponsorship->getType()->getId(),
                 $sponsor_id
             ));
-            PublishSponsorServiceDomainEventsJob::dispatch(
-                SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
-                SponsorDomainEvents::SponsorshipUpdated);
+            try {
+                PublishSponsorServiceDomainEventsJob::dispatch(
+                    SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
+                    SponsorDomainEvents::SponsorshipUpdated);
+            } catch (\Exception $e) {
+                Log::error(sprintf("SummitSponsorService::updateSponsor failed to dispatch SponsorshipUpdated for sponsorship %s: %s", $sponsorship->getId(), $e->getMessage()));
+            }
         }
 
         return $sponsor;

--- a/app/Services/Model/Imp/SummitSponsorService.php
+++ b/app/Services/Model/Imp/SummitSponsorService.php
@@ -180,6 +180,12 @@ final class SummitSponsorService
             SponsorDomainEvents::SponsorCreated);
 
         foreach ($new_sponsorships as $sponsorship) {
+            Log::debug(sprintf(
+                "SummitSponsorService::addSponsor dispatching SponsorshipCreated for sponsorship %s type %s sponsor %s",
+                $sponsorship->getId(),
+                $sponsorship->getType()->getId(),
+                $sponsor->getId()
+            ));
             PublishSponsorServiceDomainEventsJob::dispatch(
                 SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
                 SponsorDomainEvents::SponsorshipCreated);
@@ -356,16 +362,28 @@ final class SummitSponsorService
             return $sponsor;
         });
 
-        foreach ($added_sponsorships as $sponsorship) {
-            PublishSponsorServiceDomainEventsJob::dispatch(
-                SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
-                SponsorDomainEvents::SponsorshipCreated);
-        }
-
         foreach ($removed_sponsorships as $sponsorship) {
+            Log::debug(sprintf(
+                "SummitSponsorService::updateSponsor dispatching SponsorshipRemoved for sponsorship %s type %s sponsor %s",
+                $sponsorship->getId(),
+                $sponsorship->getType()->getId(),
+                $sponsor_id
+            ));
             PublishSponsorServiceDomainEventsJob::dispatch(
                 DeletedEventDTO::fromEntity($sponsorship)->serialize(),
                 SponsorDomainEvents::SponsorshipRemoved);
+        }
+
+        foreach ($added_sponsorships as $sponsorship) {
+            Log::debug(sprintf(
+                "SummitSponsorService::updateSponsor dispatching SponsorshipCreated for sponsorship %s type %s sponsor %s",
+                $sponsorship->getId(),
+                $sponsorship->getType()->getId(),
+                $sponsor_id
+            ));
+            PublishSponsorServiceDomainEventsJob::dispatch(
+                SummitSponsorshipCreatedEventDTO::fromSponsorship($sponsorship)->serialize(),
+                SponsorDomainEvents::SponsorshipCreated);
         }
 
         return $sponsor;

--- a/app/Services/Model/Imp/SummitSponsorService.php
+++ b/app/Services/Model/Imp/SummitSponsorService.php
@@ -115,9 +115,7 @@ final class SummitSponsorService
      */
     public function addSponsor(Summit $summit, array $payload): Sponsor
     {
-        $new_sponsorships = [];
-
-        $sponsor = $this->tx_service->transaction(function () use ($summit, $payload, &$new_sponsorships) {
+        [$sponsor, $new_sponsorships] = $this->tx_service->transaction(function () use ($summit, $payload) {
             $company_id = intval($payload['company_id']);
             $featured_event_id = isset($payload['featured_event_id']) ? intval($payload['featured_event_id']) : 0;
 
@@ -143,6 +141,7 @@ final class SummitSponsorService
             }
 
             $sponsor = SponsorFactory::build($payload);
+            $new_sponsorships = [];
 
             if(isset($payload['sponsorship_id'])) {
                 $type_id = intval($payload['sponsorship_id']);
@@ -172,7 +171,7 @@ final class SummitSponsorService
 
             $summit->addSummitSponsor($sponsor);
 
-            return $sponsor;
+            return [$sponsor, $new_sponsorships];
         });
 
         PublishSponsorServiceDomainEventsJob::dispatch(
@@ -204,10 +203,7 @@ final class SummitSponsorService
      */
     public function updateSponsor(Summit $summit, int $sponsor_id, array $payload): Sponsor
     {
-        $added_sponsorships = [];
-        $removed_sponsorships = [];
-
-        $sponsor = $this->tx_service->transaction(function () use ($summit, $sponsor_id, $payload, &$added_sponsorships, &$removed_sponsorships) {
+        [$sponsor, $added_sponsorships, $removed_sponsorships] = $this->tx_service->transaction(function () use ($summit, $sponsor_id, $payload) {
             Log::debug
             (
                 sprintf
@@ -252,6 +248,9 @@ final class SummitSponsorService
                     $payload['featured_event'] = $featured_event;
                 }
             }
+
+            $added_sponsorships = [];
+            $removed_sponsorships = [];
 
             if(isset($payload['sponsorship_id'])) {
                 $type_id = intval($payload['sponsorship_id']);
@@ -359,7 +358,7 @@ final class SummitSponsorService
              SummitSponsorCreatedEventDTO::fromSummitSponsor($sponsor)->serialize(),
                 SponsorDomainEvents::SponsorUpdated);
 
-            return $sponsor;
+            return [$sponsor, $added_sponsorships, $removed_sponsorships];
         });
 
         foreach ($removed_sponsorships as $sponsorship) {

--- a/tests/Unit/Services/SummitSponsorServiceEventDispatchTest.php
+++ b/tests/Unit/Services/SummitSponsorServiceEventDispatchTest.php
@@ -1,0 +1,208 @@
+<?php namespace Tests\Unit\Services;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Events\SponsorServices\SponsorDomainEvents;
+use App\Jobs\SponsorServices\PublishSponsorServiceDomainEventsJob;
+use Illuminate\Support\Facades\Queue;
+use services\model\ISummitSponsorService;
+use Tests\InsertSummitTestData;
+use Tests\TestCase;
+
+/**
+ * Class SummitSponsorServiceEventDispatchTest
+ *
+ * Verifies that PublishSponsorServiceDomainEventsJob is queued with the correct
+ * event type and non-zero entity IDs for every dispatch path introduced by the
+ * inline-sponsorship fix:
+ *
+ * - addSponsor with sponsorship_id          → SponsorCreated + SponsorshipCreated
+ * - addSponsor with sponsorships[]          → SponsorCreated + SponsorshipCreated (×N)
+ * - updateSponsor adds new sponsorship      → SponsorUpdated + SponsorshipCreated
+ * - updateSponsor mutates existing type     → SponsorUpdated + SponsorshipUpdated
+ * - updateSponsor removes sponsorship       → SponsorUpdated + SponsorshipRemoved
+ * - updateSponsor replaces (remove + add)   → SponsorUpdated + SponsorshipRemoved + SponsorshipCreated (in order)
+ *
+ * @package Tests\Unit\Services
+ */
+class SummitSponsorServiceEventDispatchTest extends TestCase
+{
+    use InsertSummitTestData;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::insertSummitTestData();
+    }
+
+    public function tearDown(): void
+    {
+        self::clearSummitTestData();
+        parent::tearDown();
+    }
+
+    private function getService(): ISummitSponsorService
+    {
+        return app(ISummitSponsorService::class);
+    }
+
+    /**
+     * Returns all queued PublishSponsorServiceDomainEventsJob instances for the
+     * given event type, asserting each carries a non-zero 'id' in its payload.
+     *
+     * @return PublishSponsorServiceDomainEventsJob[]
+     */
+    private function jobsFor(string $event_type): array
+    {
+        $jobs = Queue::pushed(PublishSponsorServiceDomainEventsJob::class, function ($job) use ($event_type) {
+            return $job->getEventType() === $event_type;
+        })->all();
+
+        foreach ($jobs as $job) {
+            $payload = $job->getPayload();
+            $this->assertArrayHasKey('id', $payload, "Payload for '$event_type' is missing 'id'");
+            $this->assertGreaterThan(0, $payload['id'], "Payload 'id' for '$event_type' must be > 0");
+        }
+
+        return $jobs;
+    }
+
+    // -------------------------------------------------------------------------
+    // addSponsor — sponsorship_id path
+    // -------------------------------------------------------------------------
+
+    public function testAddSponsorWithSponsorshipIdDispatchesSponsorCreatedAndSponsorshipCreated(): void
+    {
+        Queue::fake();
+
+        $this->getService()->addSponsor(self::$summit, [
+            'company_id'     => self::$companies_without_sponsor[0]->getId(),
+            'sponsorship_id' => self::$default_summit_sponsor_type->getId(),
+        ]);
+
+        $this->assertCount(1, $this->jobsFor(SponsorDomainEvents::SponsorCreated),    'Expected 1 SponsorCreated');
+        $this->assertCount(1, $this->jobsFor(SponsorDomainEvents::SponsorshipCreated), 'Expected 1 SponsorshipCreated');
+    }
+
+    // -------------------------------------------------------------------------
+    // addSponsor — sponsorships[] path
+    // -------------------------------------------------------------------------
+
+    public function testAddSponsorWithSponsorshipsArrayDispatchesSponsorshipCreatedForEach(): void
+    {
+        Queue::fake();
+
+        $this->getService()->addSponsor(self::$summit, [
+            'company_id'   => self::$companies_without_sponsor[1]->getId(),
+            'sponsorships' => [
+                self::$default_summit_sponsor_type->getId(),
+                self::$default_summit_sponsor_type2->getId(),
+            ],
+        ]);
+
+        $this->assertCount(1, $this->jobsFor(SponsorDomainEvents::SponsorCreated),    'Expected 1 SponsorCreated');
+        $this->assertCount(2, $this->jobsFor(SponsorDomainEvents::SponsorshipCreated), 'Expected 1 SponsorshipCreated per type');
+    }
+
+    // -------------------------------------------------------------------------
+    // updateSponsor — sponsorship_id path, no existing sponsorship → creates new
+    // -------------------------------------------------------------------------
+
+    public function testUpdateSponsorWithSponsorshipIdCreatesNewDispatchesSponsorshipCreated(): void
+    {
+        $sponsor = self::$sponsors[0];
+        foreach ($sponsor->getSponsorships()->toArray() as $sp) {
+            $sponsor->removeSponsorship($sp);
+        }
+        self::$em->flush();
+
+        Queue::fake();
+
+        $this->getService()->updateSponsor(self::$summit, $sponsor->getId(), [
+            'sponsorship_id' => self::$default_summit_sponsor_type->getId(),
+        ]);
+
+        $this->assertCount(1, $this->jobsFor(SponsorDomainEvents::SponsorUpdated),    'Expected 1 SponsorUpdated');
+        $this->assertCount(1, $this->jobsFor(SponsorDomainEvents::SponsorshipCreated), 'Expected 1 SponsorshipCreated');
+    }
+
+    // -------------------------------------------------------------------------
+    // updateSponsor — sponsorship_id path, hasSponsorships = true → mutates type
+    // -------------------------------------------------------------------------
+
+    public function testUpdateSponsorWithSponsorshipIdMutatesTypeDispatchesSponsorshipUpdated(): void
+    {
+        $sponsor = self::$sponsors[0];
+        $this->assertTrue($sponsor->hasSponsorships(), 'Pre-condition: sponsor must have at least one sponsorship');
+
+        Queue::fake();
+
+        $this->getService()->updateSponsor(self::$summit, $sponsor->getId(), [
+            'sponsorship_id' => self::$default_summit_sponsor_type2->getId(),
+        ]);
+
+        $this->assertCount(1, $this->jobsFor(SponsorDomainEvents::SponsorUpdated),    'Expected 1 SponsorUpdated');
+        $this->assertCount(1, $this->jobsFor(SponsorDomainEvents::SponsorshipUpdated), 'Expected 1 SponsorshipUpdated');
+        $this->assertCount(0, $this->jobsFor(SponsorDomainEvents::SponsorshipCreated), 'Expected no SponsorshipCreated for a type-change');
+        $this->assertCount(0, $this->jobsFor(SponsorDomainEvents::SponsorshipRemoved), 'Expected no SponsorshipRemoved for a type-change');
+    }
+
+    // -------------------------------------------------------------------------
+    // updateSponsor — sponsorships[] path, remove all
+    // -------------------------------------------------------------------------
+
+    public function testUpdateSponsorRemovesAllSponsorshipsDispatchesSponsorshipRemoved(): void
+    {
+        $sponsor = self::$sponsors[0];
+        $this->assertTrue($sponsor->hasSponsorships(), 'Pre-condition: sponsor must have at least one sponsorship');
+
+        Queue::fake();
+
+        $this->getService()->updateSponsor(self::$summit, $sponsor->getId(), [
+            'sponsorships' => [],
+        ]);
+
+        $this->assertCount(1, $this->jobsFor(SponsorDomainEvents::SponsorUpdated), 'Expected 1 SponsorUpdated');
+        $this->assertNotEmpty($this->jobsFor(SponsorDomainEvents::SponsorshipRemoved), 'Expected at least 1 SponsorshipRemoved');
+        $this->assertCount(0, $this->jobsFor(SponsorDomainEvents::SponsorshipCreated), 'Expected no SponsorshipCreated');
+    }
+
+    // -------------------------------------------------------------------------
+    // updateSponsor — sponsorships[] path, replace → SponsorshipRemoved before SponsorshipCreated
+    // -------------------------------------------------------------------------
+
+    public function testUpdateSponsorReplacesSponsorshipDispatchesRemovedBeforeCreated(): void
+    {
+        // sponsors[0] starts with default_summit_sponsor_type (type1); switch to type2.
+        $sponsor = self::$sponsors[0];
+
+        Queue::fake();
+
+        $this->getService()->updateSponsor(self::$summit, $sponsor->getId(), [
+            'sponsorships' => [self::$default_summit_sponsor_type2->getId()],
+        ]);
+
+        $this->assertCount(1, $this->jobsFor(SponsorDomainEvents::SponsorUpdated),    'Expected 1 SponsorUpdated');
+        $this->assertNotEmpty($this->jobsFor(SponsorDomainEvents::SponsorshipRemoved), 'Expected at least 1 SponsorshipRemoved');
+        $this->assertCount(1, $this->jobsFor(SponsorDomainEvents::SponsorshipCreated), 'Expected 1 SponsorshipCreated');
+
+        // SponsorshipRemoved must appear before SponsorshipCreated in the queue.
+        $all = Queue::pushed(PublishSponsorServiceDomainEventsJob::class)->values();
+        $types = $all->map(fn($job) => $job->getEventType())->all();
+
+        $removed_idx = array_search(SponsorDomainEvents::SponsorshipRemoved, $types);
+        $created_idx = array_search(SponsorDomainEvents::SponsorshipCreated, $types);
+
+        $this->assertLessThan($created_idx, $removed_idx, 'SponsorshipRemoved must be dispatched before SponsorshipCreated');
+    }
+}


### PR DESCRIPTION
ref https://app.clickup.com/t/86ba0vf07

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sponsorship lifecycle events are now emitted per-sponsorship during sponsor creation and updates, providing more granular and complete event tracking.
* **Tests**
  * Added unit tests validating event dispatch types, payloads, and ordering (including creation, update, and removal events).
* **Chore**
  * Background job payload and event-type accessors added to support event processing and testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenStackweb/summit-api/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->