### PR TITLE
perf(events): eliminate /events N+1 queries — 298 → 47 queries, ~1500ms → ~340ms

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,6 +65,7 @@ jobs:
                     - { name: "GuzzleTracingTest", filter: "--filter GuzzleTracingTest" }
                     - { name: "Repositories", filter: "tests/Repositories/" }
                     - { name: "Services", filter: "tests/Unit/Services/" }
+                    - { name: "CacheOptimizations", filter: "--filter '(PresentationSpeakerCacheTest|ResourceServerContextTest)'" }
         env:
             OTEL_SERVICE_ENABLED: false
             APP_ENV: testing

--- a/adr/002-events-endpoint-n-plus-1-elimination.md
+++ b/adr/002-events-endpoint-n-plus-1-elimination.md
@@ -1,4 +1,4 @@
-# ADR-0001: Eliminate N+1 Queries in `/events` Endpoint
+# ADR-0002: Eliminate N+1 Queries in `/events` Endpoint
 
 - **Status:** Accepted
 - **Date:** 2026-05-25

--- a/adr/002-events-endpoint-n-plus-1-elimination.md
+++ b/adr/002-events-endpoint-n-plus-1-elimination.md
@@ -1,0 +1,380 @@
+# ADR-0001: Eliminate N+1 Queries in `/events` Endpoint
+
+- **Status:** Accepted
+- **Date:** 2026-05-25
+- **Endpoint:** `GET /api/v1/summits/{id}/events`
+- **Branch:** `hotfix/cache-optimizations`
+
+## Context
+
+The `/events` endpoint was averaging ~1.5 s server-side for a typical 10-event
+page with the standard expand set (`speakers,type,created_by,track,sponsors,
+selection_plan,location,tags,media_uploads,media_uploads.media_upload_type`).
+Empirically the DB phase alone was inconsistent (sub-second up to 1.1 s) and
+the rest of the request was opaque — we did not know how much time was spent
+in the framework boot, the OAuth middleware, the controller body, the
+serializer chain, or response wrapping.
+
+A first attempt at a generic `GraphLoader`-based eager-loader caused
+regressions because it ran on every request regardless of whether the
+existing caching would have handled the load anyway. That branch was
+reverted and replaced with this work, which is **profiling-driven and
+surgical**: every change targets a specific N+1 pattern that was
+demonstrated to fire in production logs.
+
+## Decision
+
+Two distinct workstreams:
+
+1. **Profiling infrastructure** — make per-request work *measurable* before
+   making any code changes.
+2. **Targeted N+1 fixes** — each one a small, isolated change keyed to a
+   real pattern observed in the profiler output.
+
+### 1. Profiling infrastructure
+
+#### 1.1 `Server-Timing` HTTP header (`ServerTimingDoctrine` middleware)
+
+Reordered the route's middleware so `server.timing.doctrine` runs first
+(before `auth.user`), and extended it to emit a per-phase breakdown that
+Chrome DevTools renders natively in the Network tab → Timing → Server
+Timing section:
+
+```
+Server-Timing: boot;dur=…, pre;dur=…, controller;dur=…,
+               db;dur=…;desc="N queries", serializer;dur=…,
+               post;dur=…, app;dur=…, total;dur=…
+```
+
+| Phase        | Measures                                                       |
+| ------------ | -------------------------------------------------------------- |
+| `boot`       | `LARAVEL_START` → `server.timing.doctrine` middleware start    |
+| `pre`        | middleware start → controller entry (`auth.user`, etc.)        |
+| `controller` | full controller body (`processRequest` / `withReplica` closure) |
+| `db`         | aggregate SQL time across the request                          |
+| `serializer` | the `$response->toArray()` call only                           |
+| `post`       | controller return → middleware exit                            |
+| `app`        | `total − db` (cross-check vs `controller`)                     |
+| `total`      | middleware entry → middleware exit                             |
+
+The controller body marks each transition by writing `microtime(true)` to
+the session under keys `timing.controller_start`, `timing.serializer_start`,
+`timing.serializer_end`, `timing.controller_end`.
+
+#### 1.2 Accurate DB measurement: `QueryTimingMiddleware`
+
+Doctrine 3.x deprecated `Configuration::setSQLLogger`, and its replacement
+`Doctrine\DBAL\Logging\Middleware` does **not** pass query duration in its
+PSR-3 context, so the previous `ServerTimingDoctrine` reported `db = 0.4 ms`
+no matter what. We replaced it with a proper **DBAL Driver Middleware**
+(`App\Http\Middleware\Doctrine\QueryTimingMiddleware`) that wraps the driver
+chain (Driver → Connection → Statement) and times every `query()` /
+`exec()` / `Statement::execute()`. Totals accumulate into
+`QueryTimingCollector` (static, request-scoped, reset by
+`ServerTimingDoctrine` at the top of each request). Per-query overhead is
+two `microtime(true)` calls. Registered globally in `config/doctrine.php`
+so it always runs.
+
+This is the foundation everything else builds on — without accurate db ms +
+count, we could not distinguish "the database is slow" from "the serializer
+fires lazy loads we cannot see".
+
+### 2. Profiling-driven fixes
+
+For each fix below: the *Symptom* is the exact SQL pattern that fired in the
+production logs; the *Root cause* is why; the *Fix* is the minimal change;
+the *Impact* is the measured reduction in query count and/or time.
+
+---
+
+#### Fix 1 — `Member::belongsToGroup()` per-instance memoization
+
+**Symptom:** `SELECT COUNT(MemberID) FROM Group_Members JOIN Group …` fired
+**84 times** per request, all for the same `Member` (the authenticated
+user).
+
+**Root cause:** `PresentationSerializer::getMediaUploadsSerializerType()`
+calls `$currentUser->isAdmin()` and `$presentation->memberCanEdit($currentUser)`,
+both of which internally invoke `belongsToGroup($code)`. Each call
+re-executed a raw SQL `SELECT COUNT(MemberID)` against `Group_Members`. With
+~8 group codes checked per presentation and 10 presentations on the page,
+that's 80 redundant queries against an answer that never changes within a
+request.
+
+**Fix:** Added `private array $groupMembershipCache = []` (unannotated, so
+Doctrine ignores it) and cache the result keyed by trimmed group code.
+First call per code hits the DB; every subsequent call within the request
+returns the cached boolean.
+
+**File:** `app/Models/Foundation/Main/Member.php`
+
+**Impact:** 84 → ~8 queries (~76 saved, ~85 ms of DB time saved per request).
+
+---
+
+#### Fix 2 — `ResourceServerContext::getCurrentUser()` request-scoped cache
+
+**Symptom:** `SELECT * FROM Member WHERE …` fired **98 of 100 times** for
+the *same* Member ID (the current user).
+
+**Root cause:** `getCurrentUser()` is called many times per request by the
+serializer chain (per-event `getSerializerType()`, per-presentation
+`getMediaUploadsSerializerType()`, etc.). Each call runs
+`$member_repository->getByExternalId(intval($user_external_id))` plus
+optional group sync, hitting the DB every time.
+
+**Fix:** Added `private ?Member $cachedCurrentUser` and a resolved-flag,
+populated at every return point. The authenticated user does not change
+within a single request, so the same `Member` is the correct answer every
+time. Side effects (group sync, `MemberAssocSummitOrders::dispatch`, field
+updates) run only on the first call — they're idempotent per request anyway.
+
+**File:** `app/Models/OAuth2/ResourceServerContext.php`
+
+**Impact:** This was the single largest win. Total query count: **220 →
+117 (-103)**. Serializer time alone dropped ~370 ms because every redundant
+`getCurrentUser()` call had been wrapped in a transaction whose overhead
+compounded. Also collapsed the `SET TRANSACTION ISOLATION LEVEL`
+overhead from 42 → ~3 (each transaction caused a new isolation level
+declaration on connection acquisition).
+
+---
+
+#### Fix 3 — Batch preload `PresentationSpeakerAssignment + PresentationSpeaker + Member`
+
+**Symptom:** `SELECT * FROM Member WHERE id = ?` fired 56 times and
+`SELECT … FROM Presentation_Speakers WHERE PresentationID = ? AND
+PresentationSpeakerID = ?` fired 19 times.
+
+**Root cause:** Two separate lazy-load chains:
+
+1. `PresentationSpeaker::getFirstName()` and `getLastName()` fall back to
+   `$this->member->getFirstName()` when the speaker's own field is empty.
+   Member is `ManyToOne(fetch="EXTRA_LAZY")` → one DB load per speaker.
+2. `PresentationSpeaker::getPresentationAssignmentOrder($presentation)`
+   did `$this->presentations->matching($criteria)->first()`. On
+   EXTRA_LAZY collections, `matching()` **always** fires SQL regardless
+   of whether the assignment is already in the identity map.
+
+**Fix:** In `DoctrineSummitEventRepository::getAllByPage`, after the main
+hydration, run **one** DQL that fetch-joins all three:
+
+```dql
+SELECT a, s, m FROM PresentationSpeakerAssignment a
+JOIN a.speaker s
+LEFT JOIN s.member m
+WHERE a.presentation IN (:ids)
+```
+
+The `a, s, m` selection (root + fetch-joined associations) is what Doctrine
+requires for a true fetch join — `SELECT s, m` alone fails with
+*"Cannot select entity through identification variables without choosing
+at least one root entity alias"*. After the query, every speaker has its
+member already initialized in the UnitOfWork.
+
+For Fix #2 above (composite-key lookup), we added
+`PresentationSpeaker::setPreloadedAssignmentOrder(int $pid, ?int $order)`
+and a `$preloadedAssignmentOrders` array on the entity (unannotated). The
+repository iterates the assignments it just loaded and pushes each
+`(presentation_id → order)` pair into the corresponding speaker.
+`getPresentationAssignmentOrder()` now reads from this cache and only
+falls back to the `matching()` DQL when the cache is unset (e.g., for code
+paths that don't go through `getAllByPage`).
+
+**Files:**
+- `app/Repositories/Summit/DoctrineSummitEventRepository.php`
+- `app/Models/Foundation/Summit/Speakers/PresentationSpeaker.php`
+
+**Impact:** 75 queries collapsed into 1; ~216 ms of DB time saved.
+
+---
+
+#### Fix 4 — Batch preload `SummitSelectedPresentation` + memoize `getSelectionStatus()`
+
+**Symptom:** A DQL `SELECT sp FROM SummitSelectedPresentation sp JOIN sp.list
+l JOIN sp.presentation p WHERE p.id = ? AND sp.collection = ? AND
+l.list_type = ? AND l.list_class = ?` fired 20 times.
+
+**Root cause:** `Presentation::getSelectionStatus()` ran the DQL per
+presentation, and the serializer accessed `selection_status` once per
+presentation per request.
+
+**Fix:** Two parts:
+
+1. `Presentation` gains a transient `$preloadedSessionSelections` array and
+   `setPreloadedSessionSelections(array)`. `getSelectionStatus()` uses
+   these rows if set, otherwise falls through to the original DQL.
+   The computed status is also memoized in `$memoizedSelectionStatus` so
+   repeated `getSelectionStatus()` calls cost nothing after the first.
+
+2. `DoctrineSummitEventRepository::getAllByPage` runs one batch DQL with
+   the same filters (`collection=Selected, list_type=Group, list_class=Session`)
+   but `WHERE p.id IN (:ids)`, groups results by presentation id, and
+   feeds each Presentation via the setter.
+
+**Files:**
+- `app/Models/Foundation/Summit/Events/Presentations/Presentation.php`
+- `app/Repositories/Summit/DoctrineSummitEventRepository.php`
+
+**Impact:** 20 → 1 query.
+
+---
+
+#### Fix 5 — Fetch-join `Location` and `PresentationCategory` in main hydration
+
+**Symptom:**
+- 10 queries selecting `SummitAbstractLocation` (per-event lazy load).
+- 5 queries selecting `PresentationCategory` (per-event lazy load).
+
+**Root cause:** The original hydration query selected
+`e, p, et, et2` — only the event, the Presentation subclass row, and the
+type/PresentationType. `location` and `category` were EXTRA_LAZY `ManyToOne`
+associations that the serializer would dereference per event.
+
+**Fix:** Added `LEFT JOIN e.location loc + addSelect('loc')` and
+`LEFT JOIN p.category cat + addSelect('cat')` to the main query. Doctrine's
+JOINED inheritance handles `SummitVenueRoom` etc. subclasses automatically.
+
+**File:** `app/Repositories/Summit/DoctrineSummitEventRepository.php`
+
+**Impact:** 15 queries removed in a single hydration step. The JOIN tree
+grew but the total request time stayed flat compared with leaving the
+lazy loads in place (per-query latency + identity-map maintenance cost
+matched the JOIN cost).
+
+---
+
+#### Fix 6 — Batch preload `Tag`, `Sponsor`, `PresentationMaterial` collections
+
+**Symptom:** Three near-identical per-entity lazy loads:
+- 10× `SELECT … FROM Tag t INNER JOIN SummitEvent_Tags WHERE SummitEventID = ?`
+- 10× `SELECT … FROM Company c INNER JOIN SummitEvent_Sponsors WHERE …` (sponsors)
+- 10× `SELECT … FROM PresentationMaterial WHERE PresentationID = ?`
+
+**Root cause:** Each is an EXTRA_LAZY collection on the event/presentation
+that the serializer iterates. EXTRA_LAZY + iteration triggers a per-entity
+full-collection load.
+
+**Fix:** Three fetch-join batch queries after the main hydration:
+
+```dql
+SELECT e, t FROM SummitEvent e LEFT JOIN e.tags t      WHERE e.id IN (:ids)
+SELECT e, s FROM SummitEvent e LEFT JOIN e.sponsors s  WHERE e.id IN (:ids)
+SELECT p, m FROM Presentation p LEFT JOIN p.materials m WHERE p.id IN (:presentationIds)
+```
+
+The fetch-join pattern (root + collection alias both in SELECT) is what
+Doctrine requires to populate the inverse-side collection on the parent
+entities. Once those collections are populated, subsequent serializer
+iterations read from memory.
+
+**File:** `app/Repositories/Summit/DoctrineSummitEventRepository.php`
+
+**Impact:** 30 queries collapsed into 3.
+
+---
+
+#### Fix 7 — Remove redundant `et2` JOIN in main hydration
+
+**Symptom:** Log warnings `DoctrineSummitEventRepository::getAllByPage
+unexpected hydration row {"type":"PresentationType"}` fired multiple times
+per request — confirming events with `PresentationType` discriminators were
+being returned as separate root entities and silently dropped from the
+result map (so the page returned fewer items than `per_page`).
+
+**Root cause:** The main hydration explicitly joined
+`LEFT JOIN PresentationType et2 WITH et.id = et2.id` and selected `et2`,
+which made `et2` appear as a separate root entity in `getResult()`.
+Doctrine's JOINED inheritance on `SummitEventType` already hydrates the
+correct subclass via the `ClassName` discriminator column when you do
+`INNER JOIN e.type et` — the extra `et2` JOIN was redundant.
+
+**Fix:** Dropped `et2` from the main hydration's SELECT and JOIN list.
+Kept it in the `getFastCount` and `getAllIdsByPage` queries where it
+**is** used (filter predicates reference `et2.allow_attendee_vote`).
+
+**File:** `app/Repositories/Summit/DoctrineSummitEventRepository.php`
+
+**Impact:** Correctness fix — pages with presentations now return the
+correct number of items. No additional perf win but it stopped a class of
+silent data loss.
+
+## Consequences
+
+### Performance — measured on dev (`api2.dev.fnopen.com`)
+
+Same endpoint, same summit, same expand set, warm OPcache:
+
+| Metric          | Baseline (main) | After all fixes | Δ        |
+| --------------- | --------------- | --------------- | -------- |
+| Queries         | 298             | 47              | **-84%** |
+| DB time         | ~410 ms         | ~175 ms         | -57%     |
+| Serializer time | ~640 ms         | ~50 ms          | **-92%** |
+| Total (server)  | ~1500 ms        | ~340 ms         | **-77%** |
+| Speed vs prod   | baseline (1.4 s) | ~4× faster      |          |
+
+### What we kept
+
+- `ServerTimingDoctrine` middleware + `Server-Timing` header — useful for
+  ongoing visibility; Chrome DevTools renders it for free.
+- `QueryTimingMiddleware` and `QueryTimingCollector` — provides accurate
+  per-request SQL time and count without depending on Doctrine's
+  deprecated `SQLLogger`.
+- All entity-level caches (`Member::$groupMembershipCache`,
+  `ResourceServerContext::$cachedCurrentUser`,
+  `Presentation::$preloadedSessionSelections + $memoizedSelectionStatus`,
+  `PresentationSpeaker::$preloadedAssignmentOrders`). These are
+  per-instance and per-request — Doctrine discards them on entity
+  re-hydration, so there is no stale-cache risk across requests.
+
+### What we did *not* fix (and why)
+
+- **`Presentation::getSpeakers()` matching() — 10 queries.** Calls
+  `$this->speakers->matching($criteria)` which on `EXTRA_LAZY` always
+  fires SQL regardless of identity-map state. Fixing this requires
+  changing the entity method to use `toArray() + PHP usort` in memory.
+  A previous attempt at this caused regressions in other code paths
+  that depend on the lazy semantics. Out of scope for this fix.
+- **The remaining ~4 `Member` SELECTs.** These come from non-current-user
+  Member references (e.g., another event's `created_by`) and are not
+  worth batch-loading individually.
+- **Boot phase ~300 ms.** Laravel framework boot, route resolution,
+  OAuth middleware initialization. Tuning this is a separate concern
+  (config cache, route cache, OPcache preload, fewer service providers)
+  and orthogonal to the N+1 work.
+
+### Risks
+
+- The fetch-join batch queries make the hydration phase produce wider
+  result sets. If a presentation page ever has very large
+  `tags`/`sponsors`/`materials` collections per event, the batch query
+  could materialize a Cartesian-ish row set. Empirically not a problem
+  for the typical 10 events × ~5 tags/sponsors page.
+- The transient cache properties on entities (`$cachedCurrentUser`,
+  `$preloadedSessionSelections`, etc.) are correct only as long as the
+  entity instance is request-scoped. Doctrine re-hydrates entities on
+  fresh requests so the cache resets naturally, but if any code path
+  starts persisting these entities across requests (e.g., long-lived
+  workers reusing the EntityManager without `clear()`), the cache must
+  be invalidated explicitly. None of the current code does this.
+
+## Methodology — for next time
+
+The order that produced these results matters:
+
+1. **Measure first.** A generic eager-loader implemented before profiling
+   made things worse. Once we shipped `Server-Timing + QueryTimingMiddleware`
+   and saw real per-phase numbers, every subsequent fix was targeted.
+2. **Add a SQL pattern logger temporarily.** Bucketing queries by
+   normalized SQL (numeric and quoted literals replaced with `?`) made it
+   trivial to identify which N+1 to attack next. This was removed in the
+   final cleanup commit.
+3. **One pattern per commit.** Each fix is independently revertable.
+   When something didn't work as expected (e.g., the SP preload silently
+   failed because of a DQL semantical error), the bisect was a one-commit
+   step.
+4. **Keep the entity-level cache pattern uniform.** Every fix uses the
+   same shape: a private, unannotated property; a public setter called
+   by the batch loader; a check in the getter; a fall-through to the
+   original code path so out-of-band callers still work. This keeps the
+   blast radius small.

--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitEventsApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitEventsApiController.php
@@ -170,13 +170,14 @@ final class OAuth2SummitEventsApiController extends OAuth2ProtectedController
      */
     public function getEvents($summit_id)
     {
-        \Illuminate\Support\Facades\Session::put('timing.controller_start', microtime(true));
-        return $this->processRequest(function () use ($summit_id) {
+        $req = request();
+        $req->attributes->set('timing.controller_start', microtime(true));
+        return $this->processRequest(function () use ($summit_id, $req) {
             $current_user = $this->resource_server_context->getCurrentUser(true);
-            return $this->withReplica(function() use ($summit_id, $current_user) {
+            return $this->withReplica(function() use ($summit_id, $current_user, $req) {
                 $strategy = new RetrieveAllSummitEventsBySummitStrategy($this->repository, $this->event_repository, $this->resource_server_context);
                 $response = $strategy->getEvents(['summit_id' => $summit_id]);
-                \Illuminate\Support\Facades\Session::put('timing.serializer_start', microtime(true));
+                $req->attributes->set('timing.serializer_start', microtime(true));
                 $data = $response->toArray
                 (
                     SerializerUtils::getExpand(),
@@ -187,9 +188,9 @@ final class OAuth2SummitEventsApiController extends OAuth2ProtectedController
                     ],
                     $this->getSerializerType()
                 );
-                \Illuminate\Support\Facades\Session::put('timing.serializer_end', microtime(true));
+                $req->attributes->set('timing.serializer_end', microtime(true));
                 $result = $this->ok($data);
-                \Illuminate\Support\Facades\Session::put('timing.controller_end', microtime(true));
+                $req->attributes->set('timing.controller_end', microtime(true));
                 return $result;
             });
 

--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitEventsApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitEventsApiController.php
@@ -170,24 +170,27 @@ final class OAuth2SummitEventsApiController extends OAuth2ProtectedController
      */
     public function getEvents($summit_id)
     {
+        \Illuminate\Support\Facades\Session::put('timing.controller_start', microtime(true));
         return $this->processRequest(function () use ($summit_id) {
             $current_user = $this->resource_server_context->getCurrentUser(true);
             return $this->withReplica(function() use ($summit_id, $current_user) {
                 $strategy = new RetrieveAllSummitEventsBySummitStrategy($this->repository, $this->event_repository, $this->resource_server_context);
                 $response = $strategy->getEvents(['summit_id' => $summit_id]);
-                return $this->ok
+                \Illuminate\Support\Facades\Session::put('timing.serializer_start', microtime(true));
+                $data = $response->toArray
                 (
-                    $response->toArray
-                    (
-                        SerializerUtils::getExpand(),
-                        SerializerUtils::getFields(),
-                        SerializerUtils::getRelations(),
-                        [
-                            'current_user' => $current_user
+                    SerializerUtils::getExpand(),
+                    SerializerUtils::getFields(),
+                    SerializerUtils::getRelations(),
+                    [
+                        'current_user' => $current_user
                     ],
-                        $this->getSerializerType()
-                    )
+                    $this->getSerializerType()
                 );
+                \Illuminate\Support\Facades\Session::put('timing.serializer_end', microtime(true));
+                $result = $this->ok($data);
+                \Illuminate\Support\Facades\Session::put('timing.controller_end', microtime(true));
+                return $result;
             });
 
         });

--- a/app/Http/Controllers/Apis/Protected/Summit/Traits/ParametrizedGetAll.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/Traits/ParametrizedGetAll.php
@@ -82,7 +82,8 @@ trait ParametrizedGetAll
         callable $defaultOrderRules = null,
         callable $defaultPageSize = null,
         callable $queryCallable = null,
-        array    $serializerParams = []
+        array    $serializerParams = [],
+        callable $afterQuery = null
     )
     {
         return $this->processRequest(function () use (
@@ -94,7 +95,8 @@ trait ParametrizedGetAll
             $defaultOrderRules,
             $defaultPageSize,
             $queryCallable,
-            $serializerParams
+            $serializerParams,
+            $afterQuery
         ) {
             $values = Request::all();
 
@@ -139,6 +141,14 @@ trait ParametrizedGetAll
                     $applyExtraFilters
                 );
             $dbEnd = (microtime(true)-$dbStart)*1000;
+
+            // Optional post-load hook so callers can pre-populate caches /
+            // batch-load related entities before serialization runs. Receives
+            // the PagingResponse so it can inspect items.
+            if (is_callable($afterQuery)) {
+                $afterQuery($data);
+            }
+
             $transformStart = microtime(true);
             $serializerParams['filter'] = $filter;
             $res = $data->toArray

--- a/app/Http/Middleware/Doctrine/QueryTimingCollector.php
+++ b/app/Http/Middleware/Doctrine/QueryTimingCollector.php
@@ -18,7 +18,15 @@ class QueryTimingCollector
     /** @var array<string, array{count:int, totalMs:float, sample:string}> */
     public static array $patterns = [];
 
-    public static function record(float $startedAt, ?string $sql = null): void
+    /**
+     * Sample of full SQL strings (with their bound values where possible).
+     * Capped at a reasonable size to avoid memory issues.
+     *
+     * @var array<int, string>
+     */
+    public static array $memberQueries = [];
+
+    public static function record(float $startedAt, ?string $sql = null, ?array $params = null): void
     {
         $ms = (microtime(true) - $startedAt) * 1000.0;
         self::$totalMs += $ms;
@@ -31,6 +39,13 @@ class QueryTimingCollector
             }
             self::$patterns[$pattern]['count']++;
             self::$patterns[$pattern]['totalMs'] += $ms;
+
+            // Capture FROM-Member SELECT queries so we can see exactly which
+            // Member IDs are being loaded and from which code path.
+            if (count(self::$memberQueries) < 100 && stripos($sql, 'FROM Member') !== false) {
+                $paramsStr = $params ? '[' . implode(',', array_map(fn($v) => is_scalar($v) ? (string)$v : gettype($v), $params)) . ']' : '';
+                self::$memberQueries[] = $paramsStr ?: 'no-params';
+            }
         }
     }
 
@@ -39,6 +54,7 @@ class QueryTimingCollector
         self::$totalMs = 0.0;
         self::$count = 0;
         self::$patterns = [];
+        self::$memberQueries = [];
     }
 
     /**

--- a/app/Http/Middleware/Doctrine/QueryTimingCollector.php
+++ b/app/Http/Middleware/Doctrine/QueryTimingCollector.php
@@ -15,87 +15,15 @@ class QueryTimingCollector
     public static float $totalMs = 0.0;
     public static int $count = 0;
 
-    /** @var array<string, array{count:int, totalMs:float, sample:string}> */
-    public static array $patterns = [];
-
-    /**
-     * Sample of full SQL strings (with their bound values where possible).
-     * Capped at a reasonable size to avoid memory issues.
-     *
-     * @var array<int, string>
-     */
-    public static array $memberQueries = [];
-
-    public static function record(float $startedAt, ?string $sql = null, ?array $params = null): void
+    public static function record(float $startedAt): void
     {
-        $ms = (microtime(true) - $startedAt) * 1000.0;
-        self::$totalMs += $ms;
+        self::$totalMs += (microtime(true) - $startedAt) * 1000.0;
         self::$count++;
-
-        if ($sql !== null) {
-            $pattern = self::normalize($sql);
-            if (!isset(self::$patterns[$pattern])) {
-                self::$patterns[$pattern] = ['count' => 0, 'totalMs' => 0.0, 'sample' => $sql];
-            }
-            self::$patterns[$pattern]['count']++;
-            self::$patterns[$pattern]['totalMs'] += $ms;
-
-            // Capture FROM-Member SELECT queries so we can see exactly which
-            // Member IDs are being loaded and from which code path.
-            // Doctrine wraps identifiers in backticks, so strip them before matching.
-            if (count(self::$memberQueries) < 100) {
-                $stripped = str_replace('`', '', $sql);
-                if (stripos($stripped, 'FROM Member') !== false) {
-                    $paramsStr = $params ? '[' . implode(',', array_map(fn($v) => is_scalar($v) ? (string)$v : gettype($v), $params)) . ']' : '';
-                    self::$memberQueries[] = $paramsStr ?: 'no-params';
-                }
-            }
-        }
     }
 
     public static function reset(): void
     {
         self::$totalMs = 0.0;
         self::$count = 0;
-        self::$patterns = [];
-        self::$memberQueries = [];
-    }
-
-    /**
-     * Returns the top N most-repeated SQL patterns, sorted by count descending.
-     *
-     * @return array<int, array{pattern:string, count:int, totalMs:float, sample:string}>
-     */
-    public static function topPatterns(int $limit = 10): array
-    {
-        $rows = [];
-        foreach (self::$patterns as $pattern => $stats) {
-            if ($stats['count'] < 2) continue; // only interested in repeats
-            $rows[] = [
-                'pattern' => $pattern,
-                'count'   => $stats['count'],
-                'totalMs' => round($stats['totalMs'], 1),
-                'sample'  => $stats['sample'],
-            ];
-        }
-        usort($rows, fn($a, $b) => $b['count'] <=> $a['count']);
-        return array_slice($rows, 0, $limit);
-    }
-
-    /**
-     * Replace numeric and quoted literals with ? so that "SELECT x WHERE id = 7570"
-     * and "SELECT x WHERE id = 7571" map to the same pattern, surfacing N+1s.
-     */
-    private static function normalize(string $sql): string
-    {
-        // Collapse positional and named params
-        $s = preg_replace('/\?|:[a-zA-Z_][a-zA-Z0-9_]*/', '?', $sql);
-        // Collapse quoted strings
-        $s = preg_replace("/'[^']*'/", '?', $s);
-        // Collapse numbers
-        $s = preg_replace('/\b\d+\b/', '?', $s);
-        // Collapse runs of whitespace
-        $s = preg_replace('/\s+/', ' ', $s);
-        return trim($s);
     }
 }

--- a/app/Http/Middleware/Doctrine/QueryTimingCollector.php
+++ b/app/Http/Middleware/Doctrine/QueryTimingCollector.php
@@ -42,9 +42,13 @@ class QueryTimingCollector
 
             // Capture FROM-Member SELECT queries so we can see exactly which
             // Member IDs are being loaded and from which code path.
-            if (count(self::$memberQueries) < 100 && stripos($sql, 'FROM Member') !== false) {
-                $paramsStr = $params ? '[' . implode(',', array_map(fn($v) => is_scalar($v) ? (string)$v : gettype($v), $params)) . ']' : '';
-                self::$memberQueries[] = $paramsStr ?: 'no-params';
+            // Doctrine wraps identifiers in backticks, so strip them before matching.
+            if (count(self::$memberQueries) < 100) {
+                $stripped = str_replace('`', '', $sql);
+                if (stripos($stripped, 'FROM Member') !== false) {
+                    $paramsStr = $params ? '[' . implode(',', array_map(fn($v) => is_scalar($v) ? (string)$v : gettype($v), $params)) . ']' : '';
+                    self::$memberQueries[] = $paramsStr ?: 'no-params';
+                }
             }
         }
     }

--- a/app/Http/Middleware/Doctrine/QueryTimingCollector.php
+++ b/app/Http/Middleware/Doctrine/QueryTimingCollector.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware\Doctrine;
+
+/**
+ * Request-scoped accumulator for SQL execution times.
+ *
+ * Static so that the DBAL Driver Middleware (instantiated by Doctrine on
+ * connection creation) and the request lifecycle middleware (ServerTimingDoctrine)
+ * can share state without needing dependency injection through Doctrine's
+ * internals. Reset at request start by ServerTimingDoctrine.
+ */
+class QueryTimingCollector
+{
+    public static float $totalMs = 0.0;
+    public static int $count = 0;
+
+    public static function record(float $startedAt): void
+    {
+        self::$totalMs += (microtime(true) - $startedAt) * 1000.0;
+        self::$count++;
+    }
+
+    public static function reset(): void
+    {
+        self::$totalMs = 0.0;
+        self::$count = 0;
+    }
+}

--- a/app/Http/Middleware/Doctrine/QueryTimingCollector.php
+++ b/app/Http/Middleware/Doctrine/QueryTimingCollector.php
@@ -15,15 +15,67 @@ class QueryTimingCollector
     public static float $totalMs = 0.0;
     public static int $count = 0;
 
-    public static function record(float $startedAt): void
+    /** @var array<string, array{count:int, totalMs:float, sample:string}> */
+    public static array $patterns = [];
+
+    public static function record(float $startedAt, ?string $sql = null): void
     {
-        self::$totalMs += (microtime(true) - $startedAt) * 1000.0;
+        $ms = (microtime(true) - $startedAt) * 1000.0;
+        self::$totalMs += $ms;
         self::$count++;
+
+        if ($sql !== null) {
+            $pattern = self::normalize($sql);
+            if (!isset(self::$patterns[$pattern])) {
+                self::$patterns[$pattern] = ['count' => 0, 'totalMs' => 0.0, 'sample' => $sql];
+            }
+            self::$patterns[$pattern]['count']++;
+            self::$patterns[$pattern]['totalMs'] += $ms;
+        }
     }
 
     public static function reset(): void
     {
         self::$totalMs = 0.0;
         self::$count = 0;
+        self::$patterns = [];
+    }
+
+    /**
+     * Returns the top N most-repeated SQL patterns, sorted by count descending.
+     *
+     * @return array<int, array{pattern:string, count:int, totalMs:float, sample:string}>
+     */
+    public static function topPatterns(int $limit = 10): array
+    {
+        $rows = [];
+        foreach (self::$patterns as $pattern => $stats) {
+            if ($stats['count'] < 2) continue; // only interested in repeats
+            $rows[] = [
+                'pattern' => $pattern,
+                'count'   => $stats['count'],
+                'totalMs' => round($stats['totalMs'], 1),
+                'sample'  => $stats['sample'],
+            ];
+        }
+        usort($rows, fn($a, $b) => $b['count'] <=> $a['count']);
+        return array_slice($rows, 0, $limit);
+    }
+
+    /**
+     * Replace numeric and quoted literals with ? so that "SELECT x WHERE id = 7570"
+     * and "SELECT x WHERE id = 7571" map to the same pattern, surfacing N+1s.
+     */
+    private static function normalize(string $sql): string
+    {
+        // Collapse positional and named params
+        $s = preg_replace('/\?|:[a-zA-Z_][a-zA-Z0-9_]*/', '?', $sql);
+        // Collapse quoted strings
+        $s = preg_replace("/'[^']*'/", '?', $s);
+        // Collapse numbers
+        $s = preg_replace('/\b\d+\b/', '?', $s);
+        // Collapse runs of whitespace
+        $s = preg_replace('/\s+/', ' ', $s);
+        return trim($s);
     }
 }

--- a/app/Http/Middleware/Doctrine/QueryTimingMiddleware.php
+++ b/app/Http/Middleware/Doctrine/QueryTimingMiddleware.php
@@ -43,7 +43,7 @@ class QueryTimingConnection extends AbstractConnectionMiddleware
         try {
             return parent::query($sql);
         } finally {
-            QueryTimingCollector::record($start);
+            QueryTimingCollector::record($start, $sql);
         }
     }
 
@@ -53,25 +53,33 @@ class QueryTimingConnection extends AbstractConnectionMiddleware
         try {
             return parent::exec($sql);
         } finally {
-            QueryTimingCollector::record($start);
+            QueryTimingCollector::record($start, $sql);
         }
     }
 
     public function prepare(string $sql): DBALStatement
     {
-        return new QueryTimingStatement(parent::prepare($sql));
+        return new QueryTimingStatement(parent::prepare($sql), $sql);
     }
 }
 
 class QueryTimingStatement extends AbstractStatementMiddleware
 {
+    private string $sql;
+
+    public function __construct($wrapped, string $sql)
+    {
+        parent::__construct($wrapped);
+        $this->sql = $sql;
+    }
+
     public function execute($params = null): DBALResult
     {
         $start = microtime(true);
         try {
             return parent::execute($params);
         } finally {
-            QueryTimingCollector::record($start);
+            QueryTimingCollector::record($start, $this->sql);
         }
     }
 }

--- a/app/Http/Middleware/Doctrine/QueryTimingMiddleware.php
+++ b/app/Http/Middleware/Doctrine/QueryTimingMiddleware.php
@@ -43,7 +43,7 @@ class QueryTimingConnection extends AbstractConnectionMiddleware
         try {
             return parent::query($sql);
         } finally {
-            QueryTimingCollector::record($start, $sql);
+            QueryTimingCollector::record($start);
         }
     }
 
@@ -53,42 +53,25 @@ class QueryTimingConnection extends AbstractConnectionMiddleware
         try {
             return parent::exec($sql);
         } finally {
-            QueryTimingCollector::record($start, $sql);
+            QueryTimingCollector::record($start);
         }
     }
 
     public function prepare(string $sql): DBALStatement
     {
-        return new QueryTimingStatement(parent::prepare($sql), $sql);
+        return new QueryTimingStatement(parent::prepare($sql));
     }
 }
 
 class QueryTimingStatement extends AbstractStatementMiddleware
 {
-    private string $sql;
-
-    public function __construct($wrapped, string $sql)
-    {
-        parent::__construct($wrapped);
-        $this->sql = $sql;
-    }
-
-    private array $boundParams = [];
-
-    public function bindValue($param, $value, $type = \Doctrine\DBAL\ParameterType::STRING): bool
-    {
-        $this->boundParams[$param] = $value;
-        return parent::bindValue($param, $value, $type);
-    }
-
     public function execute($params = null): DBALResult
     {
         $start = microtime(true);
         try {
             return parent::execute($params);
         } finally {
-            $effective = $params ?? $this->boundParams;
-            QueryTimingCollector::record($start, $this->sql, is_array($effective) ? $effective : null);
+            QueryTimingCollector::record($start);
         }
     }
 }

--- a/app/Http/Middleware/Doctrine/QueryTimingMiddleware.php
+++ b/app/Http/Middleware/Doctrine/QueryTimingMiddleware.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Middleware\Doctrine;
+
+use Doctrine\DBAL\Driver as DBALDriver;
+use Doctrine\DBAL\Driver\Connection as DBALConnection;
+use Doctrine\DBAL\Driver\Middleware as DBALMiddleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
+use Doctrine\DBAL\Driver\Result as DBALResult;
+use Doctrine\DBAL\Driver\Statement as DBALStatement;
+
+/**
+ * DBAL Driver Middleware that records SQL execution duration into
+ * QueryTimingCollector. Registered globally via config/doctrine.php so it
+ * times every query in every request; the request-scoped accumulator is
+ * reset at the top of each request by ServerTimingDoctrine.
+ *
+ * Per-query overhead is two microtime(true) calls — negligible.
+ */
+class QueryTimingMiddleware implements DBALMiddleware
+{
+    public function wrap(DBALDriver $driver): DBALDriver
+    {
+        return new QueryTimingDriver($driver);
+    }
+}
+
+class QueryTimingDriver extends AbstractDriverMiddleware
+{
+    public function connect(array $params): DBALConnection
+    {
+        return new QueryTimingConnection(parent::connect($params));
+    }
+}
+
+class QueryTimingConnection extends AbstractConnectionMiddleware
+{
+    public function query(string $sql): DBALResult
+    {
+        $start = microtime(true);
+        try {
+            return parent::query($sql);
+        } finally {
+            QueryTimingCollector::record($start);
+        }
+    }
+
+    public function exec(string $sql): int
+    {
+        $start = microtime(true);
+        try {
+            return parent::exec($sql);
+        } finally {
+            QueryTimingCollector::record($start);
+        }
+    }
+
+    public function prepare(string $sql): DBALStatement
+    {
+        return new QueryTimingStatement(parent::prepare($sql));
+    }
+}
+
+class QueryTimingStatement extends AbstractStatementMiddleware
+{
+    public function execute($params = null): DBALResult
+    {
+        $start = microtime(true);
+        try {
+            return parent::execute($params);
+        } finally {
+            QueryTimingCollector::record($start);
+        }
+    }
+}

--- a/app/Http/Middleware/Doctrine/QueryTimingMiddleware.php
+++ b/app/Http/Middleware/Doctrine/QueryTimingMiddleware.php
@@ -73,13 +73,22 @@ class QueryTimingStatement extends AbstractStatementMiddleware
         $this->sql = $sql;
     }
 
+    private array $boundParams = [];
+
+    public function bindValue($param, $value, $type = \Doctrine\DBAL\ParameterType::STRING): bool
+    {
+        $this->boundParams[$param] = $value;
+        return parent::bindValue($param, $value, $type);
+    }
+
     public function execute($params = null): DBALResult
     {
         $start = microtime(true);
         try {
             return parent::execute($params);
         } finally {
-            QueryTimingCollector::record($start, $this->sql);
+            $effective = $params ?? $this->boundParams;
+            QueryTimingCollector::record($start, $this->sql, is_array($effective) ? $effective : null);
         }
     }
 }

--- a/app/Http/Middleware/ServerTimingDoctrine.php
+++ b/app/Http/Middleware/ServerTimingDoctrine.php
@@ -3,7 +3,6 @@
 namespace App\Http\Middleware;
 
 use Closure;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Session;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -53,26 +52,6 @@ class ServerTimingDoctrine
             )
         );
         $response->headers->set('Timing-Allow-Origin', '*');
-
-        // If this request fired N+1s, log the top repeating SQL patterns so we
-        // can target the actual lazy loads. Only logs when there are repeats
-        // (count >= 2) — typical normal requests stay quiet.
-        if ($dbCount >= 20) {
-            $top = \App\Http\Middleware\Doctrine\QueryTimingCollector::topPatterns(8);
-            foreach ($top as $row) {
-                Log::warning('N+1 candidate', [
-                    'count'   => $row['count'],
-                    'totalMs' => $row['totalMs'],
-                    'sample'  => mb_substr($row['sample'], 0, 240),
-                ]);
-            }
-            // Dump Member query params so we can see which IDs are being loaded
-            // and correlate to the code path (created_by, updated_by, speaker.member, ...).
-            $memberQueries = \App\Http\Middleware\Doctrine\QueryTimingCollector::$memberQueries;
-            if (!empty($memberQueries)) {
-                Log::warning('member queries', ['count' => count($memberQueries), 'params' => $memberQueries]);
-            }
-        }
 
         return $response;
     }

--- a/app/Http/Middleware/ServerTimingDoctrine.php
+++ b/app/Http/Middleware/ServerTimingDoctrine.php
@@ -66,6 +66,12 @@ class ServerTimingDoctrine
                     'sample'  => mb_substr($row['sample'], 0, 240),
                 ]);
             }
+            // Dump Member query params so we can see which IDs are being loaded
+            // and correlate to the code path (created_by, updated_by, speaker.member, ...).
+            $memberQueries = \App\Http\Middleware\Doctrine\QueryTimingCollector::$memberQueries;
+            if (!empty($memberQueries)) {
+                Log::warning('member queries', ['count' => count($memberQueries), 'params' => $memberQueries]);
+            }
         }
 
         return $response;

--- a/app/Http/Middleware/ServerTimingDoctrine.php
+++ b/app/Http/Middleware/ServerTimingDoctrine.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Session;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -52,6 +53,20 @@ class ServerTimingDoctrine
             )
         );
         $response->headers->set('Timing-Allow-Origin', '*');
+
+        // If this request fired N+1s, log the top repeating SQL patterns so we
+        // can target the actual lazy loads. Only logs when there are repeats
+        // (count >= 2) — typical normal requests stay quiet.
+        if ($dbCount >= 20) {
+            $top = \App\Http\Middleware\Doctrine\QueryTimingCollector::topPatterns(8);
+            foreach ($top as $row) {
+                Log::warning('N+1 candidate', [
+                    'count'   => $row['count'],
+                    'totalMs' => $row['totalMs'],
+                    'sample'  => mb_substr($row['sample'], 0, 240),
+                ]);
+            }
+        }
 
         return $response;
     }

--- a/app/Http/Middleware/ServerTimingDoctrine.php
+++ b/app/Http/Middleware/ServerTimingDoctrine.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Http\Middleware\Doctrine\QueryTimingCollector;
 use Closure;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -16,13 +17,13 @@ class ServerTimingDoctrine
         // registered globally in config/doctrine.php. That gives accurate
         // per-statement durations under DBAL 3.x prepared statements, which
         // the deprecated SQLLogger / Logging\Middleware paths do not.
-        \App\Http\Middleware\Doctrine\QueryTimingCollector::reset();
+        QueryTimingCollector::reset();
 
         /** @var Response $response */
         $response = $next($request);
 
-        $dbMs = \App\Http\Middleware\Doctrine\QueryTimingCollector::$totalMs;
-        $dbCount = \App\Http\Middleware\Doctrine\QueryTimingCollector::$count;
+        $dbMs = QueryTimingCollector::$totalMs;
+        $dbCount = QueryTimingCollector::$count;
 
         $end = microtime(true);
         $totalMs = ($end - $start) * 1000.0;

--- a/app/Http/Middleware/ServerTimingDoctrine.php
+++ b/app/Http/Middleware/ServerTimingDoctrine.php
@@ -3,90 +3,27 @@
 namespace App\Http\Middleware;
 
 use Closure;
-use Doctrine\ORM\EntityManagerInterface;
 use Illuminate\Support\Facades\Session;
-use LaravelDoctrine\ORM\Facades\Registry;
-use models\utils\SilverstripeBaseModel;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 class ServerTimingDoctrine
 {
-    /** @var EntityManagerInterface */
-    private EntityManagerInterface $em;
-
-
-    public function __construct()
-    {
-        $this->em =  Registry::getManager(SilverstripeBaseModel::EntityManager);
-    }
-
     public function handle($request, Closure $next): Response
     {
         $start = microtime(true);
-        $conn = $this->em->getConnection();
-        $cfg  = $conn->getConfiguration();
 
-        $dbMs = 0.0;
+        // Reset the request-scoped SQL timing accumulator. The actual per-query
+        // timing is done by QueryTimingMiddleware, a DBAL Driver Middleware
+        // registered globally in config/doctrine.php. That gives accurate
+        // per-statement durations under DBAL 3.x prepared statements, which
+        // the deprecated SQLLogger / Logging\Middleware paths do not.
+        \App\Http\Middleware\Doctrine\QueryTimingCollector::reset();
 
-        // --- DBAL 2.x: DebugStack ---
-        if (class_exists(\Doctrine\DBAL\Logging\DebugStack::class) && method_exists($cfg, 'setSQLLogger')) {
-            $debugStack = new \Doctrine\DBAL\Logging\DebugStack();
-            $prevLogger = $cfg->getSQLLogger() ?? null;
-            $cfg->setSQLLogger($debugStack);
+        /** @var Response $response */
+        $response = $next($request);
 
-            try {
-                /** @var Response $response */
-                $response = $next($request);
-            } finally {
-                foreach ($debugStack->queries as $q) {
-                    $dbMs += isset($q['executionMS']) ? (float) $q['executionMS'] : 0.0;
-                }
-                $cfg->setSQLLogger($prevLogger);
-            }
-
-            // --- DBAL 3.x: Logging\Middleware (PSR-3) ---
-        } elseif (class_exists(\Doctrine\DBAL\Logging\Middleware::class) && method_exists($cfg, 'setMiddlewares')) {
-
-
-            $collector = new class implements LoggerInterface {
-                public float $dbMs = 0.0;
-                public function log($level, $message, array $context = []): void {
-                    if (isset($context['duration_ms'])) {
-                        $this->dbMs += (float) $context['duration_ms'];
-                    } elseif (isset($context['executionMS'])) {
-                        $this->dbMs += (float) $context['executionMS'];
-                    } elseif (isset($context['duration'])) {
-                        $this->dbMs += (float) $context['duration'];
-                    }
-                }
-                public function emergency($m, array $c = []):void { $this->log('emergency', $m, $c); }
-                public function alert($m, array $c = []):void     { $this->log('alert', $m, $c); }
-                public function critical($m, array $c = []):void  { $this->log('critical', $m, $c); }
-                public function error($m, array $c = []):void     { $this->log('error', $m, $c); }
-                public function warning($m, array $c = []):void   { $this->log('warning', $m, $c); }
-                public function notice($m, array $c = []) :void   { $this->log('notice', $m, $c); }
-                public function info($m, array $c = []):void      { $this->log('info', $m, $c); }
-                public function debug($m, array $c = []):void   { $this->log('debug', $m, $c); }
-            };
-
-            $mw   = new \Doctrine\DBAL\Logging\Middleware($collector);
-            $prev = method_exists($cfg, 'getMiddlewares') ? $cfg->getMiddlewares() : [];
-            $cfg->setMiddlewares(array_merge($prev, [$mw]));
-
-            try {
-                /** @var Response $response */
-                $response = $next($request);
-            } finally {
-                $dbMs = $collector->dbMs;
-                $cfg->setMiddlewares($prev);
-            }
-
-            // --- Fallback
-        } else {
-            /** @var Response $response */
-            $response = $next($request);
-        }
+        $dbMs = \App\Http\Middleware\Doctrine\QueryTimingCollector::$totalMs;
+        $dbCount = \App\Http\Middleware\Doctrine\QueryTimingCollector::$count;
 
         $end = microtime(true);
         $totalMs = ($end - $start) * 1000.0;
@@ -110,8 +47,8 @@ class ServerTimingDoctrine
 
         $response->headers->set('Server-Timing',
             sprintf(
-                'boot;dur=%.1f,pre;dur=%.1f,controller;dur=%.1f,db;dur=%.1f,serializer;dur=%.1f,post;dur=%.1f,app;dur=%.1f,total;dur=%.1f',
-                $bootMs, $preMs, $controllerMs, $dbMs, $serializerMs, $postMs, $appMs, $totalMs
+                'boot;dur=%.1f,pre;dur=%.1f,controller;dur=%.1f,db;dur=%.1f;desc="%d queries",serializer;dur=%.1f,post;dur=%.1f,app;dur=%.1f,total;dur=%.1f',
+                $bootMs, $preMs, $controllerMs, $dbMs, $dbCount, $serializerMs, $postMs, $appMs, $totalMs
             )
         );
         $response->headers->set('Timing-Allow-Origin', '*');

--- a/app/Http/Middleware/ServerTimingDoctrine.php
+++ b/app/Http/Middleware/ServerTimingDoctrine.php
@@ -88,15 +88,32 @@ class ServerTimingDoctrine
             $response = $next($request);
         }
 
-        $totalMs = (microtime(true) - $start) * 1000.0;
+        $end = microtime(true);
+        $totalMs = ($end - $start) * 1000.0;
         $bootMs  = defined('LARAVEL_START') ? max(($start - LARAVEL_START) * 1000.0, 0.0) : 0.0;
         $appMs   = max($totalMs - $dbMs, 0.0);
-        $dbMs = Session::has("db_time") ? (float) Session::get("db_time") : $dbMs;
-        $transformMs = Session::has("transform_time") ? (float) Session::get("transform_time") : 0.0;
-        $encodeMs = Session::has("encode_time") ? (float) Session::get("encode_time") : 0.0;
+
+        // Read controller-level timing markers (set by the controller method).
+        // If the controller didn't set them, these phases are reported as 0.
+        $cStart     = Session::has("timing.controller_start")  ? (float) Session::get("timing.controller_start")  : null;
+        $cEnd       = Session::has("timing.controller_end")    ? (float) Session::get("timing.controller_end")    : null;
+        $sStart     = Session::has("timing.serializer_start")  ? (float) Session::get("timing.serializer_start")  : null;
+        $sEnd       = Session::has("timing.serializer_end")    ? (float) Session::get("timing.serializer_end")    : null;
+
+        $preMs        = ($cStart !== null) ? max(($cStart - $start) * 1000.0, 0.0) : 0.0;
+        $controllerMs = ($cStart !== null && $cEnd !== null) ? max(($cEnd - $cStart) * 1000.0, 0.0) : 0.0;
+        $serializerMs = ($sStart !== null && $sEnd !== null) ? max(($sEnd - $sStart) * 1000.0, 0.0) : 0.0;
+        $postMs       = ($cEnd !== null) ? max(($end - $cEnd) * 1000.0, 0.0) : 0.0;
+
+        // Clear so they don't leak into a recycled worker's next request.
+        Session::forget(['timing.controller_start','timing.controller_end','timing.serializer_start','timing.serializer_end']);
+
         $response->headers->set('Server-Timing',
-            sprintf('boot;dur=%.1f,db;dur=%.1f,transform;dur=%.1f,encode;dur=%.1f,app;dur=%.1f,total;dur=%.1f',
-                $bootMs,$dbMs,$transformMs,$encodeMs,$appMs,$totalMs));
+            sprintf(
+                'boot;dur=%.1f,pre;dur=%.1f,controller;dur=%.1f,db;dur=%.1f,serializer;dur=%.1f,post;dur=%.1f,app;dur=%.1f,total;dur=%.1f',
+                $bootMs, $preMs, $controllerMs, $dbMs, $serializerMs, $postMs, $appMs, $totalMs
+            )
+        );
         $response->headers->set('Timing-Allow-Origin', '*');
 
         return $response;

--- a/app/Http/Middleware/ServerTimingDoctrine.php
+++ b/app/Http/Middleware/ServerTimingDoctrine.php
@@ -3,7 +3,6 @@
 namespace App\Http\Middleware;
 
 use Closure;
-use Illuminate\Support\Facades\Session;
 use Symfony\Component\HttpFoundation\Response;
 
 class ServerTimingDoctrine
@@ -30,20 +29,18 @@ class ServerTimingDoctrine
         $bootMs  = defined('LARAVEL_START') ? max(($start - LARAVEL_START) * 1000.0, 0.0) : 0.0;
         $appMs   = max($totalMs - $dbMs, 0.0);
 
-        // Read controller-level timing markers (set by the controller method).
+        // Read controller-level timing markers (set by the controller via $request->attributes).
         // If the controller didn't set them, these phases are reported as 0.
-        $cStart     = Session::has("timing.controller_start")  ? (float) Session::get("timing.controller_start")  : null;
-        $cEnd       = Session::has("timing.controller_end")    ? (float) Session::get("timing.controller_end")    : null;
-        $sStart     = Session::has("timing.serializer_start")  ? (float) Session::get("timing.serializer_start")  : null;
-        $sEnd       = Session::has("timing.serializer_end")    ? (float) Session::get("timing.serializer_end")    : null;
+        $attrs    = $request->attributes;
+        $cStart   = $attrs->has("timing.controller_start")  ? (float) $attrs->get("timing.controller_start")  : null;
+        $cEnd     = $attrs->has("timing.controller_end")    ? (float) $attrs->get("timing.controller_end")    : null;
+        $sStart   = $attrs->has("timing.serializer_start")  ? (float) $attrs->get("timing.serializer_start")  : null;
+        $sEnd     = $attrs->has("timing.serializer_end")    ? (float) $attrs->get("timing.serializer_end")    : null;
 
         $preMs        = ($cStart !== null) ? max(($cStart - $start) * 1000.0, 0.0) : 0.0;
         $controllerMs = ($cStart !== null && $cEnd !== null) ? max(($cEnd - $cStart) * 1000.0, 0.0) : 0.0;
         $serializerMs = ($sStart !== null && $sEnd !== null) ? max(($sEnd - $sStart) * 1000.0, 0.0) : 0.0;
         $postMs       = ($cEnd !== null) ? max(($end - $cEnd) * 1000.0, 0.0) : 0.0;
-
-        // Clear so they don't leak into a recycled worker's next request.
-        Session::forget(['timing.controller_start','timing.controller_end','timing.serializer_start','timing.serializer_end']);
 
         $response->headers->set('Server-Timing',
             sprintf(

--- a/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
@@ -104,11 +104,14 @@ class PresentationSerializer extends SummitEventSerializer
         $presentation = $this->object;
         if(!$presentation instanceof Presentation) return [];
 
+        // Include last_edited timestamp so a presentation update naturally busts the cache
+        // without needing an explicit Cache::forget — the old key just ages out via TTL.
         $key =
             sprintf
             (
-                "public_presentation_%s_%s_%s_%s",
+                "public_presentation_%s_%s_%s_%s_%s",
                 $presentation->getId(),
+                $presentation->getLastEditedUTC()?->getTimestamp() ?? 0,
                 $expand ?? "",
                 implode(",",$fields),
                 implode(",", $relations)

--- a/app/Models/Foundation/Main/Member.php
+++ b/app/Models/Foundation/Main/Member.php
@@ -1042,11 +1042,28 @@ class Member extends SilverstripeBaseModel
     }
 
     /**
+     * Request-scoped cache for group membership lookups. The current-user
+     * Member instance is shared across the whole request, and the same group
+     * codes are checked many times by serializers (isAdmin, memberCanEdit,
+     * etc.) — typical /events request fires this ~80 times for ~8 unique codes.
+     * Property is unannotated so Doctrine ignores it; resets naturally when
+     * the entity is re-hydrated on a new request.
+     *
+     * @var array<string, bool>
+     */
+    private array $groupMembershipCache = [];
+
+    /**
      * @param string $code
      * @return bool
      */
     public function belongsToGroup(string $code): bool
     {
+        $code = trim($code);
+        if (array_key_exists($code, $this->groupMembershipCache)) {
+            return $this->groupMembershipCache[$code];
+        }
+
         try {
             $sql = <<<SQL
 SELECT COUNT(MemberID)
@@ -1057,15 +1074,15 @@ SQL;
 
             $stmt = $this->prepareRawSQL($sql, [
                 'member_id' => $this->getId(),
-                'code' => trim($code),
+                'code' => $code,
             ]);
             $res = $stmt->executeQuery();
             $res = $res->fetchFirstColumn();
-            return intval($res[0]) > 0;
+            return $this->groupMembershipCache[$code] = (intval($res[0]) > 0);
         } catch (\Exception $ex) {
 
         }
-        return false;
+        return $this->groupMembershipCache[$code] = false;
 
     }
 

--- a/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
@@ -456,11 +456,13 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
         $order = $this->getSpeakerAssignmentsMaxOrder();
         $speaker_assignment = new PresentationSpeakerAssignment($this, $speaker, $order + 1);
         $this->speakers->add($speaker_assignment);
+        $this->updateLastEdited();
     }
 
     public function clearSpeakers()
     {
         $this->speakers->clear();
+        $this->updateLastEdited();
     }
 
     /**
@@ -474,6 +476,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
         if ($speaker_assignment === false) return;
         $this->speakers->removeElement($speaker_assignment);
         self::resetOrderForSelectable($this->speakers, PresentationSpeakerAssignment::class);
+        $this->updateLastEdited();
     }
 
     /**
@@ -621,6 +624,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     {
         $this->materials->removeElement($video);
         $video->unsetPresentation();
+        $this->updateLastEdited();
     }
 
     /**
@@ -630,6 +634,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     {
         $this->materials->removeElement($slide);
         $slide->unsetPresentation();
+        $this->updateLastEdited();
     }
 
     /**
@@ -639,6 +644,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     {
         $this->materials->removeElement($link);
         $link->unsetPresentation();
+        $this->updateLastEdited();
     }
 
     /**
@@ -648,6 +654,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     {
         $this->materials->removeElement($mediaUpload);
         $mediaUpload->unsetPresentation();
+        $this->updateLastEdited();
     }
 
     /**
@@ -911,6 +918,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
         $this->materials->add($material);
         $material->setPresentation($this);
         $material->setOrder($this->getMaterialsMaxOrder() + 1);
+        $this->updateLastEdited();
         return $this;
     }
 

--- a/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
@@ -491,6 +491,10 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
         $speaker_assignment = $this->speakers->matching($criteria)->first();
         if ($speaker_assignment === false) return;
         self::recalculateOrderForSelectable($this->speakers, $speaker_assignment, $order, PresentationSpeakerAssignment::class);
+        // Reordering only mutates child PresentationSpeakerAssignment rows, which does not
+        // dirty the parent Presentation, so the PreUpdate last_edited bump never fires.
+        // Bump explicitly so the serializer cache key (which embeds last_edited) invalidates.
+        $this->updateLastEdited();
     }
 
     /**

--- a/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
@@ -927,6 +927,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
      */
     public function setSelectedPresentations($selected_presentations)
     {
+        $this->memoizedSelectionStatus = null;
         $this->selected_presentations = $selected_presentations;
     }
 
@@ -1078,6 +1079,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
      */
     public function setSelectionPlan($selection_plan)
     {
+        $this->memoizedSelectionStatus = null;
         $oldSelectionPlan = $this->selection_plan;
         // if selection plan changes
         if (!is_null($oldSelectionPlan) && $oldSelectionPlan->getId() != $selection_plan->getId()) {
@@ -1089,6 +1091,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
 
     public function clearSelectionPlan()
     {
+        $this->memoizedSelectionStatus = null;
         $this->selection_plan = null;
     }
 
@@ -2181,6 +2184,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
      */
     public function setCategory(PresentationCategory $category)
     {
+        $this->memoizedSelectionStatus = null;
         // check if we change the category
         $oldCategory = $this->category;
         if (!is_null($oldCategory) && $oldCategory->getId() != $category->getId()) {

--- a/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
@@ -979,14 +979,9 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
             return $this->memoizedSelectionStatus;
         }
 
-        $preloadIsSet = isset($this->preloadedSessionSelections);
-        if ($preloadIsSet) {
+        if ($this->preloadedSessionSelections !== null) {
             $session_sel = $this->preloadedSessionSelections;
         } else {
-            \Illuminate\Support\Facades\Log::warning('getSelectionStatus cache MISS', [
-                'pid' => $this->id,
-                'class' => get_class($this),
-            ]);
             $session_sel = $this->createQuery("SELECT sp from models\summit\SummitSelectedPresentation sp
                 JOIN sp.list l
                 JOIN sp.presentation p

--- a/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
@@ -979,9 +979,14 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
             return $this->memoizedSelectionStatus;
         }
 
-        if ($this->preloadedSessionSelections !== null) {
+        $preloadIsSet = isset($this->preloadedSessionSelections);
+        if ($preloadIsSet) {
             $session_sel = $this->preloadedSessionSelections;
         } else {
+            \Illuminate\Support\Facades\Log::warning('getSelectionStatus cache MISS', [
+                'pid' => $this->id,
+                'class' => get_class($this),
+            ]);
             $session_sel = $this->createQuery("SELECT sp from models\summit\SummitSelectedPresentation sp
                 JOIN sp.list l
                 JOIN sp.presentation p

--- a/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
@@ -966,7 +966,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     /**
      * Request-scoped preload cache populated by DoctrineSummitEventRepository::getAllByPage
      * via setPreloadedSessionSelections(). When set, getSelectionStatus() uses these
-     * pre-fetched rows instead of firing its own DQL — eliminates one query per
+     * pre-fetched rows instead of firing its own DQL - eliminates one query per
      * Presentation on /events listings. Doctrine ignores the unannotated property.
      *
      * @var SummitSelectedPresentation[]|null
@@ -1092,6 +1092,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     public function setSelectionPlan($selection_plan)
     {
         $this->memoizedSelectionStatus = null;
+        $this->preloadedSessionSelections = null;
         $oldSelectionPlan = $this->selection_plan;
         // if selection plan changes
         if (!is_null($oldSelectionPlan) && $oldSelectionPlan->getId() != $selection_plan->getId()) {
@@ -1104,6 +1105,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     public function clearSelectionPlan()
     {
         $this->memoizedSelectionStatus = null;
+        $this->preloadedSessionSelections = null;
         $this->selection_plan = null;
     }
 
@@ -1309,6 +1311,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     public function recalculateMaterialOrder(PresentationMaterial $material, $new_order)
     {
         self::recalculateOrderForSelectable($this->materials, $material, $new_order);
+        $this->updateLastEdited();
     }
 
     use OrderableChilds;

--- a/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
@@ -940,6 +940,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     public function setSelectedPresentations($selected_presentations)
     {
         $this->memoizedSelectionStatus = null;
+        $this->preloadedSessionSelections = null;
         $this->selected_presentations = $selected_presentations;
     }
 
@@ -2200,6 +2201,7 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     public function setCategory(PresentationCategory $category)
     {
         $this->memoizedSelectionStatus = null;
+        $this->preloadedSessionSelections = null;
         // check if we change the category
         $oldCategory = $this->category;
         if (!is_null($oldCategory) && $oldCategory->getId() != $category->getId()) {

--- a/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
@@ -950,20 +950,50 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
      * @return string
      * @throws ValidationException
      */
+    /**
+     * Request-scoped preload cache populated by DoctrineSummitEventRepository::getAllByPage
+     * via setPreloadedSessionSelections(). When set, getSelectionStatus() uses these
+     * pre-fetched rows instead of firing its own DQL — eliminates one query per
+     * Presentation on /events listings. Doctrine ignores the unannotated property.
+     *
+     * @var SummitSelectedPresentation[]|null
+     */
+    private ?array $preloadedSessionSelections = null;
+
+    /** @var string|null memoized result of getSelectionStatus() within a request */
+    private ?string $memoizedSelectionStatus = null;
+
+    /**
+     * @param SummitSelectedPresentation[] $selections rows already filtered for
+     *        (collection=Selected, list_type=Group, list_class=Session)
+     */
+    public function setPreloadedSessionSelections(array $selections): void
+    {
+        $this->preloadedSessionSelections = $selections;
+        $this->memoizedSelectionStatus = null;
+    }
+
     public function getSelectionStatus()
     {
+        if ($this->memoizedSelectionStatus !== null) {
+            return $this->memoizedSelectionStatus;
+        }
 
-        $session_sel = $this->createQuery("SELECT sp from models\summit\SummitSelectedPresentation sp
-            JOIN sp.list l
-            JOIN sp.presentation p
-            WHERE p.id = :presentation_id
-            AND sp.collection = :collection
-            AND l.list_type = :list_type
-            AND l.list_class = :list_class")
-            ->setParameter('presentation_id', $this->id)
-            ->setParameter('collection', SummitSelectedPresentation::CollectionSelected)
-            ->setParameter('list_type', SummitSelectedPresentationList::Group)
-            ->setParameter('list_class', SummitSelectedPresentationList::Session)->getResult();
+        if ($this->preloadedSessionSelections !== null) {
+            $session_sel = $this->preloadedSessionSelections;
+        } else {
+            $session_sel = $this->createQuery("SELECT sp from models\summit\SummitSelectedPresentation sp
+                JOIN sp.list l
+                JOIN sp.presentation p
+                WHERE p.id = :presentation_id
+                AND sp.collection = :collection
+                AND l.list_type = :list_type
+                AND l.list_class = :list_class")
+                ->setParameter('presentation_id', $this->id)
+                ->setParameter('collection', SummitSelectedPresentation::CollectionSelected)
+                ->setParameter('list_type', SummitSelectedPresentationList::Group)
+                ->setParameter('list_class', SummitSelectedPresentationList::Session)->getResult();
+        }
 
         // Error out if a talk has more than one selection
         if (count($session_sel) > 1) {
@@ -971,20 +1001,20 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
         }
 
         if ($this->isPublished()) {
-            return Presentation::SelectionStatus_Accepted;
+            return $this->memoizedSelectionStatus = Presentation::SelectionStatus_Accepted;
         }
 
         // from here we need to be sure that the selection period is going on or it is over
 
         $selection_plan = $this->getSelectionPlan();
         if (is_null($selection_plan)) {
-            return Presentation::SelectionStatus_Pending;
+            return $this->memoizedSelectionStatus = Presentation::SelectionStatus_Pending;
         }
         if (!$selection_plan->hasSelectionPeriodDefined()) {
-            return Presentation::SelectionStatus_Pending;
+            return $this->memoizedSelectionStatus = Presentation::SelectionStatus_Pending;
         }
         if ($selection_plan->isSelectionNotYetStarted()) {
-            return Presentation::SelectionStatus_Pending;
+            return $this->memoizedSelectionStatus = Presentation::SelectionStatus_Pending;
         }
 
         $selection = null;
@@ -993,14 +1023,14 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
         }
 
         if (!$selection) {
-            return Presentation::SelectionStatus_Unaccepted;
+            return $this->memoizedSelectionStatus = Presentation::SelectionStatus_Unaccepted;
         }
 
         if ($selection->getOrder() <= $this->getCategory()->getSessionCount()) {
-            return Presentation::SelectionStatus_Accepted;
+            return $this->memoizedSelectionStatus = Presentation::SelectionStatus_Accepted;
         }
 
-        return Presentation::SelectionStatus_Alternate;
+        return $this->memoizedSelectionStatus = Presentation::SelectionStatus_Alternate;
     }
 
     public function getRank(): ?int

--- a/app/Models/Foundation/Summit/Events/SummitEvent.php
+++ b/app/Models/Foundation/Summit/Events/SummitEvent.php
@@ -821,11 +821,13 @@ class SummitEvent extends SilverstripeBaseModel implements IPublishableEvent
     {
         if ($this->tags->contains($tag)) return;
         $this->tags->add($tag);
+        $this->updateLastEdited();
     }
 
     public function clearTags()
     {
         $this->tags->clear();
+        $this->updateLastEdited();
     }
 
     /**

--- a/app/Models/Foundation/Summit/Speakers/PresentationSpeaker.php
+++ b/app/Models/Foundation/Summit/Speakers/PresentationSpeaker.php
@@ -1660,11 +1660,31 @@ class PresentationSpeaker extends SilverstripeBaseModel
     }
 
     /**
+     * Request-scoped cache of (presentation_id => order) populated by
+     * DoctrineSummitEventRepository::getAllByPage when assignments are batch-loaded.
+     * When set, getPresentationAssignmentOrder() reads from here instead of
+     * firing a per-call DB query via EXTRA_LAZY matching(). Unannotated so
+     * Doctrine ignores it.
+     *
+     * @var array<int, int|null>
+     */
+    private array $preloadedAssignmentOrders = [];
+
+    public function setPreloadedAssignmentOrder(int $presentationId, ?int $order): void
+    {
+        $this->preloadedAssignmentOrders[$presentationId] = $order;
+    }
+
+    /**
      * @param Presentation $presentation
      * @return int|null
      */
     public function getPresentationAssignmentOrder(Presentation $presentation): ?int
     {
+        $pid = $presentation->getId();
+        if (array_key_exists($pid, $this->preloadedAssignmentOrders)) {
+            return $this->preloadedAssignmentOrders[$pid];
+        }
         $criteria = Criteria::create();
         $criteria->where(Criteria::expr()->eq('presentation', $presentation));
         $res = $this->presentations->matching($criteria)->first();

--- a/app/Models/Foundation/Summit/Speakers/PresentationSpeaker.php
+++ b/app/Models/Foundation/Summit/Speakers/PresentationSpeaker.php
@@ -1675,6 +1675,16 @@ class PresentationSpeaker extends SilverstripeBaseModel
         $this->preloadedAssignmentOrders[$presentationId] = $order;
     }
 
+    public function clearPreloadedAssignmentOrder(int $presentationId): void
+    {
+        unset($this->preloadedAssignmentOrders[$presentationId]);
+    }
+
+    public function clearAllPreloadedAssignmentOrders(): void
+    {
+        $this->preloadedAssignmentOrders = [];
+    }
+
     /**
      * @param Presentation $presentation
      * @return int|null

--- a/app/Models/OAuth2/ResourceServerContext.php
+++ b/app/Models/OAuth2/ResourceServerContext.php
@@ -160,6 +160,20 @@ final class ResourceServerContext implements IResourceServerContext
     }
 
     /**
+     * Request-scoped cache. The current authenticated user does not change
+     * within a single request, and getCurrentUser() is called many times by
+     * serializers (per-event, per-sub-serializer permission checks). Without
+     * this cache, profiling /events showed the same Member SELECT firing 98+
+     * times via getByExternalId().
+     *
+     * Caches the resolved Member regardless of \$synch_groups / \$update_member_fields
+     * arguments — the side-effects (group sync, event dispatch, field updates)
+     * are idempotent per request and only need to run once.
+     */
+    private ?Member $cachedCurrentUser = null;
+    private bool $cachedCurrentUserResolved = false;
+
+    /**
      * @param bool $synch_groups
      * @param bool $update_member_fields
      * @return Member|null
@@ -167,6 +181,10 @@ final class ResourceServerContext implements IResourceServerContext
      */
     public function getCurrentUser(bool $synch_groups = true, bool $update_member_fields = true): ?Member
     {
+        if ($this->cachedCurrentUserResolved) {
+            return $this->cachedCurrentUser;
+        }
+
         $member = null;
         // try to get by external id
         $user_external_id = $this->getAuthContextVar(IResourceServerContext::UserId);
@@ -176,7 +194,8 @@ final class ResourceServerContext implements IResourceServerContext
         $user_email_verified = boolval($this->getAuthContextVar(IResourceServerContext::UserEmailVerified));
 
         if (is_null($user_external_id)) {
-            return null;
+            $this->cachedCurrentUserResolved = true;
+            return $this->cachedCurrentUser = null;
         }
         // first we check by external id
         $member = $this->tx_service->transaction(function () use ($user_external_id) {
@@ -231,10 +250,11 @@ final class ResourceServerContext implements IResourceServerContext
 
         if (is_null($member)) {
             Log::warning(sprintf("ResourceServerContext::getCurrentUser user not found %s (%s).", $user_external_id, $user_email));
-            return null;
+            $this->cachedCurrentUserResolved = true;
+            return $this->cachedCurrentUser = null;
         }
 
-        return $this->tx_service->transaction(function () use
+        $resolved = $this->tx_service->transaction(function () use
         (
             $member,
             $user_email,
@@ -278,6 +298,9 @@ final class ResourceServerContext implements IResourceServerContext
             MemberAssocSummitOrders::dispatch($member->getId());
             return $synch_groups ? $this->checkGroups($member) : $member;
         });
+
+        $this->cachedCurrentUserResolved = true;
+        return $this->cachedCurrentUser = $resolved;
     }
 
     /**

--- a/app/Models/OAuth2/ResourceServerContext.php
+++ b/app/Models/OAuth2/ResourceServerContext.php
@@ -175,7 +175,7 @@ final class ResourceServerContext implements IResourceServerContext
      * times via getByExternalId().
      *
      * Side-effects ($synch_groups, $update_member_fields) are tracked separately
-     * so a first call with false does not permanently suppress them — a later
+     * so a first call with false does not permanently suppress them - a later
      * call with true will still run the missing side-effect exactly once.
      */
     private ?Member $cachedCurrentUser = null;        // resolved Member (or null) for this request
@@ -191,14 +191,14 @@ final class ResourceServerContext implements IResourceServerContext
      *
      * The method has two phases:
      *
-     *   PHASE A — fast path (cache hit): if the user was already resolved this
+     *   PHASE A - fast path (cache hit): if the user was already resolved this
      *   request, return the cached Member immediately. Any side-effect that an
      *   earlier call suppressed (e.g. a previous getCurrentUser(false, false))
      *   is run now, once, so the side-effect flags reflect the strongest request
      *   so far. This is what keeps the /events serializer from re-running the
      *   same Member SELECT ~98 times per request.
      *
-     *   PHASE B — full resolution (cache miss): look the Member up by external
+     *   PHASE B - full resolution (cache miss): look the Member up by external
      *   id, then by email, then create it locally if the IDP knows it but we
      *   don't. Apply the always-on side-effects (external id, email-verified
      *   flag, order-association event) plus the optional field/group syncs, then
@@ -211,12 +211,12 @@ final class ResourceServerContext implements IResourceServerContext
      */
     public function getCurrentUser(bool $synch_groups = true, bool $update_member_fields = true): ?Member
     {
-        // ---- PHASE A: fast path — user already resolved this request ----------
+        // ---- PHASE A: fast path - user already resolved this request ----------
         if ($this->cachedCurrentUserResolved) {
             // Only Members carry side-effects; a cached null is returned as-is.
             if ($this->cachedCurrentUser !== null) {
                 // Apply field updates that an earlier call suppressed
-                // ($update_member_fields=false), exactly once — mirroring the
+                // ($update_member_fields=false), exactly once - mirroring the
                 // deferred-groups handling below so the documented contract holds.
                 if ($update_member_fields && !$this->fieldsSynched) {
                     $member = $this->cachedCurrentUser;
@@ -228,6 +228,12 @@ final class ResourceServerContext implements IResourceServerContext
                             $this->getAuthContextVar(IResourceServerContext::UserLastName)
                         );
                     });
+                    // syncMemberFields() calls setFirstName()/setLastName() on the Member,
+                    // which call updateAuthContextVar() and clear cachedCurrentUser/cachedCurrentUserResolved.
+                    // Restore from the local reference so the groups-sync block below
+                    // does not receive null.
+                    $this->cachedCurrentUser = $member;
+                    $this->cachedCurrentUserResolved = true;
                     $this->fieldsSynched = true;
                 }
                 // checkGroups() may return a re-fetched instance, so reassign the cache.
@@ -242,7 +248,7 @@ final class ResourceServerContext implements IResourceServerContext
             return $this->cachedCurrentUser;
         }
 
-        // ---- PHASE B: full resolution — first call this request ---------------
+        // ---- PHASE B: full resolution - first call this request ---------------
         // Read the IDP claims off the auth context up front.
         $user_external_id = $this->getAuthContextVar(IResourceServerContext::UserId);
         $user_first_name = $this->getAuthContextVar(IResourceServerContext::UserFirstName);
@@ -315,7 +321,7 @@ final class ResourceServerContext implements IResourceServerContext
      *   1. by external id (the stable identifier)
      *   2. by primary email (covers members created before the external id was linked)
      *   3. provision locally via registerExternalUser() when the IDP knows the
-     *      user but we don't — racy under concurrent first-time logins, so on
+     *      user but we don't - racy under concurrent first-time logins, so on
      *      failure we re-read by external id (the winner of the race created it)
      *
      * This is lookup/creation only; the profile-field, external-id, email-verified
@@ -383,7 +389,7 @@ final class ResourceServerContext implements IResourceServerContext
                 );
             } catch (\Exception $ex) {
                 Log::warning($ex);
-                // race condition lost — re-read the instance the winner created
+                // race condition lost - re-read the instance the winner created
                 $member = $this->tx_service->transaction(function () use ($user_external_id) {
                     return $this->member_repository->getByExternalId(intval($user_external_id));
                 });

--- a/app/Models/OAuth2/ResourceServerContext.php
+++ b/app/Models/OAuth2/ResourceServerContext.php
@@ -126,6 +126,8 @@ final class ResourceServerContext implements IResourceServerContext
     public function setAuthorizationContext(array $auth_context)
     {
         $this->auth_context = $auth_context;
+        $this->cachedCurrentUser = null;
+        $this->cachedCurrentUserResolved = false;
     }
 
     /**
@@ -156,6 +158,8 @@ final class ResourceServerContext implements IResourceServerContext
     public function updateAuthContextVar(string $varName, $value):void {
         if(isset($this->auth_context[$varName])){
             $this->auth_context[$varName] = $value;
+            $this->cachedCurrentUser = null;
+            $this->cachedCurrentUserResolved = false;
         }
     }
 

--- a/app/Models/OAuth2/ResourceServerContext.php
+++ b/app/Models/OAuth2/ResourceServerContext.php
@@ -178,64 +178,189 @@ final class ResourceServerContext implements IResourceServerContext
      * so a first call with false does not permanently suppress them — a later
      * call with true will still run the missing side-effect exactly once.
      */
-    private ?Member $cachedCurrentUser = null;
-    private bool $cachedCurrentUserResolved = false;
-    private bool $groupsSynched = false;
-    private bool $fieldsSynched = false;
+    private ?Member $cachedCurrentUser = null;        // resolved Member (or null) for this request
+    private bool $cachedCurrentUserResolved = false;  // has resolution run at least once? (null is a valid resolved value)
+    private bool $groupsSynched = false;              // has checkGroups() run for the cached user?
+    private bool $fieldsSynched = false;              // has syncMemberFields() run for the cached user?
 
     /**
-     * @param bool $synch_groups
-     * @param bool $update_member_fields
-     * @return Member|null
+     * Resolves the Member behind the current request's OAuth2 auth context (the
+     * IDP claims set via setAuthorizationContext()), creating a local Member the
+     * first time an IDP user is seen, and optionally syncing profile fields and
+     * group membership from the claims.
+     *
+     * The method has two phases:
+     *
+     *   PHASE A — fast path (cache hit): if the user was already resolved this
+     *   request, return the cached Member immediately. Any side-effect that an
+     *   earlier call suppressed (e.g. a previous getCurrentUser(false, false))
+     *   is run now, once, so the side-effect flags reflect the strongest request
+     *   so far. This is what keeps the /events serializer from re-running the
+     *   same Member SELECT ~98 times per request.
+     *
+     *   PHASE B — full resolution (cache miss): look the Member up by external
+     *   id, then by email, then create it locally if the IDP knows it but we
+     *   don't. Apply the always-on side-effects (external id, email-verified
+     *   flag, order-association event) plus the optional field/group syncs, then
+     *   cache the result for the rest of the request.
+     *
+     * @param bool $synch_groups         when true, reconcile local groups from the IDP claims
+     * @param bool $update_member_fields when true, copy email / first / last name from the claims
+     * @return Member|null               null when there is no authenticated user, or it cannot be resolved
      * @throws \Exception
      */
     public function getCurrentUser(bool $synch_groups = true, bool $update_member_fields = true): ?Member
     {
+        // ---- PHASE A: fast path — user already resolved this request ----------
         if ($this->cachedCurrentUserResolved) {
-            if ($synch_groups && !$this->groupsSynched && $this->cachedCurrentUser !== null) {
-                $member = $this->cachedCurrentUser;
-                $this->cachedCurrentUser = $this->tx_service->transaction(
-                    fn() => $this->checkGroups($member)
-                );
-                $this->groupsSynched = true;
+            // Only Members carry side-effects; a cached null is returned as-is.
+            if ($this->cachedCurrentUser !== null) {
+                // Apply field updates that an earlier call suppressed
+                // ($update_member_fields=false), exactly once — mirroring the
+                // deferred-groups handling below so the documented contract holds.
+                if ($update_member_fields && !$this->fieldsSynched) {
+                    $member = $this->cachedCurrentUser;
+                    $this->tx_service->transaction(function () use ($member) {
+                        $this->syncMemberFields(
+                            $member,
+                            $this->getAuthContextVar(IResourceServerContext::UserEmail),
+                            $this->getAuthContextVar(IResourceServerContext::UserFirstName),
+                            $this->getAuthContextVar(IResourceServerContext::UserLastName)
+                        );
+                    });
+                    $this->fieldsSynched = true;
+                }
+                // checkGroups() may return a re-fetched instance, so reassign the cache.
+                if ($synch_groups && !$this->groupsSynched) {
+                    $member = $this->cachedCurrentUser;
+                    $this->cachedCurrentUser = $this->tx_service->transaction(
+                        fn() => $this->checkGroups($member)
+                    );
+                    $this->groupsSynched = true;
+                }
             }
             return $this->cachedCurrentUser;
         }
 
-        $member = null;
-        // try to get by external id
+        // ---- PHASE B: full resolution — first call this request ---------------
+        // Read the IDP claims off the auth context up front.
         $user_external_id = $this->getAuthContextVar(IResourceServerContext::UserId);
         $user_first_name = $this->getAuthContextVar(IResourceServerContext::UserFirstName);
         $user_last_name = $this->getAuthContextVar(IResourceServerContext::UserLastName);
         $user_email = $this->getAuthContextVar(IResourceServerContext::UserEmail);
         $user_email_verified = boolval($this->getAuthContextVar(IResourceServerContext::UserEmailVerified));
 
+        // No external id => no authenticated user. Cache the null so we don't
+        // re-attempt resolution on every subsequent call this request.
         if (is_null($user_external_id)) {
             $this->cachedCurrentUserResolved = true;
             return $this->cachedCurrentUser = null;
         }
-        // first we check by external id
+
+        // Find the Member by external id / email, provisioning it locally if the
+        // IDP knows the user but we don't. Side-effects are applied below.
+        $member = $this->resolveMemberFromClaims(
+            $user_external_id,
+            $user_email,
+            $user_first_name,
+            $user_last_name,
+            $user_email_verified
+        );
+
+        // Still nothing (creation failed and the re-read found nothing): give up
+        // for this request, caching the null so we don't retry on every call.
+        if (is_null($member)) {
+            Log::warning(sprintf("ResourceServerContext::getCurrentUser user not found %s (%s).", $user_external_id, $user_email));
+            $this->cachedCurrentUserResolved = true;
+            return $this->cachedCurrentUser = null;
+        }
+
+        // Apply side-effects in a single transaction:
+        //   - optional field sync (email / names) when $update_member_fields
+        //   - always: persist the external id + email-verified flag, and dispatch
+        //     the order-association event
+        //   - optional group reconciliation when $synch_groups (checkGroups() may
+        //     return a re-fetched instance, which becomes the resolved Member)
+        $resolved = $this->tx_service->transaction(function () use
+        (
+            $member,
+            $user_email,
+            $user_first_name,
+            $user_last_name,
+            $user_external_id,
+            $user_email_verified,
+            $synch_groups,
+            $update_member_fields
+        ) {
+            if($update_member_fields) {
+                $this->syncMemberFields($member, $user_email, $user_first_name, $user_last_name);
+            }
+
+            $member->setUserExternalId($user_external_id);
+            $member->setEmailVerified($user_email_verified);
+            MemberAssocSummitOrders::dispatch($member->getId());
+            return $synch_groups ? $this->checkGroups($member) : $member;
+        });
+
+        // Cache the resolved user and record which side-effects ran, so PHASE A
+        // can defer only the ones a weaker first call skipped.
+        $this->cachedCurrentUserResolved = true;
+        $this->groupsSynched = $synch_groups;
+        $this->fieldsSynched = $update_member_fields;
+        return $this->cachedCurrentUser = $resolved;
+    }
+
+    /**
+     * Runs the three-strategy lookup for the Member behind the given IDP claims:
+     *   1. by external id (the stable identifier)
+     *   2. by primary email (covers members created before the external id was linked)
+     *   3. provision locally via registerExternalUser() when the IDP knows the
+     *      user but we don't — racy under concurrent first-time logins, so on
+     *      failure we re-read by external id (the winner of the race created it)
+     *
+     * This is lookup/creation only; the profile-field, external-id, email-verified
+     * and group side-effects are applied by the caller (getCurrentUser).
+     *
+     * @param string|int  $user_external_id
+     * @param string|null $user_email
+     * @param string|null $user_first_name
+     * @param string|null $user_last_name
+     * @param bool        $user_email_verified
+     * @return Member|null null when the user can be neither found nor created
+     * @throws \Exception
+     */
+    private function resolveMemberFromClaims(
+        $user_external_id,
+        ?string $user_email,
+        ?string $user_first_name,
+        ?string $user_last_name,
+        bool $user_email_verified
+    ): ?Member
+    {
+        // Lookup strategy 1: by IDP external id (the stable identifier).
         $member = $this->tx_service->transaction(function () use ($user_external_id) {
             return $this->member_repository->getByExternalId(intval($user_external_id));
         });
 
         if (is_null($member)) {
-            // then by primary email
+            // Lookup strategy 2: by primary email.
             $member = $this->tx_service->transaction(function () use ($user_email) {
                 // we assume that is new idp version and claims already exists on context
                 $user_email = $this->getAuthContextVar(IResourceServerContext::UserEmail);
                 // at last resort try to get by email
-                Log::debug(sprintf("ResourceServerContext::getCurrentUser getting user by email %s", $user_email));
+                Log::debug(sprintf("ResourceServerContext::resolveMemberFromClaims getting user by email %s", $user_email));
                 return $this->member_repository->getByEmail($user_email);
             });
         }
 
-        if (is_null($member)) {// user exist on IDP but not in our local DB, proceed to create it
+        if (is_null($member)) {
+            // Lookup strategy 3: user exists on the IDP but not in our local DB,
+            // so provision it.
             Log::debug
             (
                 sprintf
                 (
-                    "ResourceServerContext::getCurrentUser creating user email %s user_external_id %s fname %s lname %s",
+                    "ResourceServerContext::resolveMemberFromClaims creating user email %s user_external_id %s fname %s lname %s",
                     $user_email,
                     $user_external_id,
                     $user_first_name,
@@ -258,68 +383,53 @@ final class ResourceServerContext implements IResourceServerContext
                 );
             } catch (\Exception $ex) {
                 Log::warning($ex);
-                // race condition lost
+                // race condition lost — re-read the instance the winner created
                 $member = $this->tx_service->transaction(function () use ($user_external_id) {
                     return $this->member_repository->getByExternalId(intval($user_external_id));
                 });
             }
         }
 
-        if (is_null($member)) {
-            Log::warning(sprintf("ResourceServerContext::getCurrentUser user not found %s (%s).", $user_external_id, $user_email));
-            $this->cachedCurrentUserResolved = true;
-            return $this->cachedCurrentUser = null;
+        return $member;
+    }
+
+    /**
+     * Applies IDP claim values (email / first name / last name) onto the local
+     * Member. Extracted so it can run both during initial resolution and as a
+     * deferred side-effect when an earlier getCurrentUser() call passed
+     * $update_member_fields=false and a later one passes true within the same request.
+     *
+     * @param Member $member
+     * @param string|null $user_email
+     * @param string|null $user_first_name
+     * @param string|null $user_last_name
+     */
+    private function syncMemberFields(Member $member, ?string $user_email, ?string $user_first_name, ?string $user_last_name): void
+    {
+        if (!empty($user_email)) {
+            Log::debug(sprintf("ResourceServerContext::syncMemberFields setting email for member %s", $member->getId()));
+            // guard against email collision: another member may already hold this email
+            $member_by_email = $this->member_repository->getByEmail($user_email);
+            if (!is_null($member_by_email) && $member_by_email->getId() !== $member->getId()) {
+                Log::warning(sprintf(
+                    "ResourceServerContext::syncMemberFields email %s already owned by member %s, invalidating it",
+                    $user_email,
+                    $member_by_email->getId()
+                ));
+                $member_by_email->setEmail(sprintf("%s-invalid@invalid", $member_by_email->getId()));
+            }
+            $member->setEmail($user_email);
         }
 
-        $resolved = $this->tx_service->transaction(function () use
-        (
-            $member,
-            $user_email,
-            $user_first_name,
-            $user_last_name,
-            $user_external_id,
-            $user_email_verified,
-            $synch_groups,
-            $update_member_fields
-        ) {
-            if($update_member_fields) {
-                // update member fields
-                if (!empty($user_email)) {
-                    Log::debug(sprintf("ResourceServerContext::getCurrentUser setting email for member %s", $member->getId()));
-                    // guard against email collision: another member may already hold this email
-                    $member_by_email = $this->member_repository->getByEmail($user_email);
-                    if (!is_null($member_by_email) && $member_by_email->getId() !== $member->getId()) {
-                        Log::warning(sprintf(
-                            "ResourceServerContext::getCurrentUser email %s already owned by member %s, invalidating it",
-                            $user_email,
-                            $member_by_email->getId()
-                        ));
-                        $member_by_email->setEmail(sprintf("%s-invalid@invalid", $member_by_email->getId()));
-                    }
-                    $member->setEmail($user_email);
-                }
+        if (!empty($user_first_name)) {
+            Log::debug(sprintf("ResourceServerContext::syncMemberFields setting first name for member %s", $member->getId()));
+            $member->setFirstName($user_first_name);
+        }
 
-                if (!empty($user_first_name)) {
-                    Log::debug(sprintf("ResourceServerContext::getCurrentUser setting first name for member %s", $member->getId()));
-                    $member->setFirstName($user_first_name);
-                }
-
-                if (!empty($user_last_name)) {
-                    Log::debug(sprintf("ResourceServerContext::getCurrentUser setting last name for member %s", $member->getId()));
-                    $member->setLastName($user_last_name);
-                }
-            }
-
-            $member->setUserExternalId($user_external_id);
-            $member->setEmailVerified($user_email_verified);
-            MemberAssocSummitOrders::dispatch($member->getId());
-            return $synch_groups ? $this->checkGroups($member) : $member;
-        });
-
-        $this->cachedCurrentUserResolved = true;
-        $this->groupsSynched = $synch_groups;
-        $this->fieldsSynched = $update_member_fields;
-        return $this->cachedCurrentUser = $resolved;
+        if (!empty($user_last_name)) {
+            Log::debug(sprintf("ResourceServerContext::syncMemberFields setting last name for member %s", $member->getId()));
+            $member->setLastName($user_last_name);
+        }
     }
 
     /**

--- a/app/Models/OAuth2/ResourceServerContext.php
+++ b/app/Models/OAuth2/ResourceServerContext.php
@@ -128,6 +128,8 @@ final class ResourceServerContext implements IResourceServerContext
         $this->auth_context = $auth_context;
         $this->cachedCurrentUser = null;
         $this->cachedCurrentUserResolved = false;
+        $this->groupsSynched = false;
+        $this->fieldsSynched = false;
     }
 
     /**
@@ -160,6 +162,8 @@ final class ResourceServerContext implements IResourceServerContext
             $this->auth_context[$varName] = $value;
             $this->cachedCurrentUser = null;
             $this->cachedCurrentUserResolved = false;
+            $this->groupsSynched = false;
+            $this->fieldsSynched = false;
         }
     }
 
@@ -170,12 +174,14 @@ final class ResourceServerContext implements IResourceServerContext
      * this cache, profiling /events showed the same Member SELECT firing 98+
      * times via getByExternalId().
      *
-     * Caches the resolved Member regardless of \$synch_groups / \$update_member_fields
-     * arguments — the side-effects (group sync, event dispatch, field updates)
-     * are idempotent per request and only need to run once.
+     * Side-effects ($synch_groups, $update_member_fields) are tracked separately
+     * so a first call with false does not permanently suppress them — a later
+     * call with true will still run the missing side-effect exactly once.
      */
     private ?Member $cachedCurrentUser = null;
     private bool $cachedCurrentUserResolved = false;
+    private bool $groupsSynched = false;
+    private bool $fieldsSynched = false;
 
     /**
      * @param bool $synch_groups
@@ -186,6 +192,13 @@ final class ResourceServerContext implements IResourceServerContext
     public function getCurrentUser(bool $synch_groups = true, bool $update_member_fields = true): ?Member
     {
         if ($this->cachedCurrentUserResolved) {
+            if ($synch_groups && !$this->groupsSynched && $this->cachedCurrentUser !== null) {
+                $member = $this->cachedCurrentUser;
+                $this->cachedCurrentUser = $this->tx_service->transaction(
+                    fn() => $this->checkGroups($member)
+                );
+                $this->groupsSynched = true;
+            }
             return $this->cachedCurrentUser;
         }
 
@@ -304,6 +317,8 @@ final class ResourceServerContext implements IResourceServerContext
         });
 
         $this->cachedCurrentUserResolved = true;
+        $this->groupsSynched = $synch_groups;
+        $this->fieldsSynched = $update_member_fields;
         return $this->cachedCurrentUser = $resolved;
     }
 

--- a/app/Repositories/Summit/DoctrineSummitEventRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitEventRepository.php
@@ -758,7 +758,7 @@ SQL,
         if (!empty($presentationIds)) {
             try {
                 $this->getEntityManager()->createQuery(
-                    'SELECT s, m FROM ' . \App\Models\Foundation\Summit\Speakers\PresentationSpeakerAssignment::class . ' a ' .
+                    'SELECT a, s, m FROM ' . \App\Models\Foundation\Summit\Speakers\PresentationSpeakerAssignment::class . ' a ' .
                     'JOIN a.speaker s ' .
                     'LEFT JOIN s.member m ' .
                     'WHERE a.presentation IN (:ids)'

--- a/app/Repositories/Summit/DoctrineSummitEventRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitEventRepository.php
@@ -712,11 +712,15 @@ SQL,
         $ids = $this->getAllIdsByPage($paging_info, $filter, $order);
         Log::debug("DoctrineSummitEventRepository::getAllByPage ids", ['ids' => $ids]);
         $query = $this->getEntityManager()->createQueryBuilder()
-            ->select('e, p , et, et2')
+            ->select('e, p , et, et2, loc')
             ->from($this->getBaseEntity(), "e")
             ->innerJoin("e.type", "et")->addSelect("et")
             ->leftJoin(PresentationType::class, 'et2', 'WITH', 'et.id = et2.id')->addSelect("et2")
             ->leftJoin(Presentation::class, 'p', 'WITH', 'e.id = p.id')->addSelect("p")
+            // Fetch-join location so the serializer's $event->getLocation() does not
+            // lazy-load per event (one query saved per event on /events listings).
+            // Doctrine's JOINED inheritance handles SummitVenueRoom etc. subclasses.
+            ->leftJoin('e.location', 'loc')->addSelect('loc')
             ->where('e.id IN (:ids)')
             ->setParameter('ids', $ids);
 
@@ -742,6 +746,23 @@ SQL,
         $data = [];
         foreach ($ids as $id) {
             if (isset($byId[$id])) $data[] = $byId[$id];
+        }
+
+        // Batch-preload Tag rows for every event on the page so the serializer's
+        // foreach (\$event->getTags()) does not lazy-load the collection per event.
+        // SELECT e, t fetch-joins tags onto each SummitEvent.
+        if (!empty($ids)) {
+            try {
+                $this->getEntityManager()->createQuery(
+                    'SELECT e, t FROM ' . SummitEvent::class . ' e ' .
+                    'LEFT JOIN e.tags t ' .
+                    'WHERE e.id IN (:ids)'
+                )->setParameter('ids', $ids)->getResult();
+            } catch (\Exception $ex) {
+                Log::warning('DoctrineSummitEventRepository::getAllByPage tags preload failed', [
+                    'error' => $ex->getMessage(),
+                ]);
+            }
         }
 
         // Targeted N+1 preload for Presentation rows on this page:
@@ -825,6 +846,22 @@ SQL,
                     if ($speaker && $presentation && method_exists($speaker, 'setPreloadedAssignmentOrder')) {
                         $speaker->setPreloadedAssignmentOrder($presentation->getId(), $a->getOrder());
                     }
+                }
+
+                // Batch-preload PresentationMaterial rows so the serializer's
+                // getMediaUploads/getSlides/getLinks/etc. iterates from memory instead
+                // of firing one query per presentation. Selecting both p and m makes
+                // this a fetch-join that populates p.materials with the rows.
+                try {
+                    $em->createQuery(
+                        'SELECT p, m FROM ' . Presentation::class . ' p ' .
+                        'LEFT JOIN p.materials m ' .
+                        'WHERE p.id IN (:ids)'
+                    )->setParameter('ids', $presentationIds)->getResult();
+                } catch (\Exception $ex) {
+                    Log::warning('DoctrineSummitEventRepository::getAllByPage materials preload failed', [
+                        'error' => $ex->getMessage(),
+                    ]);
                 }
 
                 // Diagnostic: confirm what was actually loaded.

--- a/app/Repositories/Summit/DoctrineSummitEventRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitEventRepository.php
@@ -757,12 +757,47 @@ SQL,
         }
         if (!empty($presentationIds)) {
             try {
-                $this->getEntityManager()->createQuery(
+                $em = $this->getEntityManager();
+                $assignments = $em->createQuery(
                     'SELECT a, s, m FROM ' . \App\Models\Foundation\Summit\Speakers\PresentationSpeakerAssignment::class . ' a ' .
                     'JOIN a.speaker s ' .
                     'LEFT JOIN s.member m ' .
                     'WHERE a.presentation IN (:ids)'
                 )->setParameter('ids', $presentationIds)->getResult();
+
+                // Diagnostic: confirm what was actually loaded.
+                $speakerIds = [];
+                $memberIds  = [];
+                $speakerInitialized = 0;
+                $memberInitialized  = 0;
+                foreach ($assignments as $a) {
+                    if (method_exists($a, 'getSpeaker')) {
+                        $s = $a->getSpeaker();
+                        if ($s) {
+                            $speakerIds[$s->getId()] = true;
+                            if (!($s instanceof \Doctrine\Persistence\Proxy) || $s->__isInitialized()) {
+                                $speakerInitialized++;
+                            }
+                            if (method_exists($s, 'getMember')) {
+                                $m = $s->getMember();
+                                if ($m) {
+                                    $memberIds[$m->getId()] = true;
+                                    if (!($m instanceof \Doctrine\Persistence\Proxy) || $m->__isInitialized()) {
+                                        $memberInitialized++;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Log::warning('preload diagnostic', [
+                    'presentationIds'    => count($presentationIds),
+                    'assignmentsLoaded'  => count($assignments),
+                    'uniqueSpeakers'     => count($speakerIds),
+                    'speakersInitialized'=> $speakerInitialized,
+                    'uniqueMembers'      => count($memberIds),
+                    'membersInitialized' => $memberInitialized,
+                ]);
             } catch (\Exception $ex) {
                 Log::warning('DoctrineSummitEventRepository::getAllByPage speaker+member preload failed', [
                     'error' => $ex->getMessage(),

--- a/app/Repositories/Summit/DoctrineSummitEventRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitEventRepository.php
@@ -821,23 +821,11 @@ SQL,
                         $pid = $sp->getPresentation()->getId();
                         $byPresentation[$pid][] = $sp;
                     }
-                    $fed = 0;
-                    $skipped = 0;
                     foreach ($data as $event) {
                         if ($event instanceof Presentation && method_exists($event, 'setPreloadedSessionSelections')) {
                             $event->setPreloadedSessionSelections($byPresentation[$event->getId()] ?? []);
-                            $fed++;
-                        } else {
-                            $skipped++;
                         }
                     }
-                    Log::warning('selection-status preload diagnostic', [
-                        'presentationIds'  => count($presentationIds),
-                        'selectionsLoaded' => count($selections),
-                        'fed'              => $fed,
-                        'skipped'          => $skipped,
-                        'eventClasses'     => array_map(fn($e) => get_class($e), array_slice($data, 0, 3)),
-                    ]);
                 } catch (\Exception $ex) {
                     Log::warning('DoctrineSummitEventRepository::getAllByPage selection-status preload failed', [
                         'error' => $ex->getMessage(),
@@ -879,39 +867,6 @@ SQL,
                     ]);
                 }
 
-                // Diagnostic: confirm what was actually loaded.
-                $speakerIds = [];
-                $memberIds  = [];
-                $speakerInitialized = 0;
-                $memberInitialized  = 0;
-                foreach ($assignments as $a) {
-                    if (method_exists($a, 'getSpeaker')) {
-                        $s = $a->getSpeaker();
-                        if ($s) {
-                            $speakerIds[$s->getId()] = true;
-                            if (!($s instanceof \Doctrine\Persistence\Proxy) || $s->__isInitialized()) {
-                                $speakerInitialized++;
-                            }
-                            if (method_exists($s, 'getMember')) {
-                                $m = $s->getMember();
-                                if ($m) {
-                                    $memberIds[$m->getId()] = true;
-                                    if (!($m instanceof \Doctrine\Persistence\Proxy) || $m->__isInitialized()) {
-                                        $memberInitialized++;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                Log::warning('preload diagnostic', [
-                    'presentationIds'    => count($presentationIds),
-                    'assignmentsLoaded'  => count($assignments),
-                    'uniqueSpeakers'     => count($speakerIds),
-                    'speakersInitialized'=> $speakerInitialized,
-                    'uniqueMembers'      => count($memberIds),
-                    'membersInitialized' => $memberInitialized,
-                ]);
             } catch (\Exception $ex) {
                 Log::warning('DoctrineSummitEventRepository::getAllByPage speaker+member preload failed', [
                     'error' => $ex->getMessage(),

--- a/app/Repositories/Summit/DoctrineSummitEventRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitEventRepository.php
@@ -712,7 +712,7 @@ SQL,
         $ids = $this->getAllIdsByPage($paging_info, $filter, $order);
         Log::debug("DoctrineSummitEventRepository::getAllByPage ids", ['ids' => $ids]);
         $query = $this->getEntityManager()->createQueryBuilder()
-            ->select('e, p , et, et2, loc')
+            ->select('e, p , et, et2, loc, cat')
             ->from($this->getBaseEntity(), "e")
             ->innerJoin("e.type", "et")->addSelect("et")
             ->leftJoin(PresentationType::class, 'et2', 'WITH', 'et.id = et2.id')->addSelect("et2")
@@ -721,6 +721,8 @@ SQL,
             // lazy-load per event (one query saved per event on /events listings).
             // Doctrine's JOINED inheritance handles SummitVenueRoom etc. subclasses.
             ->leftJoin('e.location', 'loc')->addSelect('loc')
+            // Fetch-join PresentationCategory (track) — was 5 queries per request.
+            ->leftJoin('p.category', 'cat')->addSelect('cat')
             ->where('e.id IN (:ids)')
             ->setParameter('ids', $ids);
 
@@ -760,6 +762,19 @@ SQL,
                 )->setParameter('ids', $ids)->getResult();
             } catch (\Exception $ex) {
                 Log::warning('DoctrineSummitEventRepository::getAllByPage tags preload failed', [
+                    'error' => $ex->getMessage(),
+                ]);
+            }
+
+            // Same pattern for Sponsors (ManyToMany Company on SummitEvent).
+            try {
+                $this->getEntityManager()->createQuery(
+                    'SELECT e, s FROM ' . SummitEvent::class . ' e ' .
+                    'LEFT JOIN e.sponsors s ' .
+                    'WHERE e.id IN (:ids)'
+                )->setParameter('ids', $ids)->getResult();
+            } catch (\Exception $ex) {
+                Log::warning('DoctrineSummitEventRepository::getAllByPage sponsors preload failed', [
                     'error' => $ex->getMessage(),
                 ]);
             }

--- a/app/Repositories/Summit/DoctrineSummitEventRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitEventRepository.php
@@ -758,6 +758,44 @@ SQL,
         if (!empty($presentationIds)) {
             try {
                 $em = $this->getEntityManager();
+
+                // Batch-preload SummitSelectedPresentation rows for all presentations
+                // on this page. getSelectionStatus() on each Presentation then uses the
+                // preloaded data instead of firing its own DQL per presentation.
+                // Filters match getSelectionStatus()'s constants exactly.
+                try {
+                    $selections = $em->createQuery(
+                        'SELECT sp, p FROM ' . SummitSelectedPresentation::class . ' sp ' .
+                        'JOIN sp.list l ' .
+                        'JOIN sp.presentation p ' .
+                        'WHERE p.id IN (:ids) ' .
+                        'AND sp.collection = :collection ' .
+                        'AND l.list_type = :list_type ' .
+                        'AND l.list_class = :list_class'
+                    )
+                    ->setParameter('ids', $presentationIds)
+                    ->setParameter('collection', SummitSelectedPresentation::CollectionSelected)
+                    ->setParameter('list_type', SummitSelectedPresentationList::Group)
+                    ->setParameter('list_class', SummitSelectedPresentationList::Session)
+                    ->getResult();
+
+                    // Group by presentation id and feed each Presentation entity.
+                    $byPresentation = [];
+                    foreach ($selections as $sp) {
+                        $pid = $sp->getPresentation()->getId();
+                        $byPresentation[$pid][] = $sp;
+                    }
+                    foreach ($data as $event) {
+                        if ($event instanceof Presentation && method_exists($event, 'setPreloadedSessionSelections')) {
+                            $event->setPreloadedSessionSelections($byPresentation[$event->getId()] ?? []);
+                        }
+                    }
+                } catch (\Exception $ex) {
+                    Log::warning('DoctrineSummitEventRepository::getAllByPage selection-status preload failed', [
+                        'error' => $ex->getMessage(),
+                    ]);
+                }
+
                 $assignments = $em->createQuery(
                     'SELECT a, s, m FROM ' . \App\Models\Foundation\Summit\Speakers\PresentationSpeakerAssignment::class . ' a ' .
                     'JOIN a.speaker s ' .

--- a/app/Repositories/Summit/DoctrineSummitEventRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitEventRepository.php
@@ -801,9 +801,9 @@ SQL,
                 // Filters match getSelectionStatus()'s constants exactly.
                 try {
                     $selections = $em->createQuery(
-                        'SELECT sp, p FROM ' . SummitSelectedPresentation::class . ' sp ' .
+                        'SELECT sp FROM ' . SummitSelectedPresentation::class . ' sp ' .
+                        'JOIN FETCH sp.presentation p ' .
                         'JOIN sp.list l ' .
-                        'JOIN sp.presentation p ' .
                         'WHERE p.id IN (:ids) ' .
                         'AND sp.collection = :collection ' .
                         'AND l.list_type = :list_type ' .

--- a/app/Repositories/Summit/DoctrineSummitEventRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitEventRepository.php
@@ -815,6 +815,18 @@ SQL,
                     'WHERE a.presentation IN (:ids)'
                 )->setParameter('ids', $presentationIds)->getResult();
 
+                // Stuff each speaker's preloaded assignment-order cache so that
+                // PresentationSpeaker::getPresentationAssignmentOrder() does not
+                // fall back to an EXTRA_LAZY matching() query per (speaker,presentation)
+                // pair. The serializer calls this once per speaker per presentation.
+                foreach ($assignments as $a) {
+                    $speaker = method_exists($a, 'getSpeaker') ? $a->getSpeaker() : null;
+                    $presentation = method_exists($a, 'getPresentation') ? $a->getPresentation() : null;
+                    if ($speaker && $presentation && method_exists($speaker, 'setPreloadedAssignmentOrder')) {
+                        $speaker->setPreloadedAssignmentOrder($presentation->getId(), $a->getOrder());
+                    }
+                }
+
                 // Diagnostic: confirm what was actually loaded.
                 $speakerIds = [];
                 $memberIds  = [];

--- a/app/Repositories/Summit/DoctrineSummitEventRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitEventRepository.php
@@ -785,11 +785,23 @@ SQL,
                         $pid = $sp->getPresentation()->getId();
                         $byPresentation[$pid][] = $sp;
                     }
+                    $fed = 0;
+                    $skipped = 0;
                     foreach ($data as $event) {
                         if ($event instanceof Presentation && method_exists($event, 'setPreloadedSessionSelections')) {
                             $event->setPreloadedSessionSelections($byPresentation[$event->getId()] ?? []);
+                            $fed++;
+                        } else {
+                            $skipped++;
                         }
                     }
+                    Log::warning('selection-status preload diagnostic', [
+                        'presentationIds'  => count($presentationIds),
+                        'selectionsLoaded' => count($selections),
+                        'fed'              => $fed,
+                        'skipped'          => $skipped,
+                        'eventClasses'     => array_map(fn($e) => get_class($e), array_slice($data, 0, 3)),
+                    ]);
                 } catch (\Exception $ex) {
                     Log::warning('DoctrineSummitEventRepository::getAllByPage selection-status preload failed', [
                         'error' => $ex->getMessage(),

--- a/app/Repositories/Summit/DoctrineSummitEventRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitEventRepository.php
@@ -744,6 +744,32 @@ SQL,
             if (isset($byId[$id])) $data[] = $byId[$id];
         }
 
+        // Targeted N+1 preload for Presentation rows on this page:
+        // one DQL query that loads PresentationSpeakerAssignment + PresentationSpeaker + Member.
+        // After this, identity-map lookups by the serializer no longer trigger:
+        //   - per-speaker Member SELECT (was 56 queries on a typical /events page)
+        //   - per-speaker Presentation_Speakers composite-key SELECT (was 19)
+        // Net: ~75 queries collapsed into 1, ~216ms DB time saved per request.
+        // Only runs when there is at least one Presentation in the page.
+        $presentationIds = [];
+        foreach ($data as $event) {
+            if ($event instanceof Presentation) $presentationIds[] = $event->getId();
+        }
+        if (!empty($presentationIds)) {
+            try {
+                $this->getEntityManager()->createQuery(
+                    'SELECT s, m FROM ' . \App\Models\Foundation\Summit\Speakers\PresentationSpeakerAssignment::class . ' a ' .
+                    'JOIN a.speaker s ' .
+                    'LEFT JOIN s.member m ' .
+                    'WHERE a.presentation IN (:ids)'
+                )->setParameter('ids', $presentationIds)->getResult();
+            } catch (\Exception $ex) {
+                Log::warning('DoctrineSummitEventRepository::getAllByPage speaker+member preload failed', [
+                    'error' => $ex->getMessage(),
+                ]);
+            }
+        }
+
         if ($shuffleResults) shuffle($data);
 
         $end = time() - $start;

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -14,7 +14,8 @@ module.exports = {
         "subject-min-length": [RULE_ERROR_LEVEL, "always", SUBJECT_MIN_LENGTH],
         "subject-case": [0], // optional: allow flexibility in subject case
         "header-max-length": [RULE_ERROR_LEVEL, "always", HEADER_MAX_LENGTH],
-        "body-max-line-length":  [RULE_ERROR_LEVEL, "always", BODY_MAX_LENGTH]
+        "body-max-line-length":  [RULE_ERROR_LEVEL, "always", BODY_MAX_LENGTH],
+        "footer-max-line-length":   [RULE_ERROR_LEVEL, "always", BODY_MAX_LENGTH],
     },
     plugins: [
         {

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -84,6 +84,7 @@ return [
              */
             'middlewares' => array_filter([
                 env('DOCTRINE_LOGGING', false) ? Doctrine\DBAL\Logging\Middleware::class : null,
+                \App\Http\Middleware\Doctrine\QueryTimingMiddleware::class,
             ]),
         ],
         'model' => [
@@ -150,6 +151,7 @@ return [
              */
             'middlewares' => array_filter([
                 env('DOCTRINE_LOGGING', false) ? Doctrine\DBAL\Logging\Middleware::class : null,
+                \App\Http\Middleware\Doctrine\QueryTimingMiddleware::class,
             ]),
         ],
         'model_write' => [
@@ -216,6 +218,7 @@ return [
              */
             'middlewares' => array_filter([
                 env('DOCTRINE_LOGGING', false) ? Doctrine\DBAL\Logging\Middleware::class : null,
+                \App\Http\Middleware\Doctrine\QueryTimingMiddleware::class,
             ]),
         ]
     ],

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -1530,7 +1530,7 @@ Route::group(array('prefix' => 'summits'), function () {
         // tickets
         Route::group(['prefix' => 'tickets'], function () {
 
-            Route::get('', ['middleware' => ['auth.user',  'server.timing.doctrine'], 'uses' => 'OAuth2SummitTicketApiController@getAllBySummit']);
+            Route::get('', ['middleware' => ['server.timing.doctrine', 'auth.user'], 'uses' => 'OAuth2SummitTicketApiController@getAllBySummit']);
             Route::get('external', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitTicketApiController@getAllBySummitExternal']);
 
             Route::group(['prefix' => 'csv'], function () {

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -633,7 +633,7 @@ Route::group(array('prefix' => 'summits'), function () {
         // events
         Route::group(array('prefix' => 'events'), function () {
 
-            Route::get('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitEventsApiController@getEvents']);
+            Route::get('', ['middleware' => ['auth.user', 'server.timing.doctrine'], 'uses' => 'OAuth2SummitEventsApiController@getEvents']);
 
             Route::group(['prefix' => 'csv'], function () {
                 Route::get('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitEventsApiController@getEventsCSV']);

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -633,7 +633,7 @@ Route::group(array('prefix' => 'summits'), function () {
         // events
         Route::group(array('prefix' => 'events'), function () {
 
-            Route::get('', ['middleware' => ['auth.user', 'server.timing.doctrine'], 'uses' => 'OAuth2SummitEventsApiController@getEvents']);
+            Route::get('', ['middleware' => ['server.timing.doctrine', 'auth.user'], 'uses' => 'OAuth2SummitEventsApiController@getEvents']);
 
             Route::group(['prefix' => 'csv'], function () {
                 Route::get('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitEventsApiController@getEventsCSV']);

--- a/tests/PresentationSpeakerCacheTest.php
+++ b/tests/PresentationSpeakerCacheTest.php
@@ -140,4 +140,35 @@ final class PresentationSpeakerCacheTest extends TestCase
         $status = $pres->getSelectionStatus();
         $this->assertSame(Presentation::SelectionStatus_Pending, $status);
     }
+
+    // ------------------------------------------------------------------ //
+    // Presentation::updateSpeakerOrder cache invalidation (last_edited)   //
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Reordering speakers only mutates child PresentationSpeakerAssignment rows,
+     * which does not dirty the parent Presentation, so the ORM PreUpdate
+     * last_edited bump never fires. Since PresentationSerializer's cache key now
+     * embeds last_edited, a reorder that does not bump it would serve stale
+     * cached speaker order for the full TTL. updateSpeakerOrder() must bump
+     * last_edited explicitly so the cache key invalidates.
+     */
+    public function testUpdateSpeakerOrderBumpsLastEditedToInvalidateSerializerCache(): void
+    {
+        $presentation = new Presentation();
+        $speaker      = new PresentationSpeaker();
+        $presentation->addSpeaker($speaker);
+
+        // Pin last_edited to a deliberately stale value (the cache key embeds this).
+        $presentation->setLastEdited(new \DateTime('2000-01-01 00:00:00', new \DateTimeZone('UTC')));
+        $staleTs = $presentation->getLastEditedUTC()->getTimestamp();
+
+        $presentation->updateSpeakerOrder($speaker, 1);
+
+        $this->assertGreaterThan(
+            $staleTs,
+            $presentation->getLastEditedUTC()->getTimestamp(),
+            'updateSpeakerOrder must bump last_edited so the presentation serializer cache key invalidates'
+        );
+    }
 }

--- a/tests/PresentationSpeakerCacheTest.php
+++ b/tests/PresentationSpeakerCacheTest.php
@@ -1,0 +1,143 @@
+<?php namespace Tests;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use models\summit\Presentation;
+use models\summit\PresentationSpeaker;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the request-scoped preload caches added in the N+1
+ * elimination pass (hotfix/cache-optimizations).  No database required.
+ */
+final class PresentationSpeakerCacheTest extends TestCase
+{
+    // ------------------------------------------------------------------ //
+    // PresentationSpeaker::setPreloadedAssignmentOrder                    //
+    // ------------------------------------------------------------------ //
+
+    public function testPreloadedAssignmentOrderCacheHit(): void
+    {
+        $speaker = new PresentationSpeaker();
+        $pres    = $this->createMock(Presentation::class);
+        $pres->method('getId')->willReturn(42);
+
+        $speaker->setPreloadedAssignmentOrder(42, 3);
+
+        $this->assertSame(3, $speaker->getPresentationAssignmentOrder($pres));
+    }
+
+    public function testPreloadedAssignmentOrderNullOrderCached(): void
+    {
+        $speaker = new PresentationSpeaker();
+        $pres    = $this->createMock(Presentation::class);
+        $pres->method('getId')->willReturn(10);
+
+        $speaker->setPreloadedAssignmentOrder(10, null);
+
+        $this->assertNull($speaker->getPresentationAssignmentOrder($pres));
+    }
+
+    // ------------------------------------------------------------------ //
+    // PresentationSpeaker::clearPreloadedAssignmentOrder                  //
+    // ------------------------------------------------------------------ //
+
+    public function testClearPreloadedAssignmentOrderLeavesOtherEntriesIntact(): void
+    {
+        $speaker = new PresentationSpeaker();
+        $speaker->setPreloadedAssignmentOrder(1, 5);
+        $speaker->setPreloadedAssignmentOrder(2, 7);
+
+        $speaker->clearPreloadedAssignmentOrder(1);
+
+        $pres2 = $this->createMock(Presentation::class);
+        $pres2->method('getId')->willReturn(2);
+        $this->assertSame(7, $speaker->getPresentationAssignmentOrder($pres2),
+            'Clearing entry 1 must not affect entry 2');
+    }
+
+    public function testClearPreloadedAssignmentOrderAllowsReset(): void
+    {
+        $speaker = new PresentationSpeaker();
+        $speaker->setPreloadedAssignmentOrder(1, 5);
+        $speaker->clearPreloadedAssignmentOrder(1);
+        $speaker->setPreloadedAssignmentOrder(1, 9);
+
+        $pres = $this->createMock(Presentation::class);
+        $pres->method('getId')->willReturn(1);
+        $this->assertSame(9, $speaker->getPresentationAssignmentOrder($pres),
+            'After clear + re-set, new value must be returned');
+    }
+
+    // ------------------------------------------------------------------ //
+    // PresentationSpeaker::clearAllPreloadedAssignmentOrders              //
+    // ------------------------------------------------------------------ //
+
+    public function testClearAllPreloadedAssignmentOrdersAllowsReset(): void
+    {
+        $speaker = new PresentationSpeaker();
+        $speaker->setPreloadedAssignmentOrder(1, 2);
+        $speaker->setPreloadedAssignmentOrder(3, 4);
+
+        $speaker->clearAllPreloadedAssignmentOrders();
+        $speaker->setPreloadedAssignmentOrder(1, 10);
+
+        $pres = $this->createMock(Presentation::class);
+        $pres->method('getId')->willReturn(1);
+        $this->assertSame(10, $speaker->getPresentationAssignmentOrder($pres));
+    }
+
+    // ------------------------------------------------------------------ //
+    // Presentation::setPreloadedSessionSelections / getSelectionStatus    //
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Verifies the preloaded branch is exercised: with an empty preloaded
+     * array the method must return Pending without ever calling createQuery()
+     * (which would throw because there is no EntityManager in this context).
+     */
+    public function testGetSelectionStatusUsesPreloadedBranchWhenSet(): void
+    {
+        $pres = new Presentation();
+        $pres->setPreloadedSessionSelections([]);
+
+        $status = $pres->getSelectionStatus();
+
+        $this->assertSame(Presentation::SelectionStatus_Pending, $status);
+    }
+
+    public function testGetSelectionStatusMemoizesResult(): void
+    {
+        $pres = new Presentation();
+        $pres->setPreloadedSessionSelections([]);
+
+        $first  = $pres->getSelectionStatus();
+        $second = $pres->getSelectionStatus();
+
+        $this->assertSame($first, $second, 'Second call must return the memoized value');
+    }
+
+    public function testSetPreloadedSessionSelectionsResetsMemoization(): void
+    {
+        $pres = new Presentation();
+        $pres->setPreloadedSessionSelections([]);
+        $pres->getSelectionStatus(); // fills memoized cache
+
+        // Resetting preloaded selections must clear the memoized result so the
+        // next getSelectionStatus() re-evaluates instead of returning stale data.
+        $pres->setPreloadedSessionSelections([]);
+        // Must not throw — preloaded path is used again, not the DQL fallback.
+        $status = $pres->getSelectionStatus();
+        $this->assertSame(Presentation::SelectionStatus_Pending, $status);
+    }
+}

--- a/tests/Repositories/EventsEndpointPreloadQueryCountTest.php
+++ b/tests/Repositories/EventsEndpointPreloadQueryCountTest.php
@@ -1,0 +1,171 @@
+<?php namespace Tests\Repositories;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Http\Middleware\Doctrine\QueryTimingCollector;
+use App\Models\Foundation\Main\IGroup;
+use Illuminate\Support\Facades\App;
+use models\main\Member;
+use models\summit\ISummitEventRepository;
+use models\summit\Presentation;
+use models\summit\PresentationSpeaker;
+use Tests\InsertSummitTestData;
+use Tests\ProtectedApiTestCase;
+use utils\FilterParser;
+use utils\PagingInfo;
+
+/**
+ * Integration / query-count regression test for the /events N+1 elimination
+ * (PR #549, hotfix/cache-optimizations).
+ *
+ * Lives under tests/Repositories/ so it runs in the CI "Repositories" matrix job.
+ *
+ * Unlike PresentationSpeakerCacheTest (which proves the preload helpers in
+ * isolation), this test drives the real DoctrineSummitEventRepository::getAllByPage
+ * path — the same path the /events endpoint uses — and asserts that the
+ * per-speaker work the serializer does does NOT scale with the number of
+ * distinct speakers/members on the page.
+ *
+ * IMPORTANT seed note: the base InsertSummitTestData shares ONE speaker across
+ * all presentations, and that speaker's member is the authenticated user (already
+ * in the identity map). That cannot reproduce the member/order N+1, which only
+ * appears with DISTINCT speakers. So this test attaches several distinct speakers
+ * (each with its own member) to distinct presentations, then clears the identity
+ * map so getAllByPage must load everything fresh — exactly like a real request.
+ *
+ * The guarded property: after getAllByPage's preload (LEFT JOIN s.member m +
+ * assignment fetch), the serializer's per-speaker accessors — getMember() field
+ * access and getPresentationAssignmentOrder() — fire ZERO additional queries even
+ * across distinct speakers. Without the preload, each distinct speaker forces a
+ * lazy member-proxy init plus a per-(speaker,presentation) assignment-order query,
+ * so this count would scale with the number of speakers.
+ */
+final class EventsEndpointPreloadQueryCountTest extends ProtectedApiTestCase
+{
+    use InsertSummitTestData;
+
+    private const DISTINCT_SPEAKERS = 5;
+
+    protected function setUp(): void
+    {
+        $this->current_group = IGroup::TrackChairs;
+        parent::setUp();
+        self::insertSummitTestData();
+    }
+
+    public function tearDown(): void
+    {
+        self::clearSummitTestData();
+        parent::tearDown();
+    }
+
+    public function testEventsPagePreloadDoesNotScaleQueriesWithDistinctSpeakers(): void
+    {
+        $em = self::$em;
+
+        // Attach N distinct speakers (each with its own, otherwise-unloaded member)
+        // to N distinct seeded presentations.
+        $targetIds = [];
+        foreach (self::$presentations as $presentation) {
+            if (!($presentation instanceof Presentation)) continue;
+
+            $suffix = str_random(8);
+            $member = new Member();
+            $member->setEmail(sprintf("nplus1+%s@example.test", $suffix));
+            $member->setActive(true);
+            $member->setFirstName("NPlusOne");
+            $member->setLastName($suffix);
+            $member->setEmailVerified(true);
+            $member->setUserExternalId(mt_rand());
+            $em->persist($member);
+
+            $speaker = new PresentationSpeaker();
+            $speaker->setFirstName("NPlusOne");
+            $speaker->setLastName($suffix);
+            $speaker->setBio("bio");
+            $speaker->setMember($member);
+            $em->persist($speaker);
+
+            $presentation->addSpeaker($speaker);
+            $targetIds[] = $presentation->getId();
+
+            if (count($targetIds) >= self::DISTINCT_SPEAKERS) break;
+        }
+        $em->flush();
+        $this->assertCount(self::DISTINCT_SPEAKERS, $targetIds, 'precondition: distinct speakers attached');
+
+        $summitId = self::$summit->getId();
+
+        // Evict everything so getAllByPage loads fresh — otherwise the new members
+        // would already be managed and getMember() would never need a query.
+        $em->clear();
+
+        /** @var ISummitEventRepository $repo */
+        $repo = App::make(ISummitEventRepository::class);
+        $filter = FilterParser::parse(['summit_id==' . $summitId], ['summit_id' => ['==']]);
+
+        $response = $repo->getAllByPage(new PagingInfo(1, 100), $filter);
+
+        $byId = [];
+        foreach ($response->getItems() as $event) {
+            if ($event instanceof Presentation) $byId[$event->getId()] = $event;
+        }
+        $targets = [];
+        foreach ($targetIds as $pid) {
+            $this->assertArrayHasKey($pid, $byId, "target presentation $pid must appear on the page");
+            $targets[$pid] = $byId[$pid];
+        }
+
+        // Warm each presentation's speakers collection (the per-presentation
+        // getSpeakers() matching() cost — not the N+1 under test) and collect the
+        // (presentation, speaker) pairs the serializer iterates.
+        QueryTimingCollector::reset();
+        $pairs = [];
+        foreach ($targets as $presentation) {
+            foreach ($presentation->getSpeakers() as $speaker) {
+                $pairs[] = [$presentation, $speaker];
+            }
+        }
+        $warmQueries = QueryTimingCollector::$count;
+        $this->assertGreaterThanOrEqual(
+            self::DISTINCT_SPEAKERS,
+            count($pairs),
+            'precondition: page must expose the distinct speakers'
+        );
+
+        // Measure ONLY the per-speaker accessors the preload is responsible for.
+        // Members are accessed via a real field (getFirstName) to force any lazy
+        // proxy to initialise — that init is exactly the N+1 the preload removes.
+        QueryTimingCollector::reset();
+        foreach ($pairs as [$presentation, $speaker]) {
+            $member = $speaker->getMember();
+            if ($member !== null) $member->getFirstName(); // force proxy init if lazy
+            $speaker->getPresentationAssignmentOrder($presentation);
+        }
+        $accessorQueries = QueryTimingCollector::$count;
+
+        $this->assertSame(
+            0,
+            $accessorQueries,
+            sprintf(
+                'Across %d (presentation, speaker) pairs with %d distinct speakers, preloaded member + '
+                . 'assignment-order accessors must fire 0 queries; got %d (getSpeakers warm-up: %d). '
+                . 'A count that scales with speakers means the /events N+1 has regressed.',
+                count($pairs),
+                self::DISTINCT_SPEAKERS,
+                $accessorQueries,
+                $warmQueries
+            )
+        );
+    }
+}

--- a/tests/ResourceServerContextTest.php
+++ b/tests/ResourceServerContextTest.php
@@ -37,4 +37,33 @@ class ResourceServerContextTest extends BrowserKitTestCase
 
         $member = $ctx->getCurrentUser(true);
     }
+
+    public function testSetAuthorizationContextResetsUserCache(): void
+    {
+        $ctx = App::make(IResourceServerContext::class);
+
+        $context = [];
+        $context['user_id']             = "1080";
+        $context['external_user_id']    = "1080";
+        $context['user_identifier']     = "test";
+        $context['user_email']          = "test@test.com";
+        $context['user_email_verified'] = true;
+        $context['user_first_name']     = "test";
+        $context['user_last_name']      = "test";
+        $context['user_groups']         = ['raw-users'];
+        $ctx->setAuthorizationContext($context);
+        $ctx->getCurrentUser(false); // warm the request-scoped cache
+
+        $ref  = new \ReflectionClass($ctx);
+        $prop = $ref->getProperty('cachedCurrentUserResolved');
+        $prop->setAccessible(true);
+        $this->assertTrue($prop->getValue($ctx),
+            'Prerequisite: cache must be warm after the first getCurrentUser() call');
+
+        // A second setAuthorizationContext() must invalidate the cache so the
+        // next getCurrentUser() re-fetches instead of returning the stale member.
+        $ctx->setAuthorizationContext($context);
+        $this->assertFalse($prop->getValue($ctx),
+            'setAuthorizationContext() must reset cachedCurrentUserResolved');
+    }
 }

--- a/tests/ResourceServerContextTest.php
+++ b/tests/ResourceServerContextTest.php
@@ -21,8 +21,7 @@ class ResourceServerContextTest extends BrowserKitTestCase
 {
     public function testSync(){
         $ctx = App::make(IResourceServerContext::class);
-        if(!$ctx instanceof IResourceServerContext)
-            throw new \Exception();
+        $this->assertInstanceOf(IResourceServerContext::class, $ctx);
 
         $context = [];
         $context['user_id'] = "1080";
@@ -36,6 +35,20 @@ class ResourceServerContextTest extends BrowserKitTestCase
         $ctx->setAuthorizationContext($context);
 
         $member = $ctx->getCurrentUser(true);
+
+        // A member is resolved/created from the IDP auth-context claims...
+        $this->assertNotNull($member, 'getCurrentUser must resolve a member from the auth context');
+        // ...and the claim fields are synced onto it.
+        $this->assertEquals($context['user_email'], $member->getEmail());
+        $this->assertEquals($context['user_first_name'], $member->getFirstName());
+        $this->assertEquals($context['user_last_name'], $member->getLastName());
+
+        // Request-scoped cache: a second call returns the identical instance.
+        $this->assertSame(
+            $member,
+            $ctx->getCurrentUser(true),
+            'getCurrentUser must return the cached instance within a request'
+        );
     }
 
     public function testSetAuthorizationContextResetsUserCache(): void


### PR DESCRIPTION
ref: https://app.clickup.com/t/86ba466d4
## Summary

Profiling-driven N+1 elimination on `GET /api/v1/summits/{id}/events`.

| | Baseline | Final |
|---|---|---|
| Queries / request | 298 | **47** (-84%) |
| Server time | ~1500ms | **~340ms** (-77%) |
| Speed vs prod | baseline | **~4× faster** |

Full design notes, every fix (symptom / root cause / impact), and what was intentionally NOT fixed: [`adr/002-events-endpoint-n-plus-1-elimination.md`](adr/002-events-endpoint-n-plus-1-elimination.md).

## What changed

**Profiling infrastructure (kept in main):**
- `ServerTimingDoctrine` middleware emits a per-phase `Server-Timing` response header — Chrome DevTools renders it natively in the Network → Timing panel.
- New DBAL Driver Middleware `QueryTimingMiddleware` provides accurate per-request SQL time + query count (Doctrine 3.x deprecated `SQLLogger` no longer works for prepared statements).

**Surgical fixes — each one keyed to a measured pattern:**

| Fix | Saved | File(s) |
|---|---|---|
| `Member::belongsToGroup()` per-instance memoization | 76 q (~85ms) | `Models/Foundation/Main/Member.php` |
| `ResourceServerContext::getCurrentUser()` request-scoped cache | 103 q (~400ms) | `Models/OAuth2/ResourceServerContext.php` |
| Batch `PresentationSpeakerAssignment + Speaker + Member` preload | 75 q (~216ms) | `Repositories/Summit/DoctrineSummitEventRepository.php` |
| `PresentationSpeaker::getPresentationAssignmentOrder()` preloaded cache | 19 q | `Models/Foundation/Summit/Speakers/PresentationSpeaker.php` |
| Batch `SummitSelectedPresentation` preload + memoize `getSelectionStatus()` | 20 q | `Models/Foundation/Summit/Events/Presentations/Presentation.php` |
| Fetch-join `location` + `category` in main hydration | 15 q | `Repositories/Summit/DoctrineSummitEventRepository.php` |
| Batch `Tag` / `Sponsor` / `PresentationMaterial` preloads | 30 q | `Repositories/Summit/DoctrineSummitEventRepository.php` |
| Remove redundant `et2` JOIN from hydration (also fixed silent row-drop bug) | correctness | `Repositories/Summit/DoctrineSummitEventRepository.php` |

## Methodology

1. Built per-phase `Server-Timing` instrumentation + accurate DB timing FIRST (a previous generic-eager-loader attempt without measurements caused regressions; the branch was reverted).
2. Added a temporary SQL pattern logger that bucketed queries by normalized SQL (numeric literals + quoted strings collapsed to `?`). Dumped top patterns to laravel.log when `db_count >= 20`.
3. Targeted one pattern per commit — every change is independently revertable.
4. Removed diagnostic code in the final cleanup commit; kept `Server-Timing` + `QueryTimingMiddleware`.

## Verification

Tested on `api2.dev.fnopen.com` over many runs with the same expand set used by the admin UI:
`expand=speakers,type,created_by,track,sponsors,selection_plan,location,tags,media_uploads,media_uploads.media_upload_type`

Final steady-state Server-Timing:
```
boot;dur=~330, pre;dur=~50, controller;dur=~280, db;dur=~175;desc="47 queries", serializer;dur=~50, total;dur=~340
```

## What was intentionally NOT fixed

- `Presentation::getSpeakers() matching()` — 10 queries. Requires entity method change (`toArray() + PHP usort`); previous attempt caused regressions.
- ~4 remaining Member SELECTs from non-current-user references (e.g. another event's `created_by`).
- Boot phase ~300ms (Laravel framework + service providers + OAuth middleware). Out of scope.
- 3 remaining `SET TRANSACTION` statements (~2ms total). Connection lifecycle, not application code.

## Risks / things to watch

- The fetch-join batch queries produce wider result sets. Not a problem at typical `per_page=10` × handful of tags/sponsors per event, but worth re-profiling if pagination defaults grow.
- Transient cache properties on entities (`$cachedCurrentUser`, `$preloadedSessionSelections`, etc.) are correct only as long as instances are request-scoped. Long-lived workers reusing an EM without `clear()` would need explicit invalidation. None of the current code does this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Events API: page-scoped batched preloads and DB query timing to eliminate N+1s and improve response times.

* **Bug Fixes**
  * Corrected selection-status computation and fixed missing events in listings.

* **User-visible Behavior**
  * "Last edited" timestamps now update on tag/material/speaker changes; responses include richer Server-Timing phase breakdowns and DB query counts.

* **Documentation**
  * Added an ADR documenting the approach.

* **Tests**
  * New tests for preload caching, current-user cache invalidation, and endpoint preload query-count regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->