### PR TITLE
fix(members): stop stale access-token group claim from stripping out-of-band groups

### DIFF
--- a/app/Models/OAuth2/ResourceServerContext.php
+++ b/app/Models/OAuth2/ResourceServerContext.php
@@ -299,7 +299,10 @@ final class ResourceServerContext implements IResourceServerContext
             $groups[] = trim($slug);
             Log::debug(sprintf("ResourceServerContext::checkGroups member %s %s slug %s", $member->getId(), $member->getEmail(), trim($idpGroup['slug'])));
         }
-        return $this->member_service->synchronizeGroups($member, $groups);
+        // additive-only: the token "user_groups" claim is a snapshot taken at token issuance and
+        // can be stale, so it must not prune groups assigned out-of-band after login. Group
+        // removals are handled exclusively by the authoritative live-IDP webhook path.
+        return $this->member_service->synchronizeGroups($member, $groups, false);
     }
 
     /**

--- a/app/Services/Model/IMemberService.php
+++ b/app/Services/Model/IMemberService.php
@@ -76,9 +76,12 @@ interface IMemberService
     /**
      * @param Member $member
      * @param array $groups
+     * @param bool $allow_removals when false, groups absent from $groups are NOT pruned
+     *                             (used by the per-request, possibly-stale, token-claim path);
+     *                             only the authoritative live-IDP path should pass true.
      * @return Member
      */
-    public function synchronizeGroups(Member $member, array $groups):Member;
+    public function synchronizeGroups(Member $member, array $groups, bool $allow_removals = true):Member;
 
     /**
      * @param string $email

--- a/app/Services/Model/Imp/MemberService.php
+++ b/app/Services/Model/Imp/MemberService.php
@@ -503,11 +503,15 @@ final class MemberService
             // suppress a later full (authoritative idp) sync of the same group set.
             $groups_key = $groups;
             sort($groups_key);
+            // fingerprint the (sorted) group set so distinct lists can't collide into the same
+            // key: a raw "_" join is ambiguous (["a_b","c"] and ["a","b_c"] both yield "a_b_c"),
+            // which would wrongly short-circuit a sync for the wrong set for the TTL window.
+            $groups_fingerprint = sha1(json_encode(array_values($groups_key)));
             $cache_key = sprintf(
                 "member_%s_%s_%s_sync_groups",
                 $member->getId(),
                 $allow_removals ? "full" : "add",
-                implode("_", $groups_key)
+                $groups_fingerprint
             );
 
             $val = $this->cache_service->getSingleValue($cache_key);

--- a/app/Services/Model/Imp/MemberService.php
+++ b/app/Services/Model/Imp/MemberService.php
@@ -492,50 +492,71 @@ final class MemberService
      * @return Member
      * @throws \Exception
      */
-    public function synchronizeGroups(Member $member, array $groups): Member
+    public function synchronizeGroups(Member $member, array $groups, bool $allow_removals = true): Member
     {
-        return $this->tx_service->transaction(function () use ($member, $groups) {
+        return $this->tx_service->transaction(function () use ($member, $groups, $allow_removals) {
 
-            $val = $this->cache_service->getSingleValue(sprintf("member_%s_%s_sync_groups", $member->getId(), implode("_", $groups)));
+            // GET and SET must share the same key. The previous code read a per-group key but
+            // wrote one without the group list, so the throttle never hit and the full add/remove
+            // logic ran on every request. The list is sorted so token/idp orderings collapse to a
+            // single entry, and the mode is part of the key so an additive (request) sync can't
+            // suppress a later full (authoritative idp) sync of the same group set.
+            $groups_key = $groups;
+            sort($groups_key);
+            $cache_key = sprintf(
+                "member_%s_%s_%s_sync_groups",
+                $member->getId(),
+                $allow_removals ? "full" : "add",
+                implode("_", $groups_key)
+            );
+
+            $val = $this->cache_service->getSingleValue($cache_key);
 
             if(!empty($val)){
                 Log::debug(sprintf("MemberService::synchronizeGroups member %s email %s synch already done", $member->getId(), $member->getEmail()));
                 return $member;
             }
 
-            $groups2Remove = [];
+            Log::debug(sprintf("MemberService::synchronizeGroups member %s email %s allow_removals %s", $member->getId(), $member->getEmail(), $allow_removals ? "true" : "false"));
 
-            Log::debug(sprintf("MemberService::synchronizeGroups member %s email %s", $member->getId(), $member->getEmail()));
+            // Removals are driven only by the authoritative live IDP profile (the webhook path).
+            // The per-request path passes the access-token group claim, a snapshot taken when the
+            // token was issued that can be stale, so it must never remove groups assigned out-of-band
+            // (e.g. a sponsors-services group added after the token was minted).
+            if ($allow_removals) {
 
-            foreach($member->getGroups() as $group){
-                // if this group was added from idp, clear it, just in case we were deleted from that group
-                if(!in_array($group->getCode(), $groups)){
-                    // do not remove if we are super admins, since we do need this group too ( backward compatibility with SS CMS)
-                    if($group->getCode() == IGroup::Administrators && in_array(IGroup::SuperAdmins, $groups))
-                        continue;
+                $groups2Remove = [];
 
-                    // skipping this groups bc are managed by SS side
-                    if(in_array($group->getCode(), [IGroup::FoundationMembers, IGroup::CommunityMembers, IGroup::TrackChairs, IGroup::Sponsors])){
-                        Log::debug(sprintf("MemberService::synchronizeGroups skipping group %s removal", $group->getCode()));
-                        continue;
-                    }
+                foreach($member->getGroups() as $group){
+                    // if this group was added from idp, clear it, just in case we were deleted from that group
+                    if(!in_array($group->getCode(), $groups)){
+                        // do not remove if we are super admins, since we do need this group too ( backward compatibility with SS CMS)
+                        if($group->getCode() == IGroup::Administrators && in_array(IGroup::SuperAdmins, $groups))
+                            continue;
 
-                    Log::debug(sprintf("MemberService::synchronizeGroups member %s email %s marking group %s to remove (external) dues is not on member current groups", $member->getId(), $member->getEmail(), $group->getCode()));
-                    $groups2Remove[] = $group;
-                }
-            }
+                        // skipping this groups bc are managed by SS side
+                        if(in_array($group->getCode(), [IGroup::FoundationMembers, IGroup::CommunityMembers, IGroup::TrackChairs, IGroup::Sponsors])){
+                            Log::debug(sprintf("MemberService::synchronizeGroups skipping group %s removal", $group->getCode()));
+                            continue;
+                        }
 
-            // remove all groups that arent on our IDP profile anymore ...
-            foreach ($groups2Remove as $externalGroup){
-                if($externalGroup->getCode() === IGroup::SuperAdmins && $member->belongsToGroup(IGroup::Administrators)){
-                    $group = $this->group_repository->getBySlug(IGroup::Administrators);
-                    if(!is_null($group)) {
-                        Log::debug(sprintf("MemberService::synchronizeGroups member %s email %s removing from group %s due is also a super admin", $member->getId(), $member->getEmail(), $group->getCode()));
-                        $member->removeFromGroup($group);
+                        Log::debug(sprintf("MemberService::synchronizeGroups member %s email %s marking group %s to remove (external) dues is not on member current groups", $member->getId(), $member->getEmail(), $group->getCode()));
+                        $groups2Remove[] = $group;
                     }
                 }
-                Log::debug(sprintf("MemberService::synchronizeGroups member %s email %s removing from group %s", $member->getId(), $member->getEmail(), $externalGroup->getCode()));
-                $member->removeFromGroup($externalGroup);
+
+                // remove all groups that arent on our IDP profile anymore ...
+                foreach ($groups2Remove as $externalGroup){
+                    if($externalGroup->getCode() === IGroup::SuperAdmins && $member->belongsToGroup(IGroup::Administrators)){
+                        $group = $this->group_repository->getBySlug(IGroup::Administrators);
+                        if(!is_null($group)) {
+                            Log::debug(sprintf("MemberService::synchronizeGroups member %s email %s removing from group %s due is also a super admin", $member->getId(), $member->getEmail(), $group->getCode()));
+                            $member->removeFromGroup($group);
+                        }
+                    }
+                    Log::debug(sprintf("MemberService::synchronizeGroups member %s email %s removing from group %s", $member->getId(), $member->getEmail(), $externalGroup->getCode()));
+                    $member->removeFromGroup($externalGroup);
+                }
             }
 
             // sync
@@ -584,7 +605,7 @@ final class MemberService
 
             }
 
-            $this->cache_service->setSingleValue(sprintf("member_%s_sync_groups", $member->getId()), 1, self::SYNCH_GROUPS_TTL);
+            $this->cache_service->setSingleValue($cache_key, 1, self::SYNCH_GROUPS_TTL);
             return $member;
         });
     }

--- a/tests/MemberServiceTest.php
+++ b/tests/MemberServiceTest.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\DB;
 use LaravelDoctrine\ORM\Facades\EntityManager;
 use LaravelDoctrine\ORM\Facades\Registry;
 use libs\utils\ITransactionService;
+use models\main\Group;
 use models\main\Member;
 use models\utils\SilverstripeBaseModel;
 
@@ -182,6 +183,89 @@ final class MemberServiceTest extends TestCase
             $former_member->getEmail(),
             "former member's email must be invalidated"
         );
+    }
+
+    /**
+     * Regression: the per-request group sync is driven by the access-token "user_groups"
+     * claim, which is a snapshot taken when the token was issued and can be stale. It must
+     * NOT remove groups assigned out-of-band after the token was minted (e.g. a member added
+     * to "sponsors-services" by the IDP webhook). Only the authoritative live-IDP path
+     * (allow_removals = true) may prune groups.
+     */
+    public function testSynchronizeGroupsAdditiveModePreservesOutOfBandGroups(): void
+    {
+        $prefix    = strtolower(str_random(8));
+        $keep_code = "keep-{$prefix}";
+        $drop_code = "drop-{$prefix}";
+
+        $member = new Member();
+        $member->setEmail(strtolower("sync+{$prefix}@test.com"));
+        $member->setActive(true);
+        $member->setEmailVerified(true);
+        $member->setFirstName("Sync");
+        $member->setLastName("User");
+        $member->setUserExternalId($this->create_external_id);
+
+        $keep_group = new Group();
+        $keep_group->setCode($keep_code);
+        $keep_group->setTitle($keep_code);
+        $keep_group->setDescription($keep_code);
+        $keep_group->setExternal();
+
+        // group assigned out-of-band (not present in the stale token claim, not in the skip-list)
+        $drop_group = new Group();
+        $drop_group->setCode($drop_code);
+        $drop_group->setTitle($drop_code);
+        $drop_group->setDescription($drop_code);
+        $drop_group->setExternal();
+
+        $this->em->persist($keep_group);
+        $this->em->persist($drop_group);
+        $member->add2Group($keep_group);
+        $member->add2Group($drop_group);
+        $this->em->persist($member);
+        $this->em->flush();
+
+        $member_id = $member->getId();
+        $service   = App::make(IMemberService::class);
+
+        // request/token path: stale claim lists only $keep_code, removals disabled
+        $service->synchronizeGroups($member, [$keep_code], false);
+        $this->em->clear();
+
+        $member = $this->member_repository->find($member_id);
+        $this->assertTrue($member->belongsToGroup($keep_code), "kept group must remain");
+        $this->assertTrue(
+            $member->belongsToGroup($drop_code),
+            "additive (request) sync must not remove out-of-band group {$drop_code}"
+        );
+
+        // authoritative live-IDP path: same claim, removals enabled -> prunes $drop_code
+        $service->synchronizeGroups($member, [$keep_code]);
+        $this->em->clear();
+
+        $member = $this->member_repository->find($member_id);
+        $this->assertTrue($member->belongsToGroup($keep_code), "kept group must remain after full sync");
+        $this->assertFalse(
+            $member->belongsToGroup($drop_code),
+            "authoritative full sync must still prune {$drop_code}"
+        );
+
+        // best-effort cleanup of the test groups (the member is removed in tearDown)
+        try {
+            $member = $this->member_repository->find($member_id);
+            if (!is_null($member)) {
+                $member->setGroups(new \Doctrine\Common\Collections\ArrayCollection());
+                $this->em->flush();
+            }
+            foreach ([$keep_code, $drop_code] as $code) {
+                $g = $this->em->getRepository(Group::class)->findOneBy(['code' => $code]);
+                if (!is_null($g)) $this->em->remove($g);
+            }
+            $this->em->flush();
+        } catch (\Exception $ex) {
+            // best-effort
+        }
     }
 
     private function buildExternalProfilePayload(int $external_id, string $email): array


### PR DESCRIPTION
ref: https://app.clickup.com/t/86ba66hh9

getCurrentUser() ran synchronizeGroups() on every request using the access-token user_groups claim, a snapshot taken at token issuance. That path removed any group not present in the (stale) claim and not in a hardcoded skip-list, so a group added out-of-band after login (e.g. sponsors-services added via the PublishUserUpdated webhook) was re-stripped by the next /members/me request reusing the old token.

- synchronizeGroups() gains $allow_removals (default true); the per-request path (ResourceServerContext::checkGroups) now passes false, making it additive-only. Removals remain on the authoritative live-IDP webhook path only.
- Fix the throttle cache: GET read a per-group key while SET wrote a key without the group list, so it never hit and the add/remove logic ran on every request. Keys are now unified (sorted, mode-tagged).
- Add MemberServiceTest regression coverage for both additive and full-sync modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Group synchronization now supports an additive-only mode for token-based flows to avoid pruning groups added out-of-band; authoritative live-IDP updates continue to perform full sync/removals.

* **Tests**
  * Added a regression test ensuring additive synchronization preserves out-of-band groups and authoritative sync can remove them.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenStackweb/summit-api/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->