### PR TITLE
feat(events): add PUT /events/{id}/draft endpoint to save incomplete submissions

### DIFF
--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitEventsApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitEventsApiController.php
@@ -1085,9 +1085,48 @@ final class OAuth2SummitEventsApiController extends OAuth2ProtectedController
      */
     public function updateEvent($summit_id, $event_id)
     {
-        return $this->processRequest(function() use($summit_id, $event_id){
+        return $this->_updateEvent($summit_id, $event_id);
+    }
 
-            Log::debug(sprintf("OAuth2SummitEventsApiController::updateEvent summit id %s event id %s", $summit_id, $event_id));
+     #[OA\Put(
+        path: '/api/v1/summits/{id}/events/{event_id}/draft',
+        operationId: 'updateDraftEvent',
+        summary: 'Update an existing draft event',
+        description: 'Updates an existing draft event for a specific summit.',
+        security: [['summit_events_api_oauth2' => [SummitScopes::WriteSummitData, SummitScopes::WriteEventData]]],
+        x: ['required-groups' => [IGroup::SuperAdmins, IGroup::Administrators, IGroup::SummitAdministrators, IGroup::SummitRegistrationAdmins, IGroup::TrackChairs, IGroup::TrackChairsAdmins]],
+        tags: ['Summit Events'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, description: 'Summit ID or slug', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'event_id', in: 'path', required: true, description: 'Event ID', schema: new OA\Schema(type: 'integer')),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/UpdateSummitEventRequest')
+        ),
+        responses: [
+            new OA\Response(response: Response::HTTP_OK, description: 'Draft event updated successfully', content: new OA\JsonContent(ref: '#/components/schemas/SummitEvent')),
+            new OA\Response(response: Response::HTTP_BAD_REQUEST, description: 'Bad Request'),
+            new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: 'Unauthorized'),
+            new OA\Response(response: Response::HTTP_FORBIDDEN, description: 'Forbidden'),
+            new OA\Response(response: Response::HTTP_NOT_FOUND, description: 'Not Found'),
+            new OA\Response(response: Response::HTTP_PRECONDITION_FAILED, description: 'Validation error'),
+            new OA\Response(response: Response::HTTP_INTERNAL_SERVER_ERROR, description: 'Server Error'),
+        ]
+    )]
+    /**
+     * @param $summit_id
+     * @param $event_id
+     * @return mixed
+     */
+    public function updateDraftEvent($summit_id, $event_id)
+    {
+        return $this->_updateEvent($summit_id, $event_id, true);
+    }
+
+    private function _updateEvent($summit_id, $event_id, bool $saveAsIncomplete = false)
+    {
+        return $this->processRequest(function() use($summit_id, $event_id, $saveAsIncomplete) {
 
             $summit = SummitFinderStrategyFactory::build($this->repository, $this->resource_server_context)->find($summit_id);
             if (is_null($summit))
@@ -1106,42 +1145,30 @@ final class OAuth2SummitEventsApiController extends OAuth2ProtectedController
 
             $payload = $this->getJsonData();
 
-            // Creates a Validator instance and validates the data.
             $rules = $isAdmin ? SummitEventValidationRulesFactory::build($payload, true) : null;
-            if(is_null($rules)){
+            if (is_null($rules)) {
                 $rules = $isTrackChair ? SummitEventValidationRulesFactory::buildForTrackChair($payload, true) : null;
             }
 
-            if(is_null($rules))
+            if (is_null($rules))
                 return $this->error403();
-
 
             $payload = $this->getJsonPayload($rules, true);
 
-            $fields = [
-                'title',
-                'description',
-                'social_summary',
-            ];
+            $fields = ['title', 'description', 'social_summary'];
 
-            if($isAdmin) {
-                Log::debug(sprintf("OAuth2SummitEventsApiController::updateEvent summit id %s event id %s updating event", $summit_id, $event_id));
-                $event = $this->service->updateEvent($summit, $event_id, HTMLCleaner::cleanData($payload, $fields));
-            }
-            else{
-                Log::debug(sprintf("OAuth2SummitEventsApiController::updateEvent summit id %s event id %s updating duration", $summit_id, $event_id));
+            if ($isAdmin) {
+                $event = $this->service->updateEvent($summit, $event_id, HTMLCleaner::cleanData($payload, $fields), true, $saveAsIncomplete);
+            } else {
                 $event = $this->service->updateDuration($payload, $summit, $event);
             }
 
             return $this->ok(SerializerRegistry::getInstance()->getSerializer($event, $this->getSerializerType())
-                ->serialize
-                (
+                ->serialize(
                     SerializerUtils::getExpand(),
                     SerializerUtils::getFields(),
                     SerializerUtils::getRelations(),
-                    [
-                        'current_user' => $current_member
-                    ]
+                    ['current_user' => $current_member]
                 )
             );
         });

--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitEventsApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitEventsApiController.php
@@ -1094,7 +1094,7 @@ final class OAuth2SummitEventsApiController extends OAuth2ProtectedController
         summary: 'Update an existing draft event',
         description: 'Updates an existing draft event for a specific summit.',
         security: [['summit_events_api_oauth2' => [SummitScopes::WriteSummitData, SummitScopes::WriteEventData]]],
-        x: ['required-groups' => [IGroup::SuperAdmins, IGroup::Administrators, IGroup::SummitAdministrators, IGroup::SummitRegistrationAdmins, IGroup::TrackChairs, IGroup::TrackChairsAdmins]],
+        x: ['required-groups' => [IGroup::SuperAdmins, IGroup::Administrators, IGroup::SummitAdministrators, IGroup::TrackChairsAdmins]],
         tags: ['Summit Events'],
         parameters: [
             new OA\Parameter(name: 'id', in: 'path', required: true, description: 'Summit ID or slug', schema: new OA\Schema(type: 'string')),

--- a/app/Services/Model/ISummitService.php
+++ b/app/Services/Model/ISummitService.php
@@ -53,9 +53,10 @@ interface ISummitService
      * @param int $event_id
      * @param array $data
      * @param bool $trigger_data_update
+     * @param bool $saveAsIncomplete
      * @return SummitEvent
      */
-    public function updateEvent(Summit $summit, $event_id, array $data, bool $trigger_data_update = true);
+    public function updateEvent(Summit $summit, $event_id, array $data, bool $trigger_data_update = true, bool $saveAsIncomplete = false);
 
     /**
      * @param Summit $summit

--- a/app/Services/Model/Imp/SummitService.php
+++ b/app/Services/Model/Imp/SummitService.php
@@ -889,6 +889,9 @@ final class SummitService
     {
         if (!$event instanceof Presentation) return;
 
+        if ($saveAsIncomplete && $event->isPublished())
+            throw new ValidationException('Cannot save a published event as incomplete.');
+
         if (!$saveAsIncomplete || $event->isNew()) {
             // if we are creating the presentation from admin, then
             // we should mark it as received and complete
@@ -903,13 +906,15 @@ final class SummitService
             $shouldClearSpeakers = isset($data['speakers']) && count($data['speakers']) == 0;
             $speakers = $data['speakers'] ?? [];
 
-            if ((!$saveAsIncomplete || $event->isNew()) && $event_type->isAreSpeakersMandatory()) {
-                if ($shouldClearSpeakers || ($event->isNew() && count($speakers) == 0))
-                    throw new ValidationException('Speakers are mandatory.');
-            }
+            if (!$saveAsIncomplete || $event->isNew()) {
+                if ($event_type->isAreSpeakersMandatory()) {
+                    if ($shouldClearSpeakers || ($event->isNew() && count($speakers) == 0))
+                        throw new ValidationException('Speakers are mandatory.');
+                }
 
-            if ($shouldClearSpeakers) {
-                $event->clearSpeakers();
+                if ($shouldClearSpeakers) {
+                    $event->clearSpeakers();
+                }
             }
 
             if (count($speakers) > 0) {
@@ -929,12 +934,14 @@ final class SummitService
             $shouldClearModerator = isset($data['moderator_speaker_id']) && intval($data['moderator_speaker_id']) == 0;
             $moderator_id = isset($data['moderator_speaker_id']) ? intval($data['moderator_speaker_id']) : 0;
 
-            if ((!$saveAsIncomplete || $event->isNew()) && $event_type->isModeratorMandatory()) {
-                if ($shouldClearModerator || ($event->isNew() && $moderator_id == 0))
-                    throw new ValidationException('moderator_speaker_id is mandatory.');
-            }
+            if (!$saveAsIncomplete || $event->isNew()) {
+                if ($event_type->isModeratorMandatory()) {
+                    if ($shouldClearModerator || ($event->isNew() && $moderator_id == 0))
+                        throw new ValidationException('moderator_speaker_id is mandatory.');
+                }
 
-            if ($shouldClearModerator) $event->unsetModerator();
+                if ($shouldClearModerator) $event->unsetModerator();
+            }
 
             if ($moderator_id > 0) {
                 $moderator = $this->speaker_repository->getById($moderator_id);

--- a/app/Services/Model/Imp/SummitService.php
+++ b/app/Services/Model/Imp/SummitService.php
@@ -617,9 +617,9 @@ final class SummitService
      * @param array $data
      * @return SummitEvent
      */
-    public function updateEvent(Summit $summit, $event_id, array $data, bool $trigger_data_update = true)
+    public function updateEvent(Summit $summit, $event_id, array $data, bool $trigger_data_update = true, bool $saveAsIncomplete = false)
     {
-        return $this->saveOrUpdateEvent($summit, $data, $event_id, $trigger_data_update);
+        return $this->saveOrUpdateEvent($summit, $data, $event_id, $trigger_data_update, $saveAsIncomplete);
     }
 
     /**
@@ -660,9 +660,9 @@ final class SummitService
      * @return SummitEvent
      * @throws Exception
      */
-    private function saveOrUpdateEvent(Summit $summit, array $data, $event_id = null, bool $trigger_data_update = true)
+    private function saveOrUpdateEvent(Summit $summit, array $data, $event_id = null, bool $trigger_data_update = true, bool $saveAsIncomplete = false)
     {
-        return $this->tx_service->transaction(function () use ($summit, $data, $event_id, $trigger_data_update) {
+        return $this->tx_service->transaction(function () use ($summit, $data, $event_id, $trigger_data_update, $saveAsIncomplete) {
 
             Log::debug
             (
@@ -832,7 +832,7 @@ final class SummitService
                 }
             }
 
-            $this->saveOrUpdatePresentationData($event, $event_type, $data);
+            $this->saveOrUpdatePresentationData($event, $event_type, $data, $saveAsIncomplete);
             $this->saveOrUpdateSummitGroupEventData($event, $event_type, $data);
 
             if (!$event_type->isAllowsLocation())
@@ -881,17 +881,20 @@ final class SummitService
      * @param SummitEvent $event
      * @param SummitEventType $event_type
      * @param array $data
+     * @param bool $saveAsIncomplete
      * @throws EntityNotFoundException
      * @throws ValidationException
      */
-    private function saveOrUpdatePresentationData(SummitEvent $event, SummitEventType $event_type, array $data)
+    private function saveOrUpdatePresentationData(SummitEvent $event, SummitEventType $event_type, array $data, bool $saveAsIncomplete = false)
     {
         if (!$event instanceof Presentation) return;
 
-        // if we are creating the presentation from admin, then
-        // we should mark it as received and complete
-        $event->setStatus(Presentation::STATUS_RECEIVED);
-        $event->setProgress(Presentation::PHASE_COMPLETE);
+        if (!$saveAsIncomplete || $event->isNew()) {
+            // if we are creating the presentation from admin, then
+            // we should mark it as received and complete
+            $event->setStatus(Presentation::STATUS_RECEIVED);
+            $event->setProgress(Presentation::PHASE_COMPLETE);
+        }
 
         // speakers
 
@@ -900,7 +903,7 @@ final class SummitService
             $shouldClearSpeakers = isset($data['speakers']) && count($data['speakers']) == 0;
             $speakers = $data['speakers'] ?? [];
 
-            if ($event_type->isAreSpeakersMandatory()) {
+            if ((!$saveAsIncomplete || $event->isNew()) && $event_type->isAreSpeakersMandatory()) {
                 if ($shouldClearSpeakers || ($event->isNew() && count($speakers) == 0))
                     throw new ValidationException('Speakers are mandatory.');
             }
@@ -926,7 +929,7 @@ final class SummitService
             $shouldClearModerator = isset($data['moderator_speaker_id']) && intval($data['moderator_speaker_id']) == 0;
             $moderator_id = isset($data['moderator_speaker_id']) ? intval($data['moderator_speaker_id']) : 0;
 
-            if ($event_type->isModeratorMandatory()) {
+            if ((!$saveAsIncomplete || $event->isNew()) && $event_type->isModeratorMandatory()) {
                 if ($shouldClearModerator || ($event->isNew() && $moderator_id == 0))
                     throw new ValidationException('moderator_speaker_id is mandatory.');
             }

--- a/database/migrations/config/Version20260609175051.php
+++ b/database/migrations/config/Version20260609175051.php
@@ -34,8 +34,6 @@ final class Version20260609175051 extends AbstractMigration
         IGroup::SuperAdmins,
         IGroup::Administrators,
         IGroup::SummitAdministrators,
-        IGroup::SummitRegistrationAdmins,
-        IGroup::TrackChairs,
         IGroup::TrackChairsAdmins,
     ];
 

--- a/database/migrations/config/Version20260609175051.php
+++ b/database/migrations/config/Version20260609175051.php
@@ -1,0 +1,83 @@
+<?php namespace Database\Migrations\Config;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Models\Foundation\Main\IGroup;
+use App\Security\SummitScopes;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Seed the update-draft-event endpoint.
+ *
+ * Idempotent via WHERE NOT EXISTS in APIEndpointsMigrationHelper.
+ */
+final class Version20260609175051 extends AbstractMigration
+{
+    use APIEndpointsMigrationHelper;
+
+    private const API_NAME = 'summits';
+    private const ENDPOINT_NAME = 'update-draft-event';
+    private const ENDPOINT_ROUTE = '/api/v1/summits/{id}/events/{event_id}/draft';
+
+    private const AUTH_GROUPS = [
+        IGroup::SuperAdmins,
+        IGroup::Administrators,
+        IGroup::SummitAdministrators,
+        IGroup::SummitRegistrationAdmins,
+        IGroup::TrackChairs,
+        IGroup::TrackChairsAdmins,
+    ];
+
+    private const SCOPES = [
+        SummitScopes::WriteSummitData,
+        SummitScopes::WriteEventData
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Seed update-draft-event endpoint with scope and authz groups';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql($this->insertEndpoint(
+            self::API_NAME,
+            self::ENDPOINT_NAME,
+            self::ENDPOINT_ROUTE,
+            'PUT'
+        ));
+
+        foreach (self::SCOPES as $scope) {
+            $this->addSql($this->insertEndpointScope(
+                self::API_NAME,
+            self::ENDPOINT_NAME,
+                $scope
+            ));
+        }
+
+        foreach (self::AUTH_GROUPS as $groupSlug) {
+            $this->addSql($this->insertEndpointAuthzGroup(self::API_NAME, self::ENDPOINT_NAME, $groupSlug));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::AUTH_GROUPS as $groupSlug) {
+            $this->addSql($this->deleteEndpointAuthzGroup(self::API_NAME, self::ENDPOINT_NAME, $groupSlug));
+        }
+
+        $this->addSql($this->deleteScopesEndpoints(self::API_NAME, self::SCOPES));
+        $this->addSql($this->deleteEndpoint(self::API_NAME, self::ENDPOINT_NAME));
+    }
+}

--- a/database/seeders/ApiEndpointsSeeder.php
+++ b/database/seeders/ApiEndpointsSeeder.php
@@ -4268,6 +4268,23 @@ class ApiEndpointsSeeder extends Seeder
                 ]
             ],
             [
+                'name' => 'update-draft-event',
+                'route' => '/api/v1/summits/{id}/events/{event_id}/draft',
+                'http_method' => 'PUT',
+                'scopes' => [
+                    SummitScopes::WriteSummitData,
+                    SummitScopes::WriteEventData
+                ],
+                'authz_groups' => [
+                    IGroup::SuperAdmins,
+                    IGroup::Administrators,
+                    IGroup::SummitAdministrators,
+                    IGroup::SummitRegistrationAdmins,
+                    IGroup::TrackChairs,
+                    IGroup::TrackChairsAdmins,
+                ]
+            ],
+            [
                 'name' => 'update-event-live-info',
                 'route' => '/api/v1/summits/{id}/events/{event_id}/live-info',
                 'http_method' => 'PUT',

--- a/database/seeders/ApiEndpointsSeeder.php
+++ b/database/seeders/ApiEndpointsSeeder.php
@@ -4279,8 +4279,6 @@ class ApiEndpointsSeeder extends Seeder
                     IGroup::SuperAdmins,
                     IGroup::Administrators,
                     IGroup::SummitAdministrators,
-                    IGroup::SummitRegistrationAdmins,
-                    IGroup::TrackChairs,
                     IGroup::TrackChairsAdmins,
                 ]
             ],

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -692,6 +692,7 @@ Route::group(array('prefix' => 'summits'), function () {
                 });
 
                 Route::put('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitEventsApiController@updateEvent']);
+                Route::put('/draft', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitEventsApiController@updateDraftEvent']);
                 Route::put('live-info', ['uses' => 'OAuth2SummitEventsApiController@updateEventLiveInfo']);
                 Route::delete('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitEventsApiController@deleteEvent']);
                 Route::put('/publish', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitEventsApiController@publishEvent']);

--- a/tests/InsertOrdersTestData.php
+++ b/tests/InsertOrdersTestData.php
@@ -139,4 +139,14 @@ trait InsertOrdersTestData
         self::$em->persist(self::$summit);
         self::$em->flush();
     }
+
+    protected static function clearOrdersTestData(): void
+    {
+        if (!is_null(self::$default_ticket_type) && !is_null(self::$default_ticket_type->getId())) {
+            DB::table('SummitTicketType')
+                ->where('ID', self::$default_ticket_type->getId())
+                ->update(['QuantitySold' => 0]);
+            self::$em->clear();
+        }
+    }
 }

--- a/tests/oauth2/OAuth2SummitEventsApiTest.php
+++ b/tests/oauth2/OAuth2SummitEventsApiTest.php
@@ -516,8 +516,29 @@ final class OAuth2SummitEventsApiTest extends ProtectedApiTestCase
         $content = $response->getContent();
         $event = json_decode($content);
         $this->assertEquals('Updated Draft Title', $event->title);
-        $this->assertNotEquals('COMPLETE', $event->progress);
+        $this->assertNotEquals(Presentation::PHASE_COMPLETE, $event->progress);
         $this->assertNotEquals(Presentation::STATUS_RECEIVED, $event->status);
+    }
+
+    public function testUpdateDraftEventOnPublishedPresentationReturns412()
+    {
+        $presentation = self::$presentations[0];
+
+        $response = $this->action(
+            "PUT",
+            "OAuth2SummitEventsApiController@updateDraftEvent",
+            [
+                'id'       => self::$summit->getId(),
+                'event_id' => $presentation->getId(),
+            ],
+            [],
+            [],
+            [],
+            $this->getAuthHeaders(),
+            json_encode(['title' => 'Should Not Update'])
+        );
+
+        $this->assertResponseStatus(412);
     }
 
     public function testPublishEvent($start_date = 1509789600, $end_date = 1509791400)

--- a/tests/oauth2/OAuth2SummitEventsApiTest.php
+++ b/tests/oauth2/OAuth2SummitEventsApiTest.php
@@ -12,10 +12,12 @@
  * limitations under the License.
  **/
 use App\Models\Foundation\Main\IGroup;
+use App\Services\Model\ISummitService;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\App;
 use models\utils\SilverstripeBaseModel;
 use services\model\IPresentationService;
+use models\summit\Presentation;
 use models\summit\SummitEvent;
 
 final class OAuth2SummitEventsApiTest extends ProtectedApiTestCase
@@ -37,6 +39,7 @@ final class OAuth2SummitEventsApiTest extends ProtectedApiTestCase
 
     public function tearDown():void
     {
+        self::clearOrdersTestData();
         self::clearSummitTestData();
         parent::tearDown();
     }
@@ -475,6 +478,46 @@ final class OAuth2SummitEventsApiTest extends ProtectedApiTestCase
         $this->assertTrue(count($event->allowed_ticket_types) == 2);
         return $event;
 
+    }
+
+    public function testUpdateDraftEventDoesNotCompleteIncompletePresentation()
+    {
+        $presentation = new Presentation();
+        self::$summit->addEvent($presentation);
+        $presentation->setTitle("Incomplete Draft Presentation");
+        $presentation->setAbstract("Draft abstract");
+        $presentation->setCategory(self::$defaultTrack);
+        $presentation->setType(self::$defaultPresentationType);
+        $presentation->setProgress(Presentation::PHASE_SUMMARY);
+        self::$em->persist($presentation);
+        self::$em->flush();
+
+        $params = [
+            'id'       => self::$summit->getId(),
+            'event_id' => $presentation->getId(),
+        ];
+
+        $data = [
+            'title' => 'Updated Draft Title',
+        ];
+
+        $response = $this->action(
+            "PUT",
+            "OAuth2SummitEventsApiController@updateDraftEvent",
+            $params,
+            [],
+            [],
+            [],
+            $this->getAuthHeaders(),
+            json_encode($data)
+        );
+
+        $this->assertResponseStatus(200);
+        $content = $response->getContent();
+        $event = json_decode($content);
+        $this->assertEquals('Updated Draft Title', $event->title);
+        $this->assertNotEquals('COMPLETE', $event->progress);
+        $this->assertNotEquals(Presentation::STATUS_RECEIVED, $event->status);
     }
 
     public function testPublishEvent($start_date = 1509789600, $end_date = 1509791400)


### PR DESCRIPTION
ref https://app.clickup.com/t/86ba3xg57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `PUT /api/v1/summits/{id}/events/{event_id}/draft` endpoint to update event drafts for summits.

* **Behavior Changes**
  * Draft updates now use role-based validation/authorization and return `403` for unsupported roles.
  * When saving as draft, presentations can remain incomplete without switching to completed/received states; attempts to draft-persist already-published presentations return `412`.

* **Tests & Data**
  * Added controller tests for draft/incomplete and published-presentation cases.
  * Extended endpoint registration via migration/seeder; updated test data setup/cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->