### PR TITLE
feat: add-on types crud

### DIFF
--- a/app/Http/Controllers/Apis/Protected/Summit/Factories/SummitSponsorshipAddOnTypeValidationRulesFactory.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/Factories/SummitSponsorshipAddOnTypeValidationRulesFactory.php
@@ -30,7 +30,7 @@ final class SummitSponsorshipAddOnTypeValidationRulesFactory extends AbstractVal
     public static function buildForUpdate(array $payload = []): array
     {
         return [
-            'name' => 'sometimes|string|max:255',
+            'name' => 'sometimes|required|string|max:255',
         ];
     }
 }

--- a/app/Http/Controllers/Apis/Protected/Summit/Factories/SummitSponsorshipAddOnTypeValidationRulesFactory.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/Factories/SummitSponsorshipAddOnTypeValidationRulesFactory.php
@@ -1,6 +1,6 @@
 <?php namespace App\Http\Controllers;
-/**
- * Copyright 2025 OpenStack Foundation
+/*
+ * Copyright 2026 OpenStack Foundation
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,37 +11,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+
 use App\Http\ValidationRulesFactories\AbstractValidationRulesFactory;
-use models\exceptions\ValidationException;
 
 /**
- * Class SummitSponsorshipAddOnsValidationRulesFactory
+ * Class SummitSponsorshipAddOnTypeValidationRulesFactory
  * @package App\Http\Controllers
  */
-final class SummitSponsorshipAddOnsValidationRulesFactory extends AbstractValidationRulesFactory
+final class SummitSponsorshipAddOnTypeValidationRulesFactory extends AbstractValidationRulesFactory
 {
-
     public static function buildForAdd(array $payload = []): array
     {
-        if (isset($payload['type_id']) && isset($payload['type']))
-            throw new ValidationException("type_id and type are mutually exclusive.");
-
         return [
-            'name'    => 'required|string|max:255',
-            'type_id' => 'required_without:type|integer',
-            'type'    => 'required_without:type_id|string|max:255',
+            'name' => 'required|string|max:255',
         ];
     }
 
     public static function buildForUpdate(array $payload = []): array
     {
-        if (isset($payload['type_id']) && isset($payload['type']))
-            throw new ValidationException("type_id and type are mutually exclusive.");
-
         return [
-            'name'    => 'sometimes|string|max:255',
-            'type_id' => 'sometimes|integer',
-            'type'    => 'sometimes|string|max:255',
+            'name' => 'sometimes|string|max:255',
         ];
     }
 }

--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitSponsorshipAddOnTypesApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitSponsorshipAddOnTypesApiController.php
@@ -120,7 +120,11 @@ final class OAuth2SummitSponsorshipAddOnTypesApiController extends OAuth2Protect
             new OA\Parameter(name: "order", description: "Order by (+id, -name)", in: "query", required: false, schema: new OA\Schema(type: "string")),
         ],
         responses: [
-            new OA\Response(response: Response::HTTP_OK, description: "OK"),
+            new OA\Response(
+                response: Response::HTTP_OK,
+                description: "OK",
+                content: new OA\JsonContent(ref: '#/components/schemas/PaginatedSummitSponsorshipAddOnTypeResponse')
+            ),
             new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
             new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
             new OA\Response(response: Response::HTTP_INTERNAL_SERVER_ERROR, description: "Server Error"),
@@ -152,7 +156,11 @@ final class OAuth2SummitSponsorshipAddOnTypesApiController extends OAuth2Protect
             )
         ),
         responses: [
-            new OA\Response(response: Response::HTTP_CREATED, description: "Created"),
+            new OA\Response(
+                response: Response::HTTP_CREATED,
+                description: "Created",
+                content: new OA\JsonContent(ref: '#/components/schemas/SummitSponsorshipAddOnType')
+            ),
             new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
             new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
             new OA\Response(response: Response::HTTP_PRECONDITION_FAILED, description: "Validation Error"),
@@ -190,7 +198,11 @@ final class OAuth2SummitSponsorshipAddOnTypesApiController extends OAuth2Protect
             new OA\Parameter(name: "id", description: "Add-on Type ID", in: "path", required: true, schema: new OA\Schema(type: "integer")),
         ],
         responses: [
-            new OA\Response(response: Response::HTTP_OK, description: "OK"),
+            new OA\Response(
+                response: Response::HTTP_OK,
+                description: "OK",
+                content: new OA\JsonContent(ref: '#/components/schemas/SummitSponsorshipAddOnType')
+            ),
             new OA\Response(response: Response::HTTP_NOT_FOUND, description: "Not Found"),
             new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
             new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
@@ -239,7 +251,11 @@ final class OAuth2SummitSponsorshipAddOnTypesApiController extends OAuth2Protect
             )
         ),
         responses: [
-            new OA\Response(response: Response::HTTP_OK, description: "OK"),
+            new OA\Response(
+                response: Response::HTTP_OK,
+                description: "OK",
+                content: new OA\JsonContent(ref: '#/components/schemas/SummitSponsorshipAddOnType')
+            ),
             new OA\Response(response: Response::HTTP_NOT_FOUND, description: "Not Found"),
             new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
             new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),

--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitSponsorshipAddOnTypesApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitSponsorshipAddOnTypesApiController.php
@@ -1,0 +1,301 @@
+<?php namespace App\Http\Controllers;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Models\Foundation\Main\IGroup;
+use App\Models\Foundation\Summit\Repositories\ISummitSponsorshipAddOnTypeRepository;
+use App\ModelSerializers\SerializerUtils;
+use App\Security\SummitScopes;
+use App\Services\Model\ISummitSponsorshipAddOnTypeService;
+use models\oauth2\IResourceServerContext;
+use models\summit\ISummitRepository;
+use ModelSerializers\SerializerRegistry;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class OAuth2SummitSponsorshipAddOnTypesApiController
+ * @package App\Http\Controllers
+ */
+final class OAuth2SummitSponsorshipAddOnTypesApiController extends OAuth2ProtectedController
+{
+    use RequestProcessor;
+    use GetAll;
+    use GetAndValidateJsonPayload;
+
+    /**
+     * @var ISummitSponsorshipAddOnTypeService
+     */
+    private $service;
+
+    /**
+     * @param ISummitSponsorshipAddOnTypeRepository $repository
+     * @param ISummitRepository $summit_repository
+     * @param ISummitSponsorshipAddOnTypeService $service
+     * @param IResourceServerContext $resource_server_context
+     */
+    public function __construct(
+        ISummitSponsorshipAddOnTypeRepository $repository,
+        ISummitRepository                     $summit_repository,
+        ISummitSponsorshipAddOnTypeService    $service,
+        IResourceServerContext                $resource_server_context
+    )
+    {
+        parent::__construct($resource_server_context);
+        $this->repository = $repository;
+        $this->summit_repository = $summit_repository;
+        $this->service = $service;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getFilterRules(): array
+    {
+        return [
+            'name' => ['==', '=@'],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getFilterValidatorRules(): array
+    {
+        return [
+            'name' => 'sometimes|required|string',
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getOrderRules(): array
+    {
+        return [
+            'id',
+            'name',
+        ];
+    }
+
+
+    /**
+     * @return ISummitRepository
+     */
+    protected function getSummitRepository(): ISummitRepository
+    {
+        return $this->summit_repository;
+    }
+
+    #[OA\Get(
+        path: "/api/v1/summits/all/add-on-types",
+        summary: "Get all sponsorship add-on types",
+        operationId: 'getAddOnTypes',
+        x: [
+            'required-groups' => [
+                IGroup::SuperAdmins,
+                IGroup::Administrators,
+                IGroup::SummitAdministrators,
+            ]
+        ],
+        security: [['summit_sponsorship_oauth2' => [
+            SummitScopes::ReadSummitData,
+            SummitScopes::ReadAllSummitData,
+        ]]],
+        tags: ["Sponsorship Add-On Types"],
+        parameters: [
+            new OA\Parameter(name: "page", description: "Page number", in: "query", required: false, schema: new OA\Schema(type: "integer", default: 1)),
+            new OA\Parameter(name: "per_page", description: "Items per page", in: "query", required: false, schema: new OA\Schema(type: "integer", default: 10)),
+            new OA\Parameter(name: "filter", description: "Filter query (name==value, name=@value)", in: "query", required: false, schema: new OA\Schema(type: "string")),
+            new OA\Parameter(name: "order", description: "Order by (+id, -name)", in: "query", required: false, schema: new OA\Schema(type: "string")),
+        ],
+        responses: [
+            new OA\Response(response: Response::HTTP_OK, description: "OK"),
+            new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
+            new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
+            new OA\Response(response: Response::HTTP_INTERNAL_SERVER_ERROR, description: "Server Error"),
+        ]
+    )]
+
+    #[OA\Post(
+        path: "/api/v1/summits/all/add-on-types",
+        summary: "Add a new sponsorship add-on type",
+        operationId: 'addAddOnType',
+        x: [
+            'required-groups' => [
+                IGroup::SuperAdmins,
+                IGroup::Administrators,
+                IGroup::SummitAdministrators,
+            ]
+        ],
+        security: [['summit_sponsorship_oauth2' => [
+            SummitScopes::WriteSummitData,
+        ]]],
+        tags: ["Sponsorship Add-On Types"],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ["name"],
+                properties: [
+                    new OA\Property(property: "name", type: "string"),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(response: Response::HTTP_CREATED, description: "Created"),
+            new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
+            new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
+            new OA\Response(response: Response::HTTP_PRECONDITION_FAILED, description: "Validation Error"),
+            new OA\Response(response: Response::HTTP_INTERNAL_SERVER_ERROR, description: "Server Error"),
+        ]
+    )]
+    public function add()
+    {
+        return $this->processRequest(function () {
+            $payload = $this->getJsonPayload(
+                SummitSponsorshipAddOnTypeValidationRulesFactory::buildForAdd(),
+                true
+            );
+
+            $type = $this->service->add($payload);
+
+            return $this->created(SerializerRegistry::getInstance()->getSerializer($type)->serialize(
+                SerializerUtils::getExpand(),
+                SerializerUtils::getFields(),
+                SerializerUtils::getRelations()
+            ));
+        });
+    }
+
+    #[OA\Get(
+        path: "/api/v1/summits/all/add-on-types/{id}",
+        summary: "Get a sponsorship add-on type by id",
+        operationId: 'getAddOnType',
+        security: [['summit_sponsorship_oauth2' => [
+            SummitScopes::ReadSummitData,
+            SummitScopes::ReadAllSummitData,
+        ]]],
+        tags: ["Sponsorship Add-On Types"],
+        parameters: [
+            new OA\Parameter(name: "id", description: "Add-on Type ID", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+        ],
+        responses: [
+            new OA\Response(response: Response::HTTP_OK, description: "OK"),
+            new OA\Response(response: Response::HTTP_NOT_FOUND, description: "Not Found"),
+            new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
+            new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
+            new OA\Response(response: Response::HTTP_INTERNAL_SERVER_ERROR, description: "Server Error"),
+        ]
+    )]
+    public function get($id)
+    {
+        return $this->processRequest(function () use ($id) {
+            $type = $this->repository->getById(intval($id));
+            if (is_null($type))
+                return $this->error404();
+
+            return $this->ok(SerializerRegistry::getInstance()->getSerializer($type)->serialize(
+                SerializerUtils::getExpand(),
+                SerializerUtils::getFields(),
+                SerializerUtils::getRelations()
+            ));
+        });
+    }
+
+    #[OA\Put(
+        path: "/api/v1/summits/all/add-on-types/{id}",
+        summary: "Update a sponsorship add-on type",
+        operationId: 'updateAddOnType',
+        x: [
+            'required-groups' => [
+                IGroup::SuperAdmins,
+                IGroup::Administrators,
+                IGroup::SummitAdministrators,
+            ]
+        ],
+        security: [['summit_sponsorship_oauth2' => [
+            SummitScopes::WriteSummitData,
+        ]]],
+        tags: ["Sponsorship Add-On Types"],
+        parameters: [
+            new OA\Parameter(name: "id", description: "Add-on Type ID", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: "name", type: "string"),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(response: Response::HTTP_OK, description: "OK"),
+            new OA\Response(response: Response::HTTP_NOT_FOUND, description: "Not Found"),
+            new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
+            new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
+            new OA\Response(response: Response::HTTP_PRECONDITION_FAILED, description: "Validation Error"),
+            new OA\Response(response: Response::HTTP_INTERNAL_SERVER_ERROR, description: "Server Error"),
+        ]
+    )]
+    public function update($id)
+    {
+        return $this->processRequest(function () use ($id) {
+            $payload = $this->getJsonPayload(
+                SummitSponsorshipAddOnTypeValidationRulesFactory::buildForUpdate(),
+                true
+            );
+
+            $type = $this->service->update(intval($id), $payload);
+
+            return $this->updated(SerializerRegistry::getInstance()->getSerializer($type)->serialize(
+                SerializerUtils::getExpand(),
+                SerializerUtils::getFields(),
+                SerializerUtils::getRelations()
+            ));
+        });
+    }
+
+    #[OA\Delete(
+        path: "/api/v1/summits/all/add-on-types/{id}",
+        summary: "Delete a sponsorship add-on type",
+        operationId: 'deleteAddOnType',
+        x: [
+            'required-groups' => [
+                IGroup::SuperAdmins,
+                IGroup::Administrators,
+                IGroup::SummitAdministrators,
+            ]
+        ],
+        security: [['summit_sponsorship_oauth2' => [
+            SummitScopes::WriteSummitData,
+        ]]],
+        tags: ["Sponsorship Add-On Types"],
+        parameters: [
+            new OA\Parameter(name: "id", description: "Add-on Type ID", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+        ],
+        responses: [
+            new OA\Response(response: Response::HTTP_NO_CONTENT, description: "No Content"),
+            new OA\Response(response: Response::HTTP_NOT_FOUND, description: "Not Found"),
+            new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
+            new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
+            new OA\Response(response: Response::HTTP_INTERNAL_SERVER_ERROR, description: "Server Error"),
+        ]
+    )]
+    public function delete($id)
+    {
+        return $this->processRequest(function () use ($id) {
+            $this->service->delete(intval($id));
+            return $this->deleted();
+        });
+    }
+}

--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitSponsorshipsApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitSponsorshipsApiController.php
@@ -409,21 +409,22 @@ final class OAuth2SummitSponsorshipsApiController
         return $this->_getAll(
             function () {
                 return [
-                    'name' => Filter::buildStringDefaultOperators(),
-                    'type' => Filter::buildStringDefaultOperators(),
+                    'name'    => Filter::buildStringDefaultOperators(),
+                    'type'    => ['==', '=@'],
+                    'type_id' => ['=='],
                 ];
             },
             function () {
                 return [
-                    'name' => 'sometimes|string',
-                    'type' => 'sometimes|string',
+                    'name'    => 'sometimes|string',
+                    'type'    => 'sometimes|string',
+                    'type_id' => 'sometimes|integer',
                 ];
             },
             function () {
                 return [
                     'id',
                     'name',
-                    'type',
                 ];
             },
             function ($filter) use ($summit, $sponsor, $sponsorship) {

--- a/app/ModelSerializers/SerializerRegistry.php
+++ b/app/ModelSerializers/SerializerRegistry.php
@@ -122,6 +122,7 @@ use App\ModelSerializers\Summit\SummitScheduleConfigSerializer;
 use App\ModelSerializers\Summit\SummitSchedulePreFilterElementConfigSerializer;
 use App\ModelSerializers\Summit\SummitSignSerializer;
 use App\ModelSerializers\Summit\SummitSponsorshipAddOnSerializer;
+use App\ModelSerializers\Summit\SummitSponsorshipAddOnTypeSerializer;
 use App\ModelSerializers\Summit\SummitSponsorshipSerializer;
 use App\ModelSerializers\Summit\SummitSponsorshipTypeSerializer;
 use App\ModelSerializers\Summit\TrackTagGroups\TrackTagGroupAllowedTagSerializer;
@@ -607,6 +608,7 @@ final class SerializerRegistry
         $this->registry['SponsorshipType'] = SponsorshipTypeSerializer::class;
         $this->registry['SummitSponsorship'] = SummitSponsorshipSerializer::class;
         $this->registry['SummitSponsorshipAddOn'] = SummitSponsorshipAddOnSerializer::class;
+        $this->registry['SummitSponsorshipAddOnType'] = SummitSponsorshipAddOnTypeSerializer::class;
         $this->registry['SummitSponsorshipType'] = SummitSponsorshipTypeSerializer::class;
         $this->registry['Sponsor'] = [
             self::SerializerType_Public => SponsorSerializer::class,

--- a/app/ModelSerializers/Summit/SummitSponsorshipAddOnSerializer.php
+++ b/app/ModelSerializers/Summit/SummitSponsorshipAddOnSerializer.php
@@ -23,8 +23,9 @@ use ModelSerializers\SilverStripeSerializer;
 final class SummitSponsorshipAddOnSerializer extends SilverStripeSerializer
 {
     protected static $array_mappings = [
-        'Name'         => 'name:json_string',
-        'TypeId'       => 'type_id:json_int',
+        'Name'          => 'name:json_string',
+        'TypeId'        => 'type_id:json_int',
+        'TypeName'      => 'type_name:json_string',
         'SponsorshipId' => 'sponsorship_id:json_int',
     ];
 

--- a/app/ModelSerializers/Summit/SummitSponsorshipAddOnSerializer.php
+++ b/app/ModelSerializers/Summit/SummitSponsorshipAddOnSerializer.php
@@ -23,12 +23,18 @@ use ModelSerializers\SilverStripeSerializer;
 final class SummitSponsorshipAddOnSerializer extends SilverStripeSerializer
 {
     protected static $array_mappings = [
-        'Name' => 'name:json_string',
-        'Type' => 'type:json_string',
+        'Name'         => 'name:json_string',
+        'TypeId'       => 'type_id:json_int',
         'SponsorshipId' => 'sponsorship_id:json_int',
     ];
 
     protected static $expand_mappings = [
+        'type' => [
+            'type' => One2ManyExpandSerializer::class,
+            'original_attribute' => 'type_id',
+            'getter' => 'getType',
+            'has' => 'hasType'
+        ],
         'sponsorship' => [
             'type' => One2ManyExpandSerializer::class,
             'original_attribute' => 'sponsorship_id',

--- a/app/ModelSerializers/Summit/SummitSponsorshipAddOnTypeSerializer.php
+++ b/app/ModelSerializers/Summit/SummitSponsorshipAddOnTypeSerializer.php
@@ -1,0 +1,26 @@
+<?php namespace App\ModelSerializers\Summit;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use ModelSerializers\SilverStripeSerializer;
+
+/**
+ * Class SummitSponsorshipAddOnTypeSerializer
+ * @package App\ModelSerializers\Summit
+ */
+final class SummitSponsorshipAddOnTypeSerializer extends SilverStripeSerializer
+{
+    protected static $array_mappings = [
+        'Name' => 'name:json_string',
+    ];
+}

--- a/app/Models/Foundation/Summit/Factories/SummitSponsorshipAddOnTypeFactory.php
+++ b/app/Models/Foundation/Summit/Factories/SummitSponsorshipAddOnTypeFactory.php
@@ -1,6 +1,6 @@
 <?php namespace App\Models\Foundation\Summit\Factories;
-/**
- * Copyright 2025 OpenStack Foundation
+/*
+ * Copyright 2026 OpenStack Foundation
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,34 +12,33 @@
  * limitations under the License.
  **/
 
-use models\exceptions\ValidationException;
-use models\summit\SummitSponsorshipAddOn;
+use models\summit\SummitSponsorshipAddOnType;
 
 /**
- * Class SummitSponsorshipAddOnFactory
+ * Class SummitSponsorshipAddOnTypeFactory
  * @package App\Models\Foundation\Summit\Factories
  */
-final class SummitSponsorshipAddOnFactory
+final class SummitSponsorshipAddOnTypeFactory
 {
     /**
      * @param array $data
-     * @return SummitSponsorshipAddOn
+     * @return SummitSponsorshipAddOnType
      */
-    public static function build(array $data): SummitSponsorshipAddOn {
-        return self::populate(new SummitSponsorshipAddOn, $data);
+    public static function build(array $data): SummitSponsorshipAddOnType
+    {
+        return self::populate(new SummitSponsorshipAddOnType(), $data);
     }
 
     /**
-     * @param SummitSponsorshipAddOn $add_on
+     * @param SummitSponsorshipAddOnType $type
      * @param array $data
-     * @return SummitSponsorshipAddOn
-     * @throws ValidationException
+     * @return SummitSponsorshipAddOnType
      */
-    public static function populate(SummitSponsorshipAddOn $add_on, array $data): SummitSponsorshipAddOn{
+    public static function populate(SummitSponsorshipAddOnType $type, array $data): SummitSponsorshipAddOnType
+    {
+        if (isset($data['name']))
+            $type->setName(trim($data['name']));
 
-        if(isset($data['name']))
-            $add_on->setName(trim($data['name']));
-
-        return $add_on;
+        return $type;
     }
 }

--- a/app/Models/Foundation/Summit/Repositories/ISummitSponsorshipAddOnTypeRepository.php
+++ b/app/Models/Foundation/Summit/Repositories/ISummitSponsorshipAddOnTypeRepository.php
@@ -1,6 +1,6 @@
 <?php namespace App\Models\Foundation\Summit\Repositories;
-/**
- * Copyright 2025 OpenStack Foundation
+/*
+ * Copyright 2026 OpenStack Foundation
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,23 +12,18 @@
  * limitations under the License.
  **/
 
-use models\summit\Summit;
+use models\summit\SummitSponsorshipAddOnType;
 use models\utils\IBaseRepository;
+
 /**
- * Interface ISummitSponsorshipAddOnRepository
+ * Interface ISummitSponsorshipAddOnTypeRepository
  * @package App\Models\Foundation\Summit\Repositories
  */
-interface ISummitSponsorshipAddOnRepository extends IBaseRepository
+interface ISummitSponsorshipAddOnTypeRepository extends IBaseRepository
 {
     /**
-     * @param Summit $summit
-     * @return array
+     * @param string $name
+     * @return SummitSponsorshipAddOnType|null
      */
-    public function getMetadata(Summit $summit): array;
-
-    /**
-     * @param int $type_id
-     * @return int
-     */
-    public function countByAddOnType(int $type_id): int;
+    public function getByName(string $name): ?SummitSponsorshipAddOnType;
 }

--- a/app/Models/Foundation/Summit/SummitSponsorshipAddOn.php
+++ b/app/Models/Foundation/Summit/SummitSponsorshipAddOn.php
@@ -72,6 +72,11 @@ class SummitSponsorshipAddOn extends SilverstripeBaseModel
         return $this->type;
     }
 
+    public function getTypeName(): ?string
+    {
+        return $this->type?->getName();
+    }
+
     public function setType(SummitSponsorshipAddOnType $type): void
     {
         $this->type = $type;

--- a/app/Models/Foundation/Summit/SummitSponsorshipAddOn.php
+++ b/app/Models/Foundation/Summit/SummitSponsorshipAddOn.php
@@ -14,7 +14,6 @@
 
 use App\Repositories\Summit\DoctrineSummitSponsorshipAddOnRepository;
 use Doctrine\ORM\Mapping as ORM;
-use models\exceptions\ValidationException;
 use models\utils\One2ManyPropertyTrait;
 use models\utils\SilverstripeBaseModel;
 
@@ -30,29 +29,13 @@ class SummitSponsorshipAddOn extends SilverstripeBaseModel
 
     protected $getIdMappings = [
         'getSponsorshipId' => 'sponsorship',
+        'getTypeId'        => 'type',
     ];
 
     protected $hasPropertyMappings = [
         'hasSponsorship' => 'sponsorship',
+        'hasType'        => 'type',
     ];
-
-    const Booth_Type = 'Booth';
-    const MeetingRoom_Type = 'Meeting_Room';
-    const ScheduleSpot_Type = 'Schedule_Spot';
-    const SignageSpot_Type = 'Signage_Spot';
-
-    const ValidTypes = [
-        self::Booth_Type,
-        self::MeetingRoom_Type,
-        self::ScheduleSpot_Type,
-        self::SignageSpot_Type,
-    ];
-
-    /**
-     * @var string
-     */
-    #[ORM\Column(name: 'Type', type: 'string')]
-    private $type;
 
     /**
      * @var string
@@ -60,32 +43,19 @@ class SummitSponsorshipAddOn extends SilverstripeBaseModel
     #[ORM\Column(name: 'Name', type: 'string')]
     private $name;
 
-     /**
+    /**
+     * @var SummitSponsorshipAddOnType|null
+     */
+    #[ORM\ManyToOne(targetEntity: SummitSponsorshipAddOnType::class, fetch: 'EXTRA_LAZY')]
+    #[ORM\JoinColumn(name: 'AddOnTypeID', referencedColumnName: 'ID', onDelete: 'SET NULL', nullable: true)]
+    private $type;
+
+    /**
      * @var SummitSponsorship
      */
     #[ORM\ManyToOne(targetEntity: SummitSponsorship::class, fetch: 'EXTRA_LAZY', inversedBy: 'add_ons')]
     #[ORM\JoinColumn(name: 'SponsorshipID', referencedColumnName: 'ID')]
     protected $sponsorship;
-
-    public static function getMetadata(): array
-    {
-        return self::ValidTypes;
-    }
-
-    public function getType(): string
-    {
-        return $this->type;
-    }
-
-    /**
-     * @throws ValidationException
-     */
-    public function setType(string $type): void
-    {
-        if(!in_array($type, self::ValidTypes))
-            throw new ValidationException(sprintf("%s is not a valid type.", $type));
-        $this->type = $type;
-    }
 
     public function getName(): string
     {
@@ -95,6 +65,21 @@ class SummitSponsorshipAddOn extends SilverstripeBaseModel
     public function setName(string $name): void
     {
         $this->name = $name;
+    }
+
+    public function getType(): ?SummitSponsorshipAddOnType
+    {
+        return $this->type;
+    }
+
+    public function setType(SummitSponsorshipAddOnType $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function clearType(): void
+    {
+        $this->type = null;
     }
 
     public function getSponsorship(): SummitSponsorship

--- a/app/Models/Foundation/Summit/SummitSponsorshipAddOnType.php
+++ b/app/Models/Foundation/Summit/SummitSponsorshipAddOnType.php
@@ -1,0 +1,41 @@
+<?php namespace models\summit;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Repositories\Summit\DoctrineSummitSponsorshipAddOnTypeRepository;
+use Doctrine\ORM\Mapping as ORM;
+use models\utils\SilverstripeBaseModel;
+
+/**
+ * @package models\summit
+ */
+#[ORM\Table(name: 'SummitSponsorshipAddOnType')]
+#[ORM\Entity(repositoryClass: DoctrineSummitSponsorshipAddOnTypeRepository::class)]
+class SummitSponsorshipAddOnType extends SilverstripeBaseModel
+{
+    /**
+     * @var string
+     */
+    #[ORM\Column(name: 'Name', type: 'string')]
+    private $name;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/app/Repositories/RepositoriesProvider.php
+++ b/app/Repositories/RepositoriesProvider.php
@@ -101,6 +101,7 @@ use App\Models\Foundation\Summit\Repositories\ISummitScheduleConfigRepository;
 use App\Models\Foundation\Summit\Repositories\ISummitSelectionPlanExtraQuestionTypeRepository;
 use App\Models\Foundation\Summit\Repositories\ISummitSignRepository;
 use App\Models\Foundation\Summit\Repositories\ISummitSponsorshipAddOnRepository;
+use App\Models\Foundation\Summit\Repositories\ISummitSponsorshipAddOnTypeRepository;
 use App\Models\Foundation\Summit\Repositories\ISummitSponsorshipRepository;
 use App\Models\Foundation\Summit\Repositories\ISummitSponsorshipTypeRepository;
 use App\Models\Foundation\Summit\Repositories\ISummitSubmissionInvitationRepository;
@@ -185,6 +186,7 @@ use models\summit\SummitRoomReservation;
 use models\summit\SummitScheduleConfig;
 use models\summit\SummitSponsorship;
 use models\summit\SummitSponsorshipAddOn;
+use models\summit\SummitSponsorshipAddOnType;
 use models\summit\SummitSponsorshipType;
 use models\summit\SummitSubmissionInvitation;
 use models\summit\SummitTaxType;
@@ -636,6 +638,13 @@ final class RepositoriesProvider extends ServiceProvider
             ISummitSponsorshipAddOnRepository::class,
             function () {
                 return EntityManager::getRepository(SummitSponsorshipAddOn::class);
+            }
+        );
+
+        App::singleton(
+            ISummitSponsorshipAddOnTypeRepository::class,
+            function () {
+                return EntityManager::getRepository(SummitSponsorshipAddOnType::class);
             }
         );
 

--- a/app/Repositories/Summit/DoctrineSummitSponsorshipAddOnRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitSponsorshipAddOnRepository.php
@@ -39,6 +39,7 @@ implements ISummitSponsorshipAddOnRepository
         $query->innerJoin("e.sponsorship", "sps");
         $query->innerJoin("sps.sponsor", "sp");
         $query->innerJoin("sp.summit", "s");
+        $query->leftJoin("e.type", "at");
         return $query;
     }
 
@@ -48,12 +49,13 @@ implements ISummitSponsorshipAddOnRepository
     protected function getFilterMappings(): array
     {
         return [
-            'id'   => new DoctrineFilterMapping("e.id :operator :value"),
-            'name' => 'e.name',
-            'type' => 'e.type',
+            'id'             => new DoctrineFilterMapping("e.id :operator :value"),
+            'name'           => 'e.name',
+            'type'           => 'at.name',
+            'type_id'        => 'at.id',
             'sponsorship_id' => 'sps.id',
-            'sponsor_id' => 'sp.id',
-            'summit_id'  => 's.id',
+            'sponsor_id'     => 'sp.id',
+            'summit_id'      => 's.id',
         ];
     }
 
@@ -65,7 +67,6 @@ implements ISummitSponsorshipAddOnRepository
         return [
             'id'   => 'e.id',
             'name' => 'e.name',
-            'type' => 'e.type',
         ];
     }
 
@@ -83,6 +84,18 @@ implements ISummitSponsorshipAddOnRepository
      */
     public function getMetadata(Summit $summit): array
     {
-        return SummitSponsorshipAddOn::getMetadata();
+        return [];
+    }
+
+    /**
+     * @param int $type_id
+     * @return int
+     */
+    public function countByAddOnType(int $type_id): int
+    {
+        return (int) $this->getEntityManager()
+            ->createQuery('SELECT COUNT(e.id) FROM ' . SummitSponsorshipAddOn::class . ' e WHERE e.type = :type_id')
+            ->setParameter('type_id', $type_id)
+            ->getSingleScalarResult();
     }
 }

--- a/app/Repositories/Summit/DoctrineSummitSponsorshipAddOnRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitSponsorshipAddOnRepository.php
@@ -67,6 +67,7 @@ implements ISummitSponsorshipAddOnRepository
         return [
             'id'   => 'e.id',
             'name' => 'e.name',
+            'type' => 'at.name',
         ];
     }
 

--- a/app/Repositories/Summit/DoctrineSummitSponsorshipAddOnTypeRepository.php
+++ b/app/Repositories/Summit/DoctrineSummitSponsorshipAddOnTypeRepository.php
@@ -1,0 +1,65 @@
+<?php namespace App\Repositories\Summit;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Models\Foundation\Summit\Repositories\ISummitSponsorshipAddOnTypeRepository;
+use App\Repositories\SilverStripeDoctrineRepository;
+use models\summit\SummitSponsorshipAddOnType;
+
+/**
+ * Class DoctrineSummitSponsorshipAddOnTypeRepository
+ * @package App\Repositories\Summit
+ */
+final class DoctrineSummitSponsorshipAddOnTypeRepository
+    extends SilverStripeDoctrineRepository
+    implements ISummitSponsorshipAddOnTypeRepository
+{
+    /**
+     * @return string
+     */
+    protected function getBaseEntity(): string
+    {
+        return SummitSponsorshipAddOnType::class;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getFilterMappings(): array
+    {
+        return [
+            'id'   => 'e.id',
+            'name' => 'e.name:json_string',
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getOrderMappings(): array
+    {
+        return [
+            'id'   => 'e.id',
+            'name' => 'e.name',
+        ];
+    }
+
+    /**
+     * @param string $name
+     * @return SummitSponsorshipAddOnType|null
+     */
+    public function getByName(string $name): ?SummitSponsorshipAddOnType
+    {
+        return $this->findOneBy(['name' => trim($name)]);
+    }
+}

--- a/app/Services/Model/ISummitSponsorshipAddOnTypeService.php
+++ b/app/Services/Model/ISummitSponsorshipAddOnTypeService.php
@@ -1,0 +1,47 @@
+<?php namespace App\Services\Model;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use models\exceptions\EntityNotFoundException;
+use models\exceptions\ValidationException;
+use models\summit\SummitSponsorshipAddOnType;
+
+/**
+ * Interface ISummitSponsorshipAddOnTypeService
+ * @package App\Services\Model
+ */
+interface ISummitSponsorshipAddOnTypeService
+{
+    /**
+     * @param array $payload
+     * @return SummitSponsorshipAddOnType
+     * @throws ValidationException
+     */
+    public function add(array $payload): SummitSponsorshipAddOnType;
+
+    /**
+     * @param int $type_id
+     * @param array $payload
+     * @return SummitSponsorshipAddOnType
+     * @throws EntityNotFoundException
+     * @throws ValidationException
+     */
+    public function update(int $type_id, array $payload): SummitSponsorshipAddOnType;
+
+    /**
+     * @param int $type_id
+     * @throws EntityNotFoundException
+     * @throws ValidationException
+     */
+    public function delete(int $type_id): void;
+}

--- a/app/Services/Model/Imp/SummitSponsorshipAddOnTypeService.php
+++ b/app/Services/Model/Imp/SummitSponsorshipAddOnTypeService.php
@@ -1,0 +1,108 @@
+<?php namespace App\Services\Model\Imp;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Models\Foundation\Summit\Factories\SummitSponsorshipAddOnTypeFactory;
+use App\Models\Foundation\Summit\Repositories\ISummitSponsorshipAddOnRepository;
+use App\Models\Foundation\Summit\Repositories\ISummitSponsorshipAddOnTypeRepository;
+use App\Services\Model\AbstractService;
+use App\Services\Model\ISummitSponsorshipAddOnTypeService;
+use libs\utils\ITransactionService;
+use models\exceptions\EntityNotFoundException;
+use models\exceptions\ValidationException;
+use models\summit\SummitSponsorshipAddOnType;
+
+/**
+ * Class SummitSponsorshipAddOnTypeService
+ * @package App\Services\Model\Imp
+ */
+final class SummitSponsorshipAddOnTypeService
+    extends AbstractService
+    implements ISummitSponsorshipAddOnTypeService
+{
+    /**
+     * @var ISummitSponsorshipAddOnTypeRepository
+     */
+    private $repository;
+
+    /**
+     * @var ISummitSponsorshipAddOnRepository
+     */
+    private $add_on_repository;
+
+    public function __construct(
+        ISummitSponsorshipAddOnTypeRepository $repository,
+        ISummitSponsorshipAddOnRepository     $add_on_repository,
+        ITransactionService                   $tx_service
+    )
+    {
+        parent::__construct($tx_service);
+        $this->repository        = $repository;
+        $this->add_on_repository = $add_on_repository;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add(array $payload): SummitSponsorshipAddOnType
+    {
+        return $this->tx_service->transaction(function () use ($payload) {
+            if (isset($payload['name'])) {
+                $existing = $this->repository->getByName(trim($payload['name']));
+                if (!is_null($existing))
+                    throw new ValidationException(sprintf("AddOnType with name '%s' already exists.", $payload['name']));
+            }
+
+            $type = SummitSponsorshipAddOnTypeFactory::build($payload);
+            $this->repository->add($type);
+            return $type;
+        });
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update(int $type_id, array $payload): SummitSponsorshipAddOnType
+    {
+        return $this->tx_service->transaction(function () use ($type_id, $payload) {
+            $type = $this->repository->getById($type_id);
+            if (is_null($type))
+                throw new EntityNotFoundException("AddOnType not found.");
+
+            if (isset($payload['name'])) {
+                $existing = $this->repository->getByName(trim($payload['name']));
+                if (!is_null($existing) && $existing->getId() !== $type->getId())
+                    throw new ValidationException(sprintf("AddOnType with name '%s' already exists.", $payload['name']));
+            }
+
+            return SummitSponsorshipAddOnTypeFactory::populate($type, $payload);
+        });
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(int $type_id): void
+    {
+        $this->tx_service->transaction(function () use ($type_id) {
+            $type = $this->repository->getById($type_id);
+            if (is_null($type))
+                throw new EntityNotFoundException("AddOnType not found.");
+
+            if ($this->add_on_repository->countByAddOnType($type_id) > 0)
+                throw new ValidationException(sprintf("AddOnType '%s' is assigned to one or more add-ons and cannot be deleted.", $type->getName()));
+
+            $this->repository->delete($type);
+        });
+    }
+}

--- a/app/Services/Model/Imp/SummitSponsorshipService.php
+++ b/app/Services/Model/Imp/SummitSponsorshipService.php
@@ -19,13 +19,17 @@ use App\Events\SponsorServices\SummitSponsorshipCreatedEventDTO;
 use App\Events\SponsorServices\DeletedEventDTO;
 use App\Jobs\SponsorServices\PublishSponsorServiceDomainEventsJob;
 use App\Models\Foundation\Summit\Factories\SummitSponsorshipAddOnFactory;
+use App\Models\Foundation\Summit\Repositories\ISummitSponsorshipAddOnTypeRepository;
 use App\Services\Model\AbstractService;
 use App\Services\Model\ISummitSponsorshipService;
 use Illuminate\Support\Facades\Log;
+use libs\utils\ITransactionService;
 use models\exceptions\EntityNotFoundException;
+use models\exceptions\ValidationException;
 use models\summit\Summit;
 use models\summit\SummitSponsorship;
 use models\summit\SummitSponsorshipAddOn;
+use models\summit\SummitSponsorshipAddOnType;
 
 /**
  * Class SummitSponsorshipService
@@ -33,6 +37,20 @@ use models\summit\SummitSponsorshipAddOn;
  */
 final class SummitSponsorshipService extends AbstractService implements ISummitSponsorshipService
 {
+    /**
+     * @var ISummitSponsorshipAddOnTypeRepository
+     */
+    private $add_on_type_repository;
+
+    public function __construct(
+        ISummitSponsorshipAddOnTypeRepository $add_on_type_repository,
+        ITransactionService                   $tx_service
+    )
+    {
+        parent::__construct($tx_service);
+        $this->add_on_type_repository = $add_on_type_repository;
+    }
+
     /**
      * @inheritDoc
      */
@@ -117,6 +135,10 @@ final class SummitSponsorshipService extends AbstractService implements ISummitS
                 throw new EntityNotFoundException("Sponsorship {$sponsorship_id} not found for sponsor {$sponsor_id}.");
 
             $add_on = SummitSponsorshipAddOnFactory::build($payload);
+
+            $type = $this->resolveAddOnType($payload);
+            if (!is_null($type)) $add_on->setType($type);
+
             $sponsorship->addAddOn($add_on);
 
             return $add_on;
@@ -172,7 +194,12 @@ final class SummitSponsorshipService extends AbstractService implements ISummitS
             if (is_null($add_on))
                 throw new EntityNotFoundException("AddOn {$add_on_id} not found for sponsorship {$sponsorship_id}.");
 
-            return SummitSponsorshipAddOnFactory::populate($add_on, $payload);
+            SummitSponsorshipAddOnFactory::populate($add_on, $payload);
+
+            $type = $this->resolveAddOnType($payload);
+            if (!is_null($type)) $add_on->setType($type);
+
+            return $add_on;
         });
 
         PublishSponsorServiceDomainEventsJob::dispatch(
@@ -228,5 +255,24 @@ final class SummitSponsorshipService extends AbstractService implements ISummitS
         PublishSponsorServiceDomainEventsJob::dispatch(
             DeletedEventDTO::fromEntity($add_on)->serialize(),
             SponsorDomainEvents::SponsorshipAddOnRemoved);
+    }
+
+    private function resolveAddOnType(array $payload): ?SummitSponsorshipAddOnType
+    {
+        if (isset($payload['type_id'])) {
+            $type = $this->add_on_type_repository->getById(intval($payload['type_id']));
+            if (is_null($type))
+                throw new ValidationException(sprintf("Invalid AddOnType %s.", $payload['type_id']));
+            return $type;
+        }
+
+        if (isset($payload['type'])) {
+            $type = $this->add_on_type_repository->getByName(trim($payload['type']));
+            if (is_null($type))
+                throw new ValidationException(sprintf("Invalid AddOnType '%s'.", $payload['type']));
+            return $type;
+        }
+
+        return null;
     }
 }

--- a/app/Services/ModelServicesProvider.php
+++ b/app/Services/ModelServicesProvider.php
@@ -36,6 +36,7 @@ use App\Services\Model\IMemberService;
 use App\Services\Model\Imp\BadgeViewTypeService;
 use App\Services\Model\Imp\CompanyService;
 use App\Services\Model\Imp\ElectionService;
+use App\Services\Model\Imp\Factories\RabbitPublisherFactory;
 use App\Services\Model\Imp\PaymentGatewayProfileService;
 use App\Services\Model\Imp\PresentationVideoMediaUploadProcessor;
 use App\Services\Model\Imp\ProcessScheduleEntityLifeCycleEventService;
@@ -59,6 +60,7 @@ use App\Services\Model\Imp\SummitRSVPService;
 use App\Services\Model\Imp\SummitScheduleSettingsService;
 use App\Services\Model\Imp\SummitSelectedPresentationListService;
 use App\Services\Model\Imp\SummitSignService;
+use App\Services\Model\Imp\SummitSponsorshipAddOnTypeService;
 use App\Services\Model\Imp\SummitSponsorshipTypeService;
 use App\Services\Model\Imp\SummitSubmissionInvitationService;
 use App\Services\Model\Imp\TrackChairRankingService;
@@ -100,6 +102,7 @@ use App\Services\Model\ISummitScheduleSettingsService;
 use App\Services\Model\ISummitSelectedPresentationListService;
 use App\Services\Model\ISummitSelectionPlanService;
 use App\Services\Model\ISummitSignService;
+use App\Services\Model\ISummitSponsorshipAddOnTypeService;
 use App\Services\Model\ISummitSponsorshipService;
 use App\Services\Model\ISummitSponsorshipTypeService;
 use App\Services\Model\ISummitSubmissionInvitationService;
@@ -343,6 +346,11 @@ final class ModelServicesProvider extends ServiceProvider
         App::singleton(
             ISummitSponsorshipService::class,
             SummitSponsorshipService::class
+        );
+
+        App::singleton(
+            ISummitSponsorshipAddOnTypeService::class,
+            SummitSponsorshipAddOnTypeService::class
         );
 
         App::singleton(ISummitOrderService::class, SummitOrderService::class);
@@ -606,6 +614,7 @@ final class ModelServicesProvider extends ServiceProvider
             ISummitRSVPService::class,
             ISummitRSVPInvitationService::class,
             IFilePostProcessorService::class,
+            ISummitSponsorshipAddOnTypeService::class,
         ];
     }
 }

--- a/app/Swagger/Models/SummitSponsorshipAddOnTypeSchema.php
+++ b/app/Swagger/Models/SummitSponsorshipAddOnTypeSchema.php
@@ -1,0 +1,35 @@
+<?php namespace App\Swagger\schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'SummitSponsorshipAddOnType',
+    type: 'object',
+    required: ['id', 'name'],
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', format: 'int64', example: 1),
+        new OA\Property(property: 'created', type: 'integer', format: 'int64', description: 'Creation timestamp (Unix epoch)'),
+        new OA\Property(property: 'last_edited', type: 'integer', format: 'int64', description: 'Last edit timestamp (Unix epoch)'),
+        new OA\Property(property: 'name', type: 'string', example: 'Booth'),
+    ]
+)]
+class SummitSponsorshipAddOnTypeSchema {}
+
+#[OA\Schema(
+    schema: 'PaginatedSummitSponsorshipAddOnTypeResponse',
+    type: 'object',
+    allOf: [
+        new OA\Schema(ref: '#/components/schemas/PaginateDataSchemaResponse'),
+        new OA\Schema(
+            type: 'object',
+            properties: [
+                new OA\Property(
+                    property: 'data',
+                    type: 'array',
+                    items: new OA\Items(ref: '#/components/schemas/SummitSponsorshipAddOnType')
+                )
+            ]
+        )
+    ]
+)]
+class PaginatedSummitSponsorshipAddOnTypeResponseSchema {}

--- a/database/migrations/config/Version20260615000000.php
+++ b/database/migrations/config/Version20260615000000.php
@@ -1,0 +1,100 @@
+<?php namespace Database\Migrations\Config;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use App\Models\Foundation\Main\IGroup;
+use App\Security\SummitScopes;
+
+/**
+ * Seed the five SummitSponsorshipAddOnType CRUD endpoints.
+ *
+ * Adds:
+ * - 5 api_endpoints rows under the 'summits' API
+ * - scope associations: ReadSummitData + ReadAllSummitData for GETs, WriteSummitData for writes
+ * - authz groups: SuperAdmins, Administrators, SummitAdministrators for all five
+ *
+ * All INSERTs are idempotent via WHERE NOT EXISTS.
+ */
+final class Version20260615000000 extends AbstractMigration
+{
+    use APIEndpointsMigrationHelper;
+
+    private const API_NAME = 'summits';
+
+    private const ENDPOINT_GET_ALL    = 'get-sponsorship-add-on-types';
+    private const ENDPOINT_ADD        = 'add-sponsorship-add-on-type';
+    private const ENDPOINT_GET_ONE    = 'get-sponsorship-add-on-type';
+    private const ENDPOINT_UPDATE     = 'update-sponsorship-add-on-type';
+    private const ENDPOINT_DELETE     = 'delete-sponsorship-add-on-type';
+
+    private const ROUTE_COLLECTION    = '/api/v1/summits/all/add-on-types';
+    private const ROUTE_ITEM          = '/api/v1/summits/all/add-on-types/{id}';
+
+    private const READ_ENDPOINTS  = [self::ENDPOINT_GET_ALL, self::ENDPOINT_GET_ONE];
+    private const WRITE_ENDPOINTS = [self::ENDPOINT_ADD, self::ENDPOINT_UPDATE, self::ENDPOINT_DELETE];
+
+    private const ALL_ENDPOINTS = [
+        self::ENDPOINT_GET_ALL,
+        self::ENDPOINT_ADD,
+        self::ENDPOINT_GET_ONE,
+        self::ENDPOINT_UPDATE,
+        self::ENDPOINT_DELETE,
+    ];
+
+    private const AUTHZ_GROUPS = [
+        IGroup::SuperAdmins,
+        IGroup::Administrators,
+        IGroup::SummitAdministrators,
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Seed SummitSponsorshipAddOnType CRUD endpoints (get-all, add, get, update, delete)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Insert endpoint rows
+        $this->addSql($this->insertEndpoint(self::API_NAME, self::ENDPOINT_GET_ALL, self::ROUTE_COLLECTION, 'GET'));
+        $this->addSql($this->insertEndpoint(self::API_NAME, self::ENDPOINT_ADD,     self::ROUTE_COLLECTION, 'POST'));
+        $this->addSql($this->insertEndpoint(self::API_NAME, self::ENDPOINT_GET_ONE, self::ROUTE_ITEM,       'GET'));
+        $this->addSql($this->insertEndpoint(self::API_NAME, self::ENDPOINT_UPDATE,  self::ROUTE_ITEM,       'PUT'));
+        $this->addSql($this->insertEndpoint(self::API_NAME, self::ENDPOINT_DELETE,  self::ROUTE_ITEM,       'DELETE'));
+
+        // Scope associations
+        foreach (self::READ_ENDPOINTS as $endpoint) {
+            $this->addSql($this->insertEndpointScope(self::API_NAME, $endpoint, SummitScopes::ReadSummitData));
+            $this->addSql($this->insertEndpointScope(self::API_NAME, $endpoint, SummitScopes::ReadAllSummitData));
+        }
+
+        foreach (self::WRITE_ENDPOINTS as $endpoint) {
+            $this->addSql($this->insertEndpointScope(self::API_NAME, $endpoint, SummitScopes::WriteSummitData));
+        }
+
+        // Authz group associations
+        foreach (self::ALL_ENDPOINTS as $endpoint) {
+            foreach (self::AUTHZ_GROUPS as $group) {
+                $this->addSql($this->insertEndpointAuthzGroup(self::API_NAME, $endpoint, $group));
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::ALL_ENDPOINTS as $endpoint) {
+            $this->addSql($this->deleteEndpoint(self::API_NAME, $endpoint));
+        }
+    }
+}

--- a/database/migrations/model/Version20260615000000.php
+++ b/database/migrations/model/Version20260615000000.php
@@ -1,0 +1,78 @@
+<?php namespace Database\Migrations\Model;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+use LaravelDoctrine\Migrations\Schema\Builder;
+use LaravelDoctrine\Migrations\Schema\Table;
+
+/**
+ * Class Version20260615000000
+ * @package Database\Migrations\Model
+ *
+ * Creates the SummitSponsorshipAddOnType lookup table and adds the nullable
+ * AddOnTypeID column to SummitSponsorshipAddOn.
+ * A companion migration (Version20260615000001) seeds the four default types,
+ * backfills AddOnTypeID from the old Type string, adds the FK, and drops Type.
+ */
+final class Version20260615000000 extends AbstractMigration
+{
+    private const AddOnTypeTable = 'SummitSponsorshipAddOnType';
+    private const AddOnTable     = 'SummitSponsorshipAddOn';
+
+    public function getDescription(): string
+    {
+        return 'Create SummitSponsorshipAddOnType table and add AddOnTypeID column to SummitSponsorshipAddOn.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $builder = new Builder($schema);
+
+        if (!$builder->hasTable(self::AddOnTypeTable)) {
+            $builder->create(self::AddOnTypeTable, function (Table $table) {
+                $table->integer('ID', true, false);
+                $table->primary('ID');
+
+                $table->timestamp('Created')->setNotnull(false);
+                $table->timestamp('LastEdited')->setNotnull(false);
+
+                $table->string('Name', 255)->setNotnull(true);
+                $table->unique('Name', 'UNIQ_SummitSponsorshipAddOnType_Name');
+            });
+        }
+
+        if (!$builder->hasColumn(self::AddOnTable, 'AddOnTypeID')) {
+            $builder->table(self::AddOnTable, function (Table $table) {
+                $table->integer('AddOnTypeID', false, false)->setNotnull(false);
+                $table->index('AddOnTypeID', 'IDX_SummitSponsorshipAddOn_AddOnTypeID');
+            });
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $builder = new Builder($schema);
+
+        // Drop the FK-carrying column before the referenced table.
+        // By the time this runs, Version20260615000001 down() will have
+        // already dropped the FK constraint.
+        if ($builder->hasColumn(self::AddOnTable, 'AddOnTypeID')) {
+            $this->addSql('ALTER TABLE `' . self::AddOnTable . '` DROP COLUMN `AddOnTypeID`');
+        }
+
+        // Builder: schema diff runs after addSql() — table is dropped last.
+        $builder->dropIfExists(self::AddOnTypeTable);
+    }
+}

--- a/database/migrations/model/Version20260615000001.php
+++ b/database/migrations/model/Version20260615000001.php
@@ -1,0 +1,110 @@
+<?php namespace Database\Migrations\Model;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+use LaravelDoctrine\Migrations\Schema\Builder;
+use LaravelDoctrine\Migrations\Schema\Table;
+
+/**
+ * Class Version20260615000001
+ * @package Database\Migrations\Model
+ *
+ * Companion to Version20260615000000.
+ * Seeds the four default SummitSponsorshipAddOnType rows, backfills
+ * AddOnTypeID on every existing SummitSponsorshipAddOn row, adds the FK
+ * constraint, and drops the legacy Type string column.
+ *
+ * Execution order within up():
+ *   addSql() calls run first (INSERT → UPDATE → ADD FK),
+ *   then schema diff from Builder runs (DROP COLUMN Type).
+ * This guarantees the UPDATE that reads Type completes before the column is removed.
+ */
+final class Version20260615000001 extends AbstractMigration
+{
+    private const AddOnTypeTable = 'SummitSponsorshipAddOnType';
+    private const AddOnTable     = 'SummitSponsorshipAddOn';
+    private const FkName         = 'FK_SummitSponsorshipAddOn_AddOnType';
+
+    public function getDescription(): string
+    {
+        return 'Seed SummitSponsorshipAddOnType defaults, backfill AddOnTypeID, add FK, drop legacy Type column.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $builder = new Builder($schema);
+
+        if (!$builder->hasTable(self::AddOnTypeTable)) {
+            // Upstream DDL migration did not run — skip rather than crash.
+            return;
+        }
+
+        // Seed the four types that correspond to the old string constants.
+        $this->addSql(<<<SQL
+            INSERT INTO `SummitSponsorshipAddOnType` (`Created`, `LastEdited`, `Name`) VALUES
+                (NOW(), NOW(), 'Booth'),
+                (NOW(), NOW(), 'Meeting_Room'),
+                (NOW(), NOW(), 'Schedule_Spot'),
+                (NOW(), NOW(), 'Signage_Spot')
+        SQL);
+
+        // Backfill AddOnTypeID from the still-present Type string column.
+        $this->addSql(<<<SQL
+            UPDATE `SummitSponsorshipAddOn` a
+                INNER JOIN `SummitSponsorshipAddOnType` t ON t.`Name` = a.`Type`
+                SET a.`AddOnTypeID` = t.`ID`
+        SQL);
+
+        // Add the FK constraint after the data is consistent.
+        $this->addSql(<<<SQL
+            ALTER TABLE `SummitSponsorshipAddOn`
+                ADD CONSTRAINT `FK_SummitSponsorshipAddOn_AddOnType`
+                    FOREIGN KEY (`AddOnTypeID`) REFERENCES `SummitSponsorshipAddOnType` (`ID`)
+                    ON DELETE SET NULL
+        SQL);
+
+        // Builder: DROP COLUMN runs as schema diff, i.e. after all addSql() above,
+        // so the UPDATE that reads Type has already executed.
+        if ($builder->hasColumn(self::AddOnTable, 'Type')) {
+            $builder->table(self::AddOnTable, function (Table $table) {
+                $table->dropColumn('Type');
+            });
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $builder = new Builder($schema);
+
+        // Restore the Type column so the backfill UPDATE below has somewhere to write.
+        if (!$builder->hasColumn(self::AddOnTable, 'Type')) {
+            $this->addSql(
+                'ALTER TABLE `SummitSponsorshipAddOn` ADD COLUMN `Type` VARCHAR(255) CHARACTER SET utf8 NULL DEFAULT NULL'
+            );
+        }
+
+        // Backfill Type from AddOnTypeID while the lookup table still exists.
+        $this->addSql(<<<SQL
+            UPDATE `SummitSponsorshipAddOn` a
+                INNER JOIN `SummitSponsorshipAddOnType` t ON t.`ID` = a.`AddOnTypeID`
+                SET a.`Type` = t.`Name`
+        SQL);
+
+        // Drop the FK so Version20260615000000 down() can remove the column and table.
+        $this->addSql(
+            'ALTER TABLE `SummitSponsorshipAddOn` DROP FOREIGN KEY `' . self::FkName . '`'
+        );
+    }
+}

--- a/database/migrations/model/Version20260615000001.php
+++ b/database/migrations/model/Version20260615000001.php
@@ -52,8 +52,9 @@ final class Version20260615000001 extends AbstractMigration
         }
 
         // Seed the four types that correspond to the old string constants.
+        // INSERT IGNORE makes this safe to re-run (unique constraint on Name).
         $this->addSql(<<<SQL
-            INSERT INTO `SummitSponsorshipAddOnType` (`Created`, `LastEdited`, `Name`) VALUES
+            INSERT IGNORE INTO `SummitSponsorshipAddOnType` (`Created`, `LastEdited`, `Name`) VALUES
                 (NOW(), NOW(), 'Booth'),
                 (NOW(), NOW(), 'Meeting_Room'),
                 (NOW(), NOW(), 'Schedule_Spot'),

--- a/database/seeders/ApiEndpointsSeeder.php
+++ b/database/seeders/ApiEndpointsSeeder.php
@@ -2853,6 +2853,73 @@ class ApiEndpointsSeeder extends Seeder
                     IGroup::SummitAdministrators,
                 ]
             ],
+            [
+                'name' => 'get-sponsorship-add-on-types',
+                'route' => '/api/v1/summits/all/add-on-types',
+                'http_method' => 'GET',
+                'scopes' => [
+                    SummitScopes::ReadSummitData,
+                    SummitScopes::ReadAllSummitData,
+                ],
+                'authz_groups' => [
+                    IGroup::SuperAdmins,
+                    IGroup::Administrators,
+                    IGroup::SummitAdministrators,
+                ]
+            ],
+            [
+                'name' => 'add-sponsorship-add-on-type',
+                'route' => '/api/v1/summits/all/add-on-types',
+                'http_method' => 'POST',
+                'scopes' => [
+                    SummitScopes::WriteSummitData,
+                ],
+                'authz_groups' => [
+                    IGroup::SuperAdmins,
+                    IGroup::Administrators,
+                    IGroup::SummitAdministrators,
+                ]
+            ],
+            [
+                'name' => 'get-sponsorship-add-on-type',
+                'route' => '/api/v1/summits/all/add-on-types/{id}',
+                'http_method' => 'GET',
+                'scopes' => [
+                    SummitScopes::ReadSummitData,
+                    SummitScopes::ReadAllSummitData,
+                ],
+                'authz_groups' => [
+                    IGroup::SuperAdmins,
+                    IGroup::Administrators,
+                    IGroup::SummitAdministrators,
+                ]
+            ],
+            [
+                'name' => 'update-sponsorship-add-on-type',
+                'route' => '/api/v1/summits/all/add-on-types/{id}',
+                'http_method' => 'PUT',
+                'scopes' => [
+                    SummitScopes::WriteSummitData,
+                ],
+                'authz_groups' => [
+                    IGroup::SuperAdmins,
+                    IGroup::Administrators,
+                    IGroup::SummitAdministrators,
+                ]
+            ],
+            [
+                'name' => 'delete-sponsorship-add-on-type',
+                'route' => '/api/v1/summits/all/add-on-types/{id}',
+                'http_method' => 'DELETE',
+                'scopes' => [
+                    SummitScopes::WriteSummitData,
+                ],
+                'authz_groups' => [
+                    IGroup::SuperAdmins,
+                    IGroup::Administrators,
+                    IGroup::SummitAdministrators,
+                ]
+            ],
             //
             [
                 'name' => 'add-sponsor-user',

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -175,6 +175,17 @@ Route::group(array('prefix' => 'summits'), function () {
     Route::group(['prefix' => 'all'], function () {
 
         Route::get('', 'OAuth2SummitApiController@getAllSummits');
+
+        Route::group(['prefix' => 'add-on-types'], function () {
+            Route::get('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitSponsorshipAddOnTypesApiController@getAll']);
+            Route::post('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitSponsorshipAddOnTypesApiController@add']);
+            Route::group(['prefix' => '{id}'], function () {
+                Route::get('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitSponsorshipAddOnTypesApiController@get']);
+                Route::put('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitSponsorshipAddOnTypesApiController@update']);
+                Route::delete('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitSponsorshipAddOnTypesApiController@delete']);
+            });
+        });
+
         Route::group(['prefix' => '{id}'], function () {
             Route::get('', 'OAuth2SummitApiController@getAllSummitByIdOrSlug');
             Route::group(['prefix' => 'registration-stats'], function () {
@@ -239,6 +250,7 @@ Route::group(array('prefix' => 'summits'), function () {
             });
 
         });
+
     });
 
     Route::post('', ['middleware' => 'auth.user', 'uses' => 'OAuth2SummitApiController@addSummit']);

--- a/tests/InsertSummitTestData.php
+++ b/tests/InsertSummitTestData.php
@@ -68,6 +68,7 @@ use models\summit\SummitRegistrationDiscountCode;
 use models\summit\SummitRegistrationPromoCode;
 use models\summit\SummitSponsorship;
 use models\summit\SummitSponsorshipAddOn;
+use models\summit\SummitSponsorshipAddOnType;
 use models\summit\SummitSponsorshipType;
 use models\summit\SummitTicketType;
 use models\summit\SummitVenue;
@@ -255,6 +256,16 @@ trait InsertSummitTestData
      * @var SummitSponsorshipType
      */
     static $default_summit_sponsor_type2;
+
+    /**
+     * @var SummitSponsorshipAddOnType
+     */
+    static $default_add_on_type_booth;
+
+    /**
+     * @var SummitSponsorshipAddOnType
+     */
+    static $default_add_on_type_meeting_room;
 
     /**
      * @var array | SummitTicketType
@@ -837,6 +848,14 @@ trait InsertSummitTestData
         self::$default_summit_sponsor_type2->setType(self::$default_sponsor_ship_type2);
         self::$summit->addSponsorshipType(self::$default_summit_sponsor_type2);
 
+        self::$default_add_on_type_booth = new SummitSponsorshipAddOnType();
+        self::$default_add_on_type_booth->setName('Booth_' . str_random(6));
+        self::$em->persist(self::$default_add_on_type_booth);
+
+        self::$default_add_on_type_meeting_room = new SummitSponsorshipAddOnType();
+        self::$default_add_on_type_meeting_room->setName('Meeting_Room_' . str_random(6));
+        self::$em->persist(self::$default_add_on_type_meeting_room);
+
         self::$companies = [];
         self::$sponsors = [];
         for($i = 0 ; $i < 20; $i++){
@@ -876,7 +895,7 @@ trait InsertSummitTestData
 
             for($j = 0; $j < 5; $j ++){
                 $a = new SummitSponsorshipAddOn();
-                $a->setType($j < 3 ? SummitSponsorshipAddOn::Booth_Type : SummitSponsorshipAddOn::MeetingRoom_Type);
+                $a->setType($j < 3 ? self::$default_add_on_type_booth : self::$default_add_on_type_meeting_room);
                 $a->setName(sprintf("AddOn %s %s", $j, str_random(4)));
                 $sps->addAddOn($a);
                 self::$em->persist($a);
@@ -1011,6 +1030,16 @@ trait InsertSummitTestData
         if (!is_null(self::$default_media_file_type)) {
             self::$em->remove(self::$default_media_file_type);
         }
+        if (!is_null(self::$default_add_on_type_booth)) {
+            self::$default_add_on_type_booth = self::$em->find(SummitSponsorshipAddOnType::class, self::$default_add_on_type_booth->getId());
+            if (!is_null(self::$default_add_on_type_booth))
+                self::$em->remove(self::$default_add_on_type_booth);
+        }
+        if (!is_null(self::$default_add_on_type_meeting_room)) {
+            self::$default_add_on_type_meeting_room = self::$em->find(SummitSponsorshipAddOnType::class, self::$default_add_on_type_meeting_room->getId());
+            if (!is_null(self::$default_add_on_type_meeting_room))
+                self::$em->remove(self::$default_add_on_type_meeting_room);
+        }
         self::$em->flush();
 
         // reset static vars
@@ -1018,6 +1047,8 @@ trait InsertSummitTestData
         self::$summit = null;
         self::$default_badge_type = null;
         self::$summit2 = null;
+        self::$default_add_on_type_booth = null;
+        self::$default_add_on_type_meeting_room = null;
         self::$mainVenue = null;
         self::$defaultTags = [];
         self::$ticket_types = [];

--- a/tests/Unit/Entities/SummitSponsorshipTest.php
+++ b/tests/Unit/Entities/SummitSponsorshipTest.php
@@ -17,6 +17,7 @@ namespace Tests\Unit\Entities;
 
 use models\summit\SummitSponsorship;
 use models\summit\SummitSponsorshipAddOn;
+use models\summit\SummitSponsorshipAddOnType;
 use models\summit\SummitSponsorshipType;
 use Tests\InsertSummitTestData;
 use Tests\TestCase;
@@ -62,7 +63,7 @@ class SummitSponsorshipTest extends TestCase
         // Create a new add-on
         $add_on = new SummitSponsorshipAddOn();
         $add_on->setName("Test Add-On " . str_random(5));
-        $add_on->setType(SummitSponsorshipAddOn::Booth_Type);
+        $add_on->setType(self::$default_add_on_type_booth);
         self::$em->persist($add_on);
         
         // Add the add-on (OneToMany relationship)
@@ -118,7 +119,7 @@ class SummitSponsorshipTest extends TestCase
         // Create a new add-on
         $add_on = new SummitSponsorshipAddOn();
         $add_on->setName("Test Add-On " . str_random(5));
-        $add_on->setType(SummitSponsorshipAddOn::Booth_Type);
+        $add_on->setType(self::$default_add_on_type_booth);
         self::$em->persist($add_on);
         
         // Add the add-on (OneToMany relationship)

--- a/tests/oauth2/OAuth2SummitSponsorshipAddOnTypesApiControllerTest.php
+++ b/tests/oauth2/OAuth2SummitSponsorshipAddOnTypesApiControllerTest.php
@@ -227,6 +227,24 @@ final class OAuth2SummitSponsorshipAddOnTypesApiControllerTest extends Protected
         $this->assertEquals($new_name, $type->name);
     }
 
+    public function testUpdateWithEmptyName(): void
+    {
+        $params = ['id' => self::$default_type->getId()];
+
+        $this->action(
+            "PUT",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@update",
+            $params,
+            [],
+            [],
+            [],
+            $this->getAuthHeaders(),
+            json_encode(['name' => ''])
+        );
+
+        $this->assertResponseStatus(412);
+    }
+
     public function testUpdateNotFound(): void
     {
         $params = ['id' => PHP_INT_MAX];

--- a/tests/oauth2/OAuth2SummitSponsorshipAddOnTypesApiControllerTest.php
+++ b/tests/oauth2/OAuth2SummitSponsorshipAddOnTypesApiControllerTest.php
@@ -1,0 +1,299 @@
+<?php
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use LaravelDoctrine\ORM\Facades\Registry;
+use models\summit\SummitSponsorshipAddOnType;
+use models\utils\SilverstripeBaseModel;
+use Tests\InsertSummitTestData;
+use Tests\ProtectedApiTestCase;
+
+/**
+ * Class OAuth2SummitSponsorshipAddOnTypesApiControllerTest
+ */
+final class OAuth2SummitSponsorshipAddOnTypesApiControllerTest extends ProtectedApiTestCase
+{
+    use InsertSummitTestData;
+
+    private static ?SummitSponsorshipAddOnType $default_type = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::insertSummitTestData();
+
+        self::$default_type = new SummitSponsorshipAddOnType();
+        self::$default_type->setName('Test_Type_' . str_random(6));
+        self::$em->persist(self::$default_type);
+        self::$em->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        if (!is_null(self::$default_type)) {
+            $em = self::$em->isOpen()
+                ? self::$em
+                : Registry::resetManager(SilverstripeBaseModel::EntityManager);
+
+            $type = $em->find(SummitSponsorshipAddOnType::class, self::$default_type->getId());
+            if (!is_null($type)) {
+                $em->remove($type);
+                $em->flush();
+            }
+            self::$default_type = null;
+        }
+        self::clearSummitTestData();
+        parent::tearDown();
+    }
+
+    public function testGetAll(): void
+    {
+        $response = $this->action(
+            "GET",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@getAll",
+            [],
+            [],
+            [],
+            [],
+            $this->getAuthHeaders()
+        );
+
+        $content = $response->getContent();
+        $this->assertResponseStatus(200);
+        $page = json_decode($content);
+        $this->assertNotNull($page);
+        $this->assertNotEmpty($page->data);
+    }
+
+    public function testGetAllFilterByName(): void
+    {
+        $params = [
+            'filter' => ['name==' . self::$default_type->getName()],
+        ];
+
+        $response = $this->action(
+            "GET",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@getAll",
+            $params,
+            [],
+            [],
+            [],
+            $this->getAuthHeaders()
+        );
+
+        $content = $response->getContent();
+        $this->assertResponseStatus(200);
+        $page = json_decode($content);
+        $this->assertNotNull($page);
+        $this->assertCount(1, $page->data);
+        $this->assertEquals(self::$default_type->getName(), $page->data[0]->name);
+    }
+
+    public function testGet(): void
+    {
+        $params = ['id' => self::$default_type->getId()];
+
+        $response = $this->action(
+            "GET",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@get",
+            $params,
+            [],
+            [],
+            [],
+            $this->getAuthHeaders()
+        );
+
+        $content = $response->getContent();
+        $this->assertResponseStatus(200);
+        $type = json_decode($content);
+        $this->assertNotNull($type);
+        $this->assertEquals(self::$default_type->getId(), $type->id);
+        $this->assertEquals(self::$default_type->getName(), $type->name);
+    }
+
+    public function testGetNotFound(): void
+    {
+        $params = ['id' => PHP_INT_MAX];
+
+        $this->action(
+            "GET",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@get",
+            $params,
+            [],
+            [],
+            [],
+            $this->getAuthHeaders()
+        );
+
+        $this->assertResponseStatus(404);
+    }
+
+    public function testAdd(): void
+    {
+        $data = [
+            'name' => 'New_Type_' . str_random(6),
+        ];
+
+        $response = $this->action(
+            "POST",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@add",
+            [],
+            [],
+            [],
+            [],
+            $this->getAuthHeaders(),
+            json_encode($data)
+        );
+
+        $content = $response->getContent();
+        $this->assertResponseStatus(201);
+        $type = json_decode($content);
+        $this->assertNotNull($type);
+        $this->assertEquals($data['name'], $type->name);
+    }
+
+    public function testAddDuplicateName(): void
+    {
+        $data = [
+            'name' => self::$default_type->getName(),
+        ];
+
+        $this->action(
+            "POST",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@add",
+            [],
+            [],
+            [],
+            [],
+            $this->getAuthHeaders(),
+            json_encode($data)
+        );
+
+        $this->assertResponseStatus(412);
+    }
+
+    public function testAddMissingName(): void
+    {
+        $data = [];
+
+        $this->action(
+            "POST",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@add",
+            [],
+            [],
+            [],
+            [],
+            $this->getAuthHeaders(),
+            json_encode($data)
+        );
+
+        $this->assertResponseStatus(412);
+    }
+
+    public function testUpdate(): void
+    {
+        $params   = ['id' => self::$default_type->getId()];
+        $new_name = 'Updated_Type_' . str_random(4);
+
+        $data = [
+            'name' => $new_name,
+        ];
+
+        $response = $this->action(
+            "PUT",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@update",
+            $params,
+            [],
+            [],
+            [],
+            $this->getAuthHeaders(),
+            json_encode($data)
+        );
+
+        $content = $response->getContent();
+        $this->assertResponseStatus(201);
+        $type = json_decode($content);
+        $this->assertNotNull($type);
+        $this->assertEquals($new_name, $type->name);
+    }
+
+    public function testUpdateNotFound(): void
+    {
+        $params = ['id' => PHP_INT_MAX];
+
+        $this->action(
+            "PUT",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@update",
+            $params,
+            [],
+            [],
+            [],
+            $this->getAuthHeaders(),
+            json_encode(['name' => 'irrelevant'])
+        );
+
+        $this->assertResponseStatus(404);
+    }
+
+    public function testDelete(): void
+    {
+        $params = ['id' => self::$default_type->getId()];
+
+        $this->action(
+            "DELETE",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@delete",
+            $params,
+            [],
+            [],
+            [],
+            $this->getAuthHeaders()
+        );
+
+        $this->assertResponseStatus(204);
+        self::$default_type = null;
+    }
+
+    public function testDeleteNotFound(): void
+    {
+        $params = ['id' => PHP_INT_MAX];
+
+        $this->action(
+            "DELETE",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@delete",
+            $params,
+            [],
+            [],
+            [],
+            $this->getAuthHeaders()
+        );
+
+        $this->assertResponseStatus(404);
+    }
+
+    public function testDeleteInUse(): void
+    {
+        $params = ['id' => self::$default_add_on_type_booth->getId()];
+
+        $this->action(
+            "DELETE",
+            "OAuth2SummitSponsorshipAddOnTypesApiController@delete",
+            $params,
+            [],
+            [],
+            [],
+            $this->getAuthHeaders()
+        );
+
+        $this->assertResponseStatus(412);
+    }
+}

--- a/tests/oauth2/OAuth2SummitSponsorshipApiControllerTest.php
+++ b/tests/oauth2/OAuth2SummitSponsorshipApiControllerTest.php
@@ -144,7 +144,8 @@ final class OAuth2SummitSponsorshipApiControllerTest
             'id' => self::$summit->getId(),
             'sponsor_id' => self::$sponsors[0]->getId(),
             'sponsorship_id' => self::$sponsors[0]->getSponsorships()[0]->getId(),
-            'filter' => ['type==Booth'],
+            'filter' => ['type=@Booth'],
+            'expand' => 'type'
         ];
 
         $response = $this->action(
@@ -321,4 +322,5 @@ final class OAuth2SummitSponsorshipApiControllerTest
         $metadata = json_decode($content);
         $this->assertNotNull($metadata);
     }
+
 }


### PR DESCRIPTION
ref https://app.clickup.com/t/86b9rdth6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full CRUD for sponsorship add-on types at `/api/v1/summits/all/add-on-types` (OAuth2-protected: list, create, retrieve by id, update, delete).
* **Refactor**
  * Sponsorship add-ons now represent the add-on type via numeric `type_id` (with optional `type` expansion); add-on listings return only `id` and `name`, with updated filter/sort behavior.
* **Bug Fixes**
  * Reject requests that specify both `type_id` and `type` together.
  * Enforce add-on type name uniqueness; block deleting a type when it’s referenced.
* **Tests**
  * Added and updated API/controller test coverage for the new endpoints and validation/filter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->