### PR TITLE
feat: async file post-processing pipeline for company logos

### DIFF
--- a/Libs/Utils/FileUtils.php
+++ b/Libs/Utils/FileUtils.php
@@ -62,7 +62,10 @@ trait FileUtils{
         stream_set_blocking($stream, true);
         @stream_set_read_buffer($stream, 0);
 
-        $localPath = rtrim(self::getLocalTmpStorage(), '/')."/".$file_name;
+        $localPath = tempnam(self::getLocalTmpStorage(), 'fproc_');
+        if ($localPath === false) {
+            throw new ValidationException("Unable to create local temporary file.");
+        }
 
         $out = fopen($localPath, 'wb'); // binary mode
         if ($out === false) {

--- a/Libs/Utils/FileUtils.php
+++ b/Libs/Utils/FileUtils.php
@@ -70,6 +70,7 @@ trait FileUtils{
         $out = fopen($localPath, 'wb'); // binary mode
         if ($out === false) {
             fclose($stream);
+            @unlink($localPath);
             throw new ValidationException("Unable to open local temp file for writing: {$localPath}");
         }
         stream_set_blocking($out, true);

--- a/Libs/Utils/FileUtils.php
+++ b/Libs/Utils/FileUtils.php
@@ -137,4 +137,17 @@ trait FileUtils{
         Log::debug(sprintf("cleanLocalFile deleting local file %s", $localPath));
         unlink($localPath);
     }
+
+    /**
+     * Deletes only the local temp file. Use in finally blocks where the remote
+     * file must be preserved on failure so queue job retries can re-download it.
+     * @param string $localPath
+     * @return void
+     */
+    public static function cleanLocalFile(string $localPath): void {
+        if (file_exists($localPath)) {
+            Log::debug(sprintf("FileUtils::cleanLocalFile deleting local temp file %s", $localPath));
+            @unlink($localPath);
+        }
+    }
 }

--- a/Libs/Utils/FileUtils.php
+++ b/Libs/Utils/FileUtils.php
@@ -118,7 +118,7 @@ trait FileUtils{
                 );
             }
         } catch (\Throwable $e) {
-          throw new ValidationException($e->getMessage());
+          throw new ValidationException($e->getMessage(), 0, $e);
         }
 
         return $localPath;

--- a/app/Http/Controllers/Apis/Protected/Main/Factories/CompanyValidationRulesFactory.php
+++ b/app/Http/Controllers/Apis/Protected/Main/Factories/CompanyValidationRulesFactory.php
@@ -69,6 +69,20 @@ final class CompanyValidationRulesFactory
             'overview' => 'nullable|string',
             'commitment' => 'nullable|string',
             'commitment_author' => 'nullable|string',
+            'big_logo' => 'sometimes|file_dto',
+            'logo' =>'sometimes|file_dto',
+        ];
+    }
+
+
+    public static function buildForFileInfo(): array {
+        return [
+            'filepath' => 'required|string',
+            'filename' => 'required|string',
+            'md5' => 'required|string',
+            'size' => 'required|integer',
+            'mime_type'=> 'sometimes|string',
+            'source_bucket' => 'sometimes|string',
         ];
     }
 }

--- a/app/Http/Controllers/Apis/Protected/Main/Factories/CompanyValidationRulesFactory.php
+++ b/app/Http/Controllers/Apis/Protected/Main/Factories/CompanyValidationRulesFactory.php
@@ -12,6 +12,7 @@
  * limitations under the License.
  **/
 
+use App\Services\Model\FileInfoDTO;
 
 /**
  * Class CompanyValidationRulesFactory
@@ -76,13 +77,6 @@ final class CompanyValidationRulesFactory
 
 
     public static function buildForFileInfo(): array {
-        return [
-            'filepath' => 'required|string',
-            'filename' => 'required|string',
-            'md5' => 'required|string',
-            'size' => 'required|integer',
-            'mime_type'=> 'sometimes|string',
-            'source_bucket' => 'sometimes|string',
-        ];
+        return FileInfoDTO::validationRules();
     }
 }

--- a/app/Http/Controllers/Apis/Protected/Main/OAuth2CompaniesApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Main/OAuth2CompaniesApiController.php
@@ -19,10 +19,12 @@ use App\Models\Foundation\Main\IGroup;
 use App\Rules\Boolean;
 use App\Security\CompanyScopes;
 use App\Security\SummitScopes;
+use App\Services\Model\FileInfoDTO;
 use App\Services\Model\ICompanyService;
 use Illuminate\Http\Request as LaravelRequest;
 use Illuminate\Http\Response;
 use models\exceptions\ValidationException;
+use models\main\Company;
 use models\main\ICompanyRepository;
 use models\oauth2\IResourceServerContext;
 use models\utils\IEntity;
@@ -505,7 +507,7 @@ final class OAuth2CompaniesApiController extends OAuth2ProtectedController
         path: "/api/v1/companies/{id}/logo",
         operationId: "addCompanyLogo",
         summary: "Add company logo",
-        description: "Uploads a logo image for the company",
+        description: "Uploads a logo image for the company. Accepts either a multipart file upload or a JSON payload referencing a file already stored in the file API.",
         security: [
             [
                 "companies_oauth2" => [
@@ -531,20 +533,36 @@ final class OAuth2CompaniesApiController extends OAuth2ProtectedController
         ],
         requestBody: new OA\RequestBody(
             required: true,
-            content: new OA\MediaType(
-                mediaType: "multipart/form-data",
-                schema: new OA\Schema(
-                    required: ["file"],
-                    properties: [
-                        new OA\Property(
-                            property: "file",
-                            type: "string",
-                            format: "binary",
-                            description: "Logo image file"
-                        )
-                    ]
-                )
-            )
+            content: [
+                new OA\MediaType(
+                    mediaType: "multipart/form-data",
+                    schema: new OA\Schema(
+                        required: ["file"],
+                        properties: [
+                            new OA\Property(
+                                property: "file",
+                                type: "string",
+                                format: "binary",
+                                description: "Logo image file"
+                            )
+                        ]
+                    )
+                ),
+                new OA\MediaType(
+                    mediaType: "application/json",
+                    schema: new OA\Schema(
+                        required: ["filepath", "filename", "md5", "size"],
+                        properties: [
+                            new OA\Property(property: "filepath", type: "string", description: "Remote storage path of the uploaded file"),
+                            new OA\Property(property: "filename", type: "string", description: "Original file name"),
+                            new OA\Property(property: "md5", type: "string", description: "MD5 hash of the file for integrity verification"),
+                            new OA\Property(property: "size", type: "integer", description: "File size in bytes"),
+                            new OA\Property(property: "mime_type", type: "string", description: "MIME type of the file"),
+                            new OA\Property(property: "source_bucket", type: "string", description: "Source storage bucket"),
+                        ]
+                    )
+                ),
+            ]
         ),
         responses: [
             new OA\Response(
@@ -556,7 +574,6 @@ final class OAuth2CompaniesApiController extends OAuth2ProtectedController
             new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
             new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
             new OA\Response(response: Response::HTTP_NOT_FOUND, description: "Company not found"),
-            new OA\Response(response: Response::HTTP_PRECONDITION_FAILED, description: "File parameter not set"),
         ]
     )]
     public function addCompanyLogo(LaravelRequest $request, $company_id)
@@ -564,12 +581,26 @@ final class OAuth2CompaniesApiController extends OAuth2ProtectedController
         return $this->processRequest(function () use ($request, $company_id) {
 
             $file = $request->file('file');
-            if (is_null($file)) {
-                return $this->error412(array('file param not set!'));
+            if (!is_null($file)) {
+                $logo = $this->service->addCompanyLogo(intval($company_id), $file);
+
+                return $this->created(SerializerRegistry::getInstance()->getSerializer($logo)->serialize());
             }
 
-            $logo = $this->service->addCompanyLogo(intval($company_id), $file);
+            // file api post processing ( new flow )
+            $payload = $this->getJsonPayload(CompanyValidationRulesFactory::buildForFileInfo());
 
+            $logo = $this->service->processFileForChildEntity(new FileInfoDTO(
+                owner_entity_id: intval($company_id),
+                owner_entity_class: Company::class,
+                owner_member_name: 'logo',
+                filepath: $payload['filepath'],
+                filename: $payload['filename'],
+                size: intval($payload['size']),
+                md5: $payload['md5'] ?? null,
+                mime_type: $payload['mime_type'] ?? null,
+                source_bucket: $payload['source_bucket'] ?? null,
+            ));
             return $this->created(SerializerRegistry::getInstance()->getSerializer($logo)->serialize());
         });
     }
@@ -624,7 +655,7 @@ final class OAuth2CompaniesApiController extends OAuth2ProtectedController
         path: "/api/v1/companies/{id}/logo/big",
         operationId: "addCompanyBigLogo",
         summary: "Add company big logo",
-        description: "Uploads a big logo image for the company",
+        description: "Uploads a big logo image for the company. Accepts either a multipart file upload or a JSON payload referencing a file already stored in the file API.",
         security: [
             [
                 "companies_oauth2" => [
@@ -650,20 +681,36 @@ final class OAuth2CompaniesApiController extends OAuth2ProtectedController
         ],
         requestBody: new OA\RequestBody(
             required: true,
-            content: new OA\MediaType(
-                mediaType: "multipart/form-data",
-                schema: new OA\Schema(
-                    required: ["file"],
-                    properties: [
-                        new OA\Property(
-                            property: "file",
-                            type: "string",
-                            format: "binary",
-                            description: "Big logo image file"
-                        )
-                    ]
-                )
-            )
+            content: [
+                new OA\MediaType(
+                    mediaType: "multipart/form-data",
+                    schema: new OA\Schema(
+                        required: ["file"],
+                        properties: [
+                            new OA\Property(
+                                property: "file",
+                                type: "string",
+                                format: "binary",
+                                description: "Big logo image file"
+                            )
+                        ]
+                    )
+                ),
+                new OA\MediaType(
+                    mediaType: "application/json",
+                    schema: new OA\Schema(
+                        required: ["filepath", "filename", "md5", "size"],
+                        properties: [
+                            new OA\Property(property: "filepath", type: "string", description: "Remote storage path of the uploaded file"),
+                            new OA\Property(property: "filename", type: "string", description: "Original file name"),
+                            new OA\Property(property: "md5", type: "string", description: "MD5 hash of the file for integrity verification"),
+                            new OA\Property(property: "size", type: "integer", description: "File size in bytes"),
+                            new OA\Property(property: "mime_type", type: "string", description: "MIME type of the file"),
+                            new OA\Property(property: "source_bucket", type: "string", description: "Source storage bucket"),
+                        ]
+                    )
+                ),
+            ]
         ),
         responses: [
             new OA\Response(
@@ -675,19 +722,31 @@ final class OAuth2CompaniesApiController extends OAuth2ProtectedController
             new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
             new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
             new OA\Response(response: Response::HTTP_NOT_FOUND, description: "Company not found"),
-            new OA\Response(response: Response::HTTP_PRECONDITION_FAILED, description: "File parameter not set"),
         ]
     )]
     public function addCompanyBigLogo(LaravelRequest $request, $company_id)
     {
         return $this->processRequest(function () use ($request, $company_id) {
             $file = $request->file('file');
-            if (is_null($file)) {
-                return $this->error412(array('file param not set!'));
+            if (!is_null($file)) {
+                $logo = $this->service->addCompanyBigLogo(intval($company_id), $file);
+                return $this->created(SerializerRegistry::getInstance()->getSerializer($logo)->serialize());
             }
 
-            $logo = $this->service->addCompanyBigLogo(intval($company_id), $file);
+            // file api post processing ( new flow )
+            $payload = $this->getJsonPayload(CompanyValidationRulesFactory::buildForFileInfo());
 
+            $logo = $this->service->processFileForChildEntity(new FileInfoDTO(
+                owner_entity_id: intval($company_id),
+                owner_entity_class: Company::class,
+                owner_member_name: 'big_logo',
+                filepath: $payload['filepath'],
+                filename: $payload['filename'],
+                size: intval($payload['size']),
+                md5: $payload['md5'] ?? null,
+                mime_type: $payload['mime_type'] ?? null,
+                source_bucket: $payload['source_bucket'] ?? null,
+            ));
             return $this->created(SerializerRegistry::getInstance()->getSerializer($logo)->serialize());
         });
     }

--- a/app/Http/Utils/FileUploadInfo.php
+++ b/app/Http/Utils/FileUploadInfo.php
@@ -47,19 +47,32 @@ final class FileUploadInfo
      */
     private $filePath;
 
+    private $md5;
+
+    private $mime_type;
+
+    private $source_bucket;
+
     /**
      * @param $file
      * @param $fileName
      * @param $fileExt
      * @param $filePath
      * @param $size
+     * @param $md5
+     * @param $mime_type
+     * @param $source_bucket
      */
     private function __construct(
         $file,
         $fileName,
         $fileExt,
         $filePath,
-        $size
+        $size,
+        $md5 = null,
+        $mime_type = null,
+        $source_bucket = null,
+
     )
     {
         $this->file = $file;
@@ -67,6 +80,9 @@ final class FileUploadInfo
         $this->fileExt = $fileExt;
         $this->size = $size;
         $this->filePath = $filePath;
+        $this->md5 = $md5;
+        $this->mime_type = $mime_type;
+        $this->source_bucket = $source_bucket;
     }
 
     public static function getStorageDriver():string{
@@ -103,23 +119,8 @@ final class FileUploadInfo
             $fileExt = pathinfo($fileName, PATHINFO_EXTENSION);
         }
 
-        if(is_null($file) && isset($payload['filepath']) && !empty($payload['filepath'])){
-            Log::debug(sprintf("FileUploadInfo::build build file is present on as %s storage (%s)", self::getStorageDriver(), $payload['filepath']));
-            $disk = Storage::disk(self::getStorageDriver());
-
-            if(!$disk->exists($payload['filepath']))
-                throw new ValidationException(sprintf("file provide on filepath %s does not exists on %s storage.", self::getStorageDriver(), $payload['filepath']));
-
-            // get in bytes should be converted to KB
-            $size = $disk->size($payload['filepath']);
-            Log::debug(sprintf("FileUploadInfo::build build file %s storage (%s) size %s", self::getStorageDriver(), $payload['filepath'], $size));
-            if($size == 0)
-                throw new ValidationException("File size is zero.");
-
-            $filePath = $payload['filepath'];
-            $fileName = pathinfo($payload['filepath'],PATHINFO_BASENAME);
-            $fileExt = pathinfo($fileName, PATHINFO_EXTENSION);
-            $file = self::isLocal() ? new UploadedFile($disk->path($payload['filepath']), $fileName): null;
+        if(is_null($file)){
+            return self::buildFromPayload($payload);
         }
 
         $fileName = $fileName && !empty($fileName) ? FileNameSanitizer::sanitize($fileName) : $fileName;
@@ -127,6 +128,50 @@ final class FileUploadInfo
         if(empty($filePath)) return null;
 
         return new self($file, $fileName, $fileExt, $filePath, $size);
+    }
+
+    public static function buildFromPayload(array $payload):?FileUploadInfo{
+        $filepath = null;
+        $filename = null;
+        $md5 = null;
+        $size = 0;
+        $mime_type = null;
+        $source_bucket = null;
+        $fileExt = null;
+        $file = null;
+        if(isset($payload['filepath']) && !empty($payload['filepath'])){
+            $filepath = trim($payload['filepath']);
+            Log::debug(sprintf("FileUploadInfo::buildFromPayload file is present on as %s storage (%s)", self::getStorageDriver(), $filepath));
+            $disk = Storage::disk(self::getStorageDriver());
+
+            if(!$disk->exists($payload['filepath'])) {
+                Log::warning(sprintf("FileUploadInfo::buildFromPayload file %s is not present at storage (%s)", self::getStorageDriver(), $filepath));
+                throw new ValidationException(sprintf("file provide on filepath %s does not exists on %s storage.", self::getStorageDriver(), $filepath));
+            }
+
+            // get in bytes should be converted to KB
+            $size = isset($payload['size']) ? intval($payload['size']): $disk->size($filepath);
+
+            Log::debug(sprintf("FileUploadInfo::buildFromPayload file %s storage (%s) size %s", self::getStorageDriver(), $payload['filepath'], $size));
+            if($size == 0) {
+                Log::warning(sprintf("FileUploadInfo::buildFromPayload file %s size is zero", $filepath));
+                throw new ValidationException("File size is zero.");
+            }
+
+
+            $filename = isset($payload['filename']) ? trim($payload['filename']): pathinfo($filepath, PATHINFO_BASENAME);
+            $md5 = isset($payload['md5']) ? trim($payload['md5']) : null;
+            $mime_type= isset($payload['mime_type']) ? trim($payload['mime_type']) : null;
+            $source_bucket =  isset($payload['source_bucket']) ? trim($payload['source_bucket']) : null;
+            $fileExt = pathinfo($filename, PATHINFO_EXTENSION);
+            $file = self::isLocal() ? new UploadedFile($disk->path($payload['filepath']), $filename): null;
+        }
+
+        $filename = $filename && !empty($filename) ? FileNameSanitizer::sanitize($filename) : $filename;
+
+        if(empty($filename) || empty($filepath)) return null;
+
+        return new self(null, $filename, $fileExt, $filepath, $size, $md5, $mime_type, $source_bucket);
     }
 
     /**
@@ -175,9 +220,26 @@ final class FileUploadInfo
         Log::debug(sprintf("FileUploadInfo::delete deleting file %s", $realPath));
     }
 
+    public function getMd5(): ?string
+    {
+        return $this->md5;
+    }
+
+    public function getMimeType(): ?string
+    {
+        return $this->mime_type;
+    }
+
+    public function getSourceBucket(): ?string
+    {
+        return $this->source_bucket;
+    }
+
     public function getFilePath(): ?string
     {
         return $this->filePath;
     }
+
+
 
 }

--- a/app/Http/Utils/FileUploadInfo.php
+++ b/app/Http/Utils/FileUploadInfo.php
@@ -144,15 +144,15 @@ final class FileUploadInfo
             Log::debug(sprintf("FileUploadInfo::buildFromPayload file is present on as %s storage (%s)", self::getStorageDriver(), $filepath));
             $disk = Storage::disk(self::getStorageDriver());
 
-            if(!$disk->exists($payload['filepath'])) {
+            if(!$disk->exists($filepath)) {
                 Log::warning(sprintf("FileUploadInfo::buildFromPayload file %s is not present at storage (%s)", self::getStorageDriver(), $filepath));
                 throw new ValidationException(sprintf("file provide on filepath %s does not exists on %s storage.", self::getStorageDriver(), $filepath));
             }
 
-            // get in bytes should be converted to KB
-            $size = isset($payload['size']) ? intval($payload['size']): $disk->size($filepath);
+            // Always retrieve the actual size from storage; never trust client-provided value.
+            $size = $disk->size($filepath);
 
-            Log::debug(sprintf("FileUploadInfo::buildFromPayload file %s storage (%s) size %s", self::getStorageDriver(), $payload['filepath'], $size));
+            Log::debug(sprintf("FileUploadInfo::buildFromPayload file %s storage (%s) size %s", self::getStorageDriver(), $filepath, $size));
             if($size == 0) {
                 Log::warning(sprintf("FileUploadInfo::buildFromPayload file %s size is zero", $filepath));
                 throw new ValidationException("File size is zero.");
@@ -164,7 +164,7 @@ final class FileUploadInfo
             $mime_type= isset($payload['mime_type']) ? trim($payload['mime_type']) : null;
             $source_bucket =  isset($payload['source_bucket']) ? trim($payload['source_bucket']) : null;
             $fileExt = pathinfo($filename, PATHINFO_EXTENSION);
-            $file = self::isLocal() ? new UploadedFile($disk->path($payload['filepath']), $filename): null;
+            $file = self::isLocal() ? new UploadedFile($disk->path($filepath), $filename): null;
         }
 
         $filename = $filename && !empty($filename) ? FileNameSanitizer::sanitize($filename) : $filename;

--- a/app/Jobs/FileProcessingJob.php
+++ b/app/Jobs/FileProcessingJob.php
@@ -28,6 +28,10 @@ class FileProcessingJob implements ShouldQueue
 
     public $timeout = 600;
 
+    public function backoff(): array {
+        return [30, 60];
+    }
+
 
     public function __construct(
         public readonly FileInfoDTO $fileInfoDTO,

--- a/app/Jobs/FileProcessingJob.php
+++ b/app/Jobs/FileProcessingJob.php
@@ -38,10 +38,13 @@ class FileProcessingJob implements ShouldQueue
     ) {}
 
     public function handle(IFilePostProcessorService $service){
-        $result = $service->postProcessFileFromFileApi($this->fileInfoDTO);
-        if (!$result) {
-            throw new \RuntimeException(sprintf("FileProcessingJob: postProcessFileFromFileApi returned false for %s", $this->fileInfoDTO));
+        try {
+            $service->postProcessFileFromFileApi($this->fileInfoDTO);
+        } catch (\InvalidArgumentException $ex) {
+            // Unrecoverable: unknown entity class or member - fail immediately, no retry
+            $this->fail($ex);
         }
+        // All other exceptions propagate so the queue retries (up to $tries times)
     }
 
     public function failed(\Throwable $exception)

--- a/app/Jobs/FileProcessingJob.php
+++ b/app/Jobs/FileProcessingJob.php
@@ -1,0 +1,44 @@
+<?php namespace App\Jobs;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+use App\Services\Model\FileInfoDTO;
+use App\Services\Model\IFilePostProcessorService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class FileProcessingJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $tries = 3;
+
+    public $timeout = 600;
+
+
+    public function __construct(
+        public readonly FileInfoDTO $fileInfoDTO,
+    ) {}
+
+    public function handle(IFilePostProcessorService $service){
+        $service->postProcessFileFromFileApi($this->fileInfoDTO);
+    }
+
+    public function failed(\Throwable $exception)
+    {
+        Log::error(sprintf( "FileProcessingJob::failed %s", $exception->getMessage()));
+    }
+}

--- a/app/Jobs/FileProcessingJob.php
+++ b/app/Jobs/FileProcessingJob.php
@@ -19,6 +19,8 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use models\exceptions\EntityNotFoundException;
+use models\exceptions\ValidationException;
 
 class FileProcessingJob implements ShouldQueue
 {
@@ -40,11 +42,12 @@ class FileProcessingJob implements ShouldQueue
     public function handle(IFilePostProcessorService $service){
         try {
             $service->postProcessFileFromFileApi($this->fileInfoDTO);
-        } catch (\InvalidArgumentException $ex) {
-            // Unrecoverable: unknown entity class or member - fail immediately, no retry
+        } catch (\InvalidArgumentException | ValidationException | EntityNotFoundException $ex) {
+            // Unrecoverable: bad config, data integrity failure (MD5 mismatch, zero-size file),
+            // or entity not found. The file content won't change between retries, so fail immediately.
             $this->fail($ex);
         }
-        // All other exceptions propagate so the queue retries (up to $tries times)
+        // Network/DB errors propagate so the queue retries (up to $tries times)
     }
 
     public function failed(\Throwable $exception)

--- a/app/Jobs/FileProcessingJob.php
+++ b/app/Jobs/FileProcessingJob.php
@@ -34,7 +34,10 @@ class FileProcessingJob implements ShouldQueue
     ) {}
 
     public function handle(IFilePostProcessorService $service){
-        $service->postProcessFileFromFileApi($this->fileInfoDTO);
+        $result = $service->postProcessFileFromFileApi($this->fileInfoDTO);
+        if (!$result) {
+            throw new \RuntimeException(sprintf("FileProcessingJob: postProcessFileFromFileApi returned false for %s", $this->fileInfoDTO));
+        }
     }
 
     public function failed(\Throwable $exception)

--- a/app/Models/Foundation/Main/Companies/Company.php
+++ b/app/Models/Foundation/Main/Companies/Company.php
@@ -25,6 +25,7 @@ use Doctrine\ORM\Mapping AS ORM;
 #[ORM\Cache(usage: 'NONSTRICT_READ_WRITE', region: 'sponsors_region')] // Class Company
 class Company extends SilverstripeBaseModel
 {
+    public const LogoAllowedExtensions = ['png', 'jpg', 'jpeg', 'svg'];
     /**
      * @var string
      */

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,6 +13,7 @@
  **/
 
 use App\Http\Utils\Logs\LaravelMailerHandler;
+use App\Services\Model\FileInfoDTO;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
@@ -187,25 +188,6 @@ class AppServiceProvider extends ServiceProvider
     static $sponsorship_validation_rules = [
         'type_id' => 'required|integer',
     ];
-
-    static $file_dto_fields = [
-        'filepath',
-        'filename',
-        'md5',
-        'size',
-        'mime_type',
-        'source_bucket',
-    ];
-
-    static $file_dto_validation_rules = [
-        'filepath' => 'required|string',
-        'filename' => 'required|string',
-        'md5' => 'required|string',
-        'size' => 'required|integer',
-        'mime_type'=> 'sometimes|string',
-        'source_bucket' => 'sometimes|string',
-    ];
-
 
     /**
      * Bootstrap any application services.
@@ -729,12 +711,11 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Validator::replacer('file_dto', function ($message, $attribute, $rule, $parameters) {
-            return sprintf("%s should be a valid file dto (%s)", $attribute, implode(',', self::$file_dto_fields));
+            return sprintf("%s should be a valid file dto (%s)", $attribute, implode(',', array_keys(FileInfoDTO::validationRules())));
         });
 
         Validator::extend('file_dto', function ($attribute, $value, $parameters, $validator) {
-            $validation = Validator::make($value, self::$file_dto_validation_rules);
-            return !$validation->fails();
+            return !Validator::make($value, FileInfoDTO::validationRules())->fails();
         });
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -188,6 +188,25 @@ class AppServiceProvider extends ServiceProvider
         'type_id' => 'required|integer',
     ];
 
+    static $file_dto_fields = [
+        'filepath',
+        'filename',
+        'md5',
+        'size',
+        'mime_type',
+        'source_bucket',
+    ];
+
+    static $file_dto_validation_rules = [
+        'filepath' => 'required|string',
+        'filename' => 'required|string',
+        'md5' => 'required|string',
+        'size' => 'required|integer',
+        'mime_type'=> 'sometimes|string',
+        'source_bucket' => 'sometimes|string',
+    ];
+
+
     /**
      * Bootstrap any application services.
      * @return void
@@ -709,6 +728,14 @@ class AppServiceProvider extends ServiceProvider
             return is_numeric($value) && intval($value) > - strlen(strval($value)) == 10;
         });
 
+        Validator::replacer('file_dto', function ($message, $attribute, $rule, $parameters) {
+            return sprintf("%s should be a valid file dto (%s)", $attribute, implode(',', self::$file_dto_fields));
+        });
+
+        Validator::extend('file_dto', function ($attribute, $value, $parameters, $validator) {
+            $validation = Validator::make($value, self::$file_dto_validation_rules);
+            return !$validation->fails();
+        });
     }
 
     /**

--- a/app/Services/FilePostProcessorService.php
+++ b/app/Services/FilePostProcessorService.php
@@ -19,6 +19,7 @@ use App\Services\Model\IFilePostProcessorService;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 use models\main\Company;
+use models\utils\IEntity;
 
 final class FilePostProcessorService implements IFilePostProcessorService
 {
@@ -36,7 +37,7 @@ final class FilePostProcessorService implements IFilePostProcessorService
         return null;
     }
 
-    public function postProcessFileFromFileApi(FileInfoDTO $file_info_dto): bool
+    public function postProcessFileFromFileApi(FileInfoDTO $file_info_dto): IEntity
     {
        Log::debug(sprintf("FilePostProcessorService::postProcessFileFromFileApi entity_class=%s member=%s", $file_info_dto->owner_entity_class, $file_info_dto->owner_member_name));
        $service = $this->locateService($file_info_dto->owner_entity_class);

--- a/app/Services/FilePostProcessorService.php
+++ b/app/Services/FilePostProcessorService.php
@@ -1,0 +1,49 @@
+<?php namespace App\Services;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Services\Model\FileInfoDTO;
+use App\Services\Model\ICompanyService;
+use App\Services\Model\IFilePostProcessorForChildEntity;
+use App\Services\Model\IFilePostProcessorService;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Log;
+use models\main\Company;
+
+final class FilePostProcessorService implements IFilePostProcessorService
+{
+
+    /**
+     * @param string $className
+     * @return IFilePostProcessorForChildEntity|null
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    private function locateService(string $className): ?IFilePostProcessorForChildEntity{
+        switch($className){
+            case Company::class:
+                return App::make(ICompanyService::class);
+        }
+        return null;
+    }
+
+    public function postProcessFileFromFileApi(FileInfoDTO $file_info_dto): bool
+    {
+       Log::debug(sprintf("FilePostProcessorService::postProcessFileFromFileApi entity_class=%s member=%s", $file_info_dto->owner_entity_class, $file_info_dto->owner_member_name));
+       $service = $this->locateService($file_info_dto->owner_entity_class);
+       if(is_null($service)){
+           Log::warning(sprintf("FilePostProcessorService: no handler registered for entity class '%s'", $file_info_dto->owner_entity_class));
+           throw new \InvalidArgumentException(sprintf("No file post-processor registered for entity class '%s'.", $file_info_dto->owner_entity_class));
+       }
+       return $service->processFileForChildEntity($file_info_dto);
+    }
+}

--- a/app/Services/Model/FileInfoDTO.php
+++ b/app/Services/Model/FileInfoDTO.php
@@ -1,0 +1,31 @@
+<?php namespace App\Services\Model;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+final class FileInfoDTO {
+    public function __construct(
+        public readonly int $owner_entity_id,
+        public readonly string $owner_entity_class,
+        public readonly string $owner_member_name,
+        public readonly string $filepath,
+        public readonly string $filename,
+        public readonly int $size,
+        public readonly ?string $md5 = null,
+        public readonly ?string $mime_type = null,
+        public readonly ?string $source_bucket = null,
+    ) {}
+
+    public function __toString(): string {
+        return json_encode(get_object_vars($this), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/app/Services/Model/FileInfoDTO.php
+++ b/app/Services/Model/FileInfoDTO.php
@@ -13,6 +13,17 @@
  **/
 
 final class FileInfoDTO {
+    public static function validationRules(): array {
+        return [
+            'filepath'      => 'required|string',
+            'filename'      => 'required|string',
+            'md5'           => 'required|string',
+            'size'          => 'required|integer',
+            'mime_type'     => 'sometimes|string',
+            'source_bucket' => 'sometimes|string',
+        ];
+    }
+
     public function __construct(
         public readonly int $owner_entity_id,
         public readonly string $owner_entity_class,

--- a/app/Services/Model/FileInfoDTO.php
+++ b/app/Services/Model/FileInfoDTO.php
@@ -26,6 +26,6 @@ final class FileInfoDTO {
     ) {}
 
     public function __toString(): string {
-        return json_encode(get_object_vars($this), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        return json_encode(get_object_vars($this), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?: '{}';
     }
 }

--- a/app/Services/Model/ICompanyService.php
+++ b/app/Services/Model/ICompanyService.php
@@ -20,7 +20,7 @@ use models\main\File;
  * Interface ICompanyService
  * @package App\Services\Model
  */
-interface ICompanyService
+interface ICompanyService extends IFilePostProcessorForChildEntity
 {
     /**
      * @param array $payload

--- a/app/Services/Model/IFilePostProcessorForChildEntity.php
+++ b/app/Services/Model/IFilePostProcessorForChildEntity.php
@@ -1,0 +1,16 @@
+<?php namespace App\Services\Model;
+
+use models\exceptions\EntityNotFoundException;
+use models\exceptions\ValidationException;
+use models\utils\IEntity;
+
+interface IFilePostProcessorForChildEntity
+{
+    /**
+     * @param FileInfoDTO $file_info_dto
+     * @return IEntity
+     * @throws EntityNotFoundException
+     * @throws ValidationException
+     */
+    public function processFileForChildEntity(FileInfoDTO $file_info_dto): IEntity;
+}

--- a/app/Services/Model/IFilePostProcessorService.php
+++ b/app/Services/Model/IFilePostProcessorService.php
@@ -11,9 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-
+use models\utils\IEntity;
 
 interface IFilePostProcessorService
 {
-    public function postProcessFileFromFileApi(FileInfoDTO $file_info_dto):bool;
+    public function postProcessFileFromFileApi(FileInfoDTO $file_info_dto):IEntity;
 }

--- a/app/Services/Model/IFilePostProcessorService.php
+++ b/app/Services/Model/IFilePostProcessorService.php
@@ -1,0 +1,19 @@
+<?php namespace App\Services\Model;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+
+interface IFilePostProcessorService
+{
+    public function postProcessFileFromFileApi(FileInfoDTO $file_info_dto):bool;
+}

--- a/app/Services/Model/Imp/CompanyService.php
+++ b/app/Services/Model/Imp/CompanyService.php
@@ -11,26 +11,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+
+use App\Http\Utils\FileUploadInfo;
 use App\Http\Utils\IFileUploader;
 use App\Jobs\CompanyEventJob;
+use App\Jobs\FileProcessingJob;
+use App\Jobs\Utils\JobDispatcher;
 use App\Models\Foundation\Main\Factories\CompanyFactory;
 use App\Services\Model\AbstractService;
+use App\Services\Model\FileInfoDTO;
 use App\Services\Model\ICompanyService;
+use App\Services\Model\IFilePostProcessorForChildEntity;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
+use libs\utils\FileUtils;
 use libs\utils\ITransactionService;
 use models\exceptions\EntityNotFoundException;
 use models\exceptions\ValidationException;
 use models\main\Company;
 use models\main\File;
 use models\main\ICompanyRepository;
+use models\utils\IEntity;
+
 /**
  * Class CompanyService
  * @package App\Services\Model\Imp
  */
 final class CompanyService
     extends AbstractService
-    implements ICompanyService
+    implements ICompanyService, IFilePostProcessorForChildEntity
 {
+    use FileUtils;
 
     /**
      * @var ICompanyRepository
@@ -66,7 +77,8 @@ final class CompanyService
      */
     public function addCompany(array $payload): Company
     {
-       return $this->tx_service->transaction(function() use($payload){
+
+       $company = $this->tx_service->transaction(function() use($payload){
            $company_name = trim($payload['name']);
            $former_company = $this->repository->getByName($company_name);
            if(!is_null($former_company)){
@@ -76,7 +88,54 @@ final class CompanyService
            $this->repository->add($company);
            return $company;
        });
+
+        if(isset($payload['logo'])){
+            $file_upload_info = FileUploadInfo::buildFromPayload($payload['logo']);
+            if(!is_null($file_upload_info)){
+                if(!in_array($file_upload_info->getFileExt(),Company::LogoAllowedExtensions ))
+                    throw new ValidationException(sprintf("Logo file does not has a valid extension (%s).", implode(',', Company::LogoAllowedExtensions)));
+                $job = new FileProcessingJob(new FileInfoDTO(
+                    owner_entity_id : $company->getId(),
+                    owner_entity_class: Company::class,
+                    owner_member_name: "logo",
+                    filepath: $file_upload_info->getFilePath(),
+                    filename: $file_upload_info->getFileName(),
+                    size: $file_upload_info->getSize(),
+                    md5: $file_upload_info->getMd5(),
+                    mime_type: $file_upload_info->getMimeType(),
+                    source_bucket: $file_upload_info->getSourceBucket()
+                ));
+                JobDispatcher::withDbFallback(
+                    job: $job,
+                );
+            }
+        }
+
+        if(isset($payload['big_logo'])){
+            $file_upload_info = FileUploadInfo::buildFromPayload($payload['big_logo']);
+            if(!is_null($file_upload_info)){
+                if(!in_array($file_upload_info->getFileExt(),Company::LogoAllowedExtensions ))
+                    throw new ValidationException(sprintf("Big Logo file does not has a valid extension (%s).", implode(',', Company::LogoAllowedExtensions)));
+                $job = new FileProcessingJob(new FileInfoDTO(
+                    owner_entity_id : $company->getId(),
+                    owner_entity_class: Company::class,
+                    owner_member_name: "big_logo",
+                    filepath: $file_upload_info->getFilePath(),
+                    filename: $file_upload_info->getFileName(),
+                    size: $file_upload_info->getSize(),
+                    md5: $file_upload_info->getMd5(),
+                    mime_type: $file_upload_info->getMimeType(),
+                    source_bucket: $file_upload_info->getSourceBucket()
+                ));
+                JobDispatcher::withDbFallback(
+                    job: $job,
+                );
+            }
+        }
+
+       return $company;
     }
+
 
     /**
      * @param int $company_id
@@ -97,6 +156,8 @@ final class CompanyService
                 if(!is_null($former_company) && $company_id !== $former_company->getId()){
                     throw new ValidationException(sprintf("company %s already exists", $payload['name']));
                 }
+
+
             }
 
             return CompanyFactory::populate($company, $payload);
@@ -128,16 +189,14 @@ final class CompanyService
     {
         return $this->tx_service->transaction(function () use ($company_id, $file, $max_file_size) {
 
-            $allowed_extensions = ['png', 'jpg', 'jpeg', 'svg'];
-
             $company = $this->repository->getById($company_id);
 
             if (is_null($company) || !$company instanceof Company) {
                 throw new EntityNotFoundException('company not found!');
             }
 
-            if (!in_array($file->extension(), $allowed_extensions)) {
-                throw new ValidationException("file does not has a valid extension ('png', 'jpg', 'jpeg', 'svg').");
+            if (!in_array($file->extension(), Company::LogoAllowedExtensions)) {
+                throw new ValidationException(sprintf("file does not has a valid extension (%s).", implode(', ', Company::LogoAllowedExtensions)));
             }
 
             if ($file->getSize() > $max_file_size) {
@@ -175,16 +234,14 @@ final class CompanyService
     {
         return $this->tx_service->transaction(function () use ($company_id, $file, $max_file_size) {
 
-            $allowed_extensions = ['png', 'jpg', 'jpeg', 'svg'];
-
             $company = $this->repository->getById($company_id);
 
             if (is_null($company) || !$company instanceof Company) {
                 throw new EntityNotFoundException('company not found!');
             }
 
-            if (!in_array($file->extension(), $allowed_extensions)) {
-                throw new ValidationException("file does not has a valid extension ('png', 'jpg', 'jpeg', 'svg').");
+            if (!in_array($file->extension(), Company::LogoAllowedExtensions)) {
+                throw new ValidationException(sprintf("file does not has a valid extension (%s).", implode(', ', Company::LogoAllowedExtensions)));
             }
 
             if ($file->getSize() > $max_file_size) {
@@ -213,5 +270,72 @@ final class CompanyService
             $company->clearBigLogo();
 
         });
+    }
+
+    /**
+     * @param FileInfoDTO $file_info_dto
+     * @return IEntity
+     * @throws EntityNotFoundException
+     * @throws ValidationException
+     */
+    public function processFileForChildEntity(FileInfoDTO $file_info_dto): IEntity{
+        Log::debug(sprintf("CompanyService::processFileForChildEntity file_info_dto %s", $file_info_dto ));
+        $logo = null;
+        switch($file_info_dto->owner_member_name){
+            case 'big_logo':
+                $localPath = self::getFileFromRemoteStorageOnTempStorage(
+                    $file_info_dto->filename,
+                    $file_info_dto->filepath
+                );
+                try {
+                    if (!is_null($file_info_dto->md5)) {
+                        $localHash = md5_file($localPath);
+                        if ($localHash === false)
+                            throw new ValidationException("File integrity check failed: unable to read local temp file.");
+                        if ($localHash !== strtolower($file_info_dto->md5))
+                            throw new ValidationException("File integrity check failed: MD5 mismatch.");
+                    }
+                    $file = new UploadedFile(
+                        path: $localPath,
+                        originalName: $file_info_dto->filename,
+                        mimeType: $file_info_dto->mime_type,
+                        error: null,
+                        test: true,
+                    );
+                    $logo = $this->addCompanyBigLogo($file_info_dto->owner_entity_id, $file);
+                } finally {
+                    self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
+                }
+                return $logo;
+            case 'logo':
+                $localPath = self::getFileFromRemoteStorageOnTempStorage(
+                    $file_info_dto->filename,
+                    $file_info_dto->filepath
+                );
+
+                try {
+                    if (!is_null($file_info_dto->md5)) {
+                        $localHash = md5_file($localPath);
+                        if ($localHash === false)
+                            throw new ValidationException("File integrity check failed: unable to read local temp file.");
+                        if ($localHash !== strtolower($file_info_dto->md5))
+                            throw new ValidationException("File integrity check failed: MD5 mismatch.");
+                    }
+                    $file = new UploadedFile(
+                        path: $localPath,
+                        originalName: $file_info_dto->filename,
+                        mimeType: $file_info_dto->mime_type,
+                        error: null,
+                        test: true,
+                    );
+                    $logo = $this->addCompanyLogo($file_info_dto->owner_entity_id, $file);
+                } finally {
+                    self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
+                }
+                return $logo;
+            default:
+                Log::warning(sprintf("CompanyService::processFileForChildEntity unknown member name '%s'", $file_info_dto->owner_member_name));
+                throw new \InvalidArgumentException(sprintf("Unknown owner_member_name '%s' for entity class '%s'.", $file_info_dto->owner_member_name, $file_info_dto->owner_entity_class));
+        }
     }
 }

--- a/app/Services/Model/Imp/CompanyService.php
+++ b/app/Services/Model/Imp/CompanyService.php
@@ -287,6 +287,7 @@ final class CompanyService
                     $file_info_dto->filename,
                     $file_info_dto->filepath
                 );
+                $succeeded = false;
                 try {
                     if (!is_null($file_info_dto->md5)) {
                         $localHash = md5_file($localPath);
@@ -303,8 +304,14 @@ final class CompanyService
                         test: true,
                     );
                     $logo = $this->addCompanyBigLogo($file_info_dto->owner_entity_id, $file);
+                    $succeeded = true;
                 } finally {
-                    self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
+                    // Remote file preserved on failure so queue retries can re-download it.
+                    if ($succeeded) {
+                        self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
+                    } else {
+                        self::cleanLocalFile($localPath);
+                    }
                 }
                 return $logo;
             case 'logo':
@@ -312,7 +319,7 @@ final class CompanyService
                     $file_info_dto->filename,
                     $file_info_dto->filepath
                 );
-
+                $succeeded = false;
                 try {
                     if (!is_null($file_info_dto->md5)) {
                         $localHash = md5_file($localPath);
@@ -329,8 +336,14 @@ final class CompanyService
                         test: true,
                     );
                     $logo = $this->addCompanyLogo($file_info_dto->owner_entity_id, $file);
+                    $succeeded = true;
                 } finally {
-                    self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
+                    // Remote file preserved on failure so queue retries can re-download it.
+                    if ($succeeded) {
+                        self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
+                    } else {
+                        self::cleanLocalFile($localPath);
+                    }
                 }
                 return $logo;
             default:

--- a/app/Services/Model/Imp/CompanyService.php
+++ b/app/Services/Model/Imp/CompanyService.php
@@ -252,7 +252,8 @@ final class CompanyService
     /**
      * Downloads a file from remote storage to a local temp path, verifies its MD5 (when provided),
      * invokes $uploader to persist it, then cleans up. On failure the remote file is preserved
-     * so queue retries can re-download it.
+     * so queue retries can re-download it. Cleanup errors after a successful upload are logged
+     * but not re-thrown - upload success determines job success, not storage housekeeping.
      */
     private function processLogoFile(FileInfoDTO $file_info_dto, callable $uploader): IEntity
     {
@@ -280,7 +281,17 @@ final class CompanyService
             $succeeded = true;
         } finally {
             if ($succeeded) {
-                self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
+                try {
+                    self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
+                } catch (\Throwable $e) {
+                    // Upload succeeded; cleanup failure is non-fatal. Log and continue so the
+                    // job does not retry and create duplicate File records.
+                    Log::warning(sprintf(
+                        "CompanyService::processLogoFile cleanup failed after successful upload (filepath=%s): %s",
+                        $file_info_dto->filepath,
+                        $e->getMessage()
+                    ));
+                }
             } else {
                 self::cleanLocalFile($localPath);
             }

--- a/app/Services/Model/Imp/CompanyService.php
+++ b/app/Services/Model/Imp/CompanyService.php
@@ -21,7 +21,6 @@ use App\Models\Foundation\Main\Factories\CompanyFactory;
 use App\Services\Model\AbstractService;
 use App\Services\Model\FileInfoDTO;
 use App\Services\Model\ICompanyService;
-use App\Services\Model\IFilePostProcessorForChildEntity;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Log;
 use libs\utils\FileUtils;
@@ -39,7 +38,7 @@ use models\utils\IEntity;
  */
 final class CompanyService
     extends AbstractService
-    implements ICompanyService, IFilePostProcessorForChildEntity
+    implements ICompanyService
 {
     use FileUtils;
 
@@ -89,49 +88,8 @@ final class CompanyService
            return $company;
        });
 
-        if(isset($payload['logo'])){
-            $file_upload_info = FileUploadInfo::buildFromPayload($payload['logo']);
-            if(!is_null($file_upload_info)){
-                if(!in_array($file_upload_info->getFileExt(),Company::LogoAllowedExtensions ))
-                    throw new ValidationException(sprintf("Logo file does not has a valid extension (%s).", implode(',', Company::LogoAllowedExtensions)));
-                $job = new FileProcessingJob(new FileInfoDTO(
-                    owner_entity_id : $company->getId(),
-                    owner_entity_class: Company::class,
-                    owner_member_name: "logo",
-                    filepath: $file_upload_info->getFilePath(),
-                    filename: $file_upload_info->getFileName(),
-                    size: $file_upload_info->getSize(),
-                    md5: $file_upload_info->getMd5(),
-                    mime_type: $file_upload_info->getMimeType(),
-                    source_bucket: $file_upload_info->getSourceBucket()
-                ));
-                JobDispatcher::withDbFallback(
-                    job: $job,
-                );
-            }
-        }
-
-        if(isset($payload['big_logo'])){
-            $file_upload_info = FileUploadInfo::buildFromPayload($payload['big_logo']);
-            if(!is_null($file_upload_info)){
-                if(!in_array($file_upload_info->getFileExt(),Company::LogoAllowedExtensions ))
-                    throw new ValidationException(sprintf("Big Logo file does not has a valid extension (%s).", implode(',', Company::LogoAllowedExtensions)));
-                $job = new FileProcessingJob(new FileInfoDTO(
-                    owner_entity_id : $company->getId(),
-                    owner_entity_class: Company::class,
-                    owner_member_name: "big_logo",
-                    filepath: $file_upload_info->getFilePath(),
-                    filename: $file_upload_info->getFileName(),
-                    size: $file_upload_info->getSize(),
-                    md5: $file_upload_info->getMd5(),
-                    mime_type: $file_upload_info->getMimeType(),
-                    source_bucket: $file_upload_info->getSourceBucket()
-                ));
-                JobDispatcher::withDbFallback(
-                    job: $job,
-                );
-            }
-        }
+        if (isset($payload['logo']))     $this->dispatchLogoJob($company, 'logo',     $payload['logo']);
+        if (isset($payload['big_logo'])) $this->dispatchLogoJob($company, 'big_logo', $payload['big_logo']);
 
        return $company;
     }
@@ -278,77 +236,80 @@ final class CompanyService
      * @throws EntityNotFoundException
      * @throws ValidationException
      */
-    public function processFileForChildEntity(FileInfoDTO $file_info_dto): IEntity{
-        Log::debug(sprintf("CompanyService::processFileForChildEntity file_info_dto %s", $file_info_dto ));
-        $logo = null;
-        switch($file_info_dto->owner_member_name){
+    public function processFileForChildEntity(FileInfoDTO $file_info_dto): IEntity {
+        Log::debug(sprintf("CompanyService::processFileForChildEntity file_info_dto %s", $file_info_dto));
+        switch ($file_info_dto->owner_member_name) {
             case 'big_logo':
-                $localPath = self::getFileFromRemoteStorageOnTempStorage(
-                    $file_info_dto->filename,
-                    $file_info_dto->filepath
-                );
-                $succeeded = false;
-                try {
-                    if (!is_null($file_info_dto->md5)) {
-                        $localHash = md5_file($localPath);
-                        if ($localHash === false)
-                            throw new ValidationException("File integrity check failed: unable to read local temp file.");
-                        if ($localHash !== strtolower($file_info_dto->md5))
-                            throw new ValidationException("File integrity check failed: MD5 mismatch.");
-                    }
-                    $file = new UploadedFile(
-                        path: $localPath,
-                        originalName: $file_info_dto->filename,
-                        mimeType: $file_info_dto->mime_type,
-                        error: null,
-                        test: true,
-                    );
-                    $logo = $this->addCompanyBigLogo($file_info_dto->owner_entity_id, $file);
-                    $succeeded = true;
-                } finally {
-                    // Remote file preserved on failure so queue retries can re-download it.
-                    if ($succeeded) {
-                        self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
-                    } else {
-                        self::cleanLocalFile($localPath);
-                    }
-                }
-                return $logo;
+                return $this->processLogoFile($file_info_dto, [$this, 'addCompanyBigLogo']);
             case 'logo':
-                $localPath = self::getFileFromRemoteStorageOnTempStorage(
-                    $file_info_dto->filename,
-                    $file_info_dto->filepath
-                );
-                $succeeded = false;
-                try {
-                    if (!is_null($file_info_dto->md5)) {
-                        $localHash = md5_file($localPath);
-                        if ($localHash === false)
-                            throw new ValidationException("File integrity check failed: unable to read local temp file.");
-                        if ($localHash !== strtolower($file_info_dto->md5))
-                            throw new ValidationException("File integrity check failed: MD5 mismatch.");
-                    }
-                    $file = new UploadedFile(
-                        path: $localPath,
-                        originalName: $file_info_dto->filename,
-                        mimeType: $file_info_dto->mime_type,
-                        error: null,
-                        test: true,
-                    );
-                    $logo = $this->addCompanyLogo($file_info_dto->owner_entity_id, $file);
-                    $succeeded = true;
-                } finally {
-                    // Remote file preserved on failure so queue retries can re-download it.
-                    if ($succeeded) {
-                        self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
-                    } else {
-                        self::cleanLocalFile($localPath);
-                    }
-                }
-                return $logo;
+                return $this->processLogoFile($file_info_dto, [$this, 'addCompanyLogo']);
             default:
                 Log::warning(sprintf("CompanyService::processFileForChildEntity unknown member name '%s'", $file_info_dto->owner_member_name));
                 throw new \InvalidArgumentException(sprintf("Unknown owner_member_name '%s' for entity class '%s'.", $file_info_dto->owner_member_name, $file_info_dto->owner_entity_class));
         }
+    }
+
+    /**
+     * Downloads a file from remote storage to a local temp path, verifies its MD5 (when provided),
+     * invokes $uploader to persist it, then cleans up. On failure the remote file is preserved
+     * so queue retries can re-download it.
+     */
+    private function processLogoFile(FileInfoDTO $file_info_dto, callable $uploader): IEntity
+    {
+        $localPath = self::getFileFromRemoteStorageOnTempStorage(
+            $file_info_dto->filename,
+            $file_info_dto->filepath
+        );
+        $succeeded = false;
+        try {
+            if (!is_null($file_info_dto->md5)) {
+                $localHash = md5_file($localPath);
+                if ($localHash === false)
+                    throw new ValidationException("File integrity check failed: unable to read local temp file.");
+                if ($localHash !== strtolower($file_info_dto->md5))
+                    throw new ValidationException("File integrity check failed: MD5 mismatch.");
+            }
+            $file = new UploadedFile(
+                path: $localPath,
+                originalName: $file_info_dto->filename,
+                mimeType: $file_info_dto->mime_type,
+                error: null,
+                test: true,
+            );
+            $logo = $uploader($file_info_dto->owner_entity_id, $file);
+            $succeeded = true;
+        } finally {
+            if ($succeeded) {
+                self::cleanLocalAndRemoteFile($localPath, $file_info_dto->filepath);
+            } else {
+                self::cleanLocalFile($localPath);
+            }
+        }
+        return $logo;
+    }
+
+    private function dispatchLogoJob(Company $company, string $memberName, array $payload): void
+    {
+        $file_upload_info = FileUploadInfo::buildFromPayload($payload);
+        if (is_null($file_upload_info)) return;
+
+        if (!in_array($file_upload_info->getFileExt(), Company::LogoAllowedExtensions))
+            throw new ValidationException(sprintf(
+                "%s file does not have a valid extension (%s).",
+                ucwords(str_replace('_', ' ', $memberName)),
+                implode(',', Company::LogoAllowedExtensions)
+            ));
+
+        JobDispatcher::withDbFallback(job: new FileProcessingJob(new FileInfoDTO(
+            owner_entity_id:    $company->getId(),
+            owner_entity_class: Company::class,
+            owner_member_name:  $memberName,
+            filepath:           $file_upload_info->getFilePath(),
+            filename:           $file_upload_info->getFileName(),
+            size:               $file_upload_info->getSize(),
+            md5:                $file_upload_info->getMd5(),
+            mime_type:          $file_upload_info->getMimeType(),
+            source_bucket:      $file_upload_info->getSourceBucket()
+        )));
     }
 }

--- a/app/Services/ModelServicesProvider.php
+++ b/app/Services/ModelServicesProvider.php
@@ -18,6 +18,7 @@ use App\Services\Apis\ExternalRegistrationFeeds\ExternalRegistrationFeedFactory;
 use App\Services\Apis\ExternalRegistrationFeeds\IExternalRegistrationFeedFactory;
 use App\Services\Apis\ExternalScheduleFeeds\ExternalScheduleFeedFactory;
 use App\Services\Apis\ExternalScheduleFeeds\IExternalScheduleFeedFactory;
+use App\Services\FilePostProcessorService;
 use App\Services\FileSystem\IFileDownloadStrategy;
 use App\Services\FileSystem\IFileUploadStrategy;
 use App\Services\FileSystem\Swift\SwiftStorageFileDownloadStrategy;
@@ -29,12 +30,12 @@ use App\Services\Model\IAttendeeService;
 use App\Services\Model\IBadgeViewTypeService;
 use App\Services\Model\ICompanyService;
 use App\Services\Model\IElectionService;
+use App\Services\Model\IFilePostProcessorService;
 use App\Services\Model\ILocationService;
 use App\Services\Model\IMemberService;
 use App\Services\Model\Imp\BadgeViewTypeService;
 use App\Services\Model\Imp\CompanyService;
 use App\Services\Model\Imp\ElectionService;
-use App\Services\Model\Imp\Factories\RabbitPublisherFactory;
 use App\Services\Model\Imp\PaymentGatewayProfileService;
 use App\Services\Model\Imp\PresentationVideoMediaUploadProcessor;
 use App\Services\Model\Imp\ProcessScheduleEntityLifeCycleEventService;
@@ -140,8 +141,6 @@ use App\Services\SummitOrderExtraQuestionTypeService;
 use App\Services\SummitRefundPolicyTypeService;
 use App\Services\SummitSponsorService;
 use App\Services\SummitSponsorshipService;
-use App\Services\Utils\IPublisherService;
-use App\Services\Utils\RabbitPublisherService;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\ServiceProvider;
 use services\model\ChatTeamService;
@@ -529,6 +528,10 @@ final class ModelServicesProvider extends ServiceProvider
             ISummitRSVPService::class,
             SummitRSVPService::class
         );
+        App::singleton(
+            IFilePostProcessorService::class,
+            FilePostProcessorService::class
+        );
     }
 
     /**
@@ -602,6 +605,7 @@ final class ModelServicesProvider extends ServiceProvider
             ISponsorUserSyncService::class,
             ISummitRSVPService::class,
             ISummitRSVPInvitationService::class,
+            IFilePostProcessorService::class,
         ];
     }
 }

--- a/app/Swagger/CompaniesSchemas.php
+++ b/app/Swagger/CompaniesSchemas.php
@@ -46,23 +46,6 @@ class PaginatedBaseCompaniesResponseSchema
 {
 }
 
-#[OA\Schema(
-    schema: "FileDTO",
-    description: "File metadata payload produced by the File API after a successful upload",
-    required: ["filepath", "filename", "md5", "size"],
-    properties: [
-        new OA\Property(property: "filepath", type: "string", description: "Remote storage path of the uploaded file", example: "companies/1/tmp/logo.png"),
-        new OA\Property(property: "filename", type: "string", description: "Original file name", example: "logo.png"),
-        new OA\Property(property: "md5", type: "string", description: "MD5 hash of the file for integrity verification", example: "d41d8cd98f00b204e9800998ecf8427e"),
-        new OA\Property(property: "size", type: "integer", description: "File size in bytes", example: 204800),
-        new OA\Property(property: "mime_type", type: "string", nullable: true, description: "MIME type of the file", example: "image/png"),
-        new OA\Property(property: "source_bucket", type: "string", nullable: true, description: "Source storage bucket", example: "my-uploads-bucket"),
-    ],
-    type: "object"
-)]
-class FileDTOSchema
-{
-}
 
 #[OA\Schema(
     schema: "CompanyCreateRequest",

--- a/app/Swagger/CompaniesSchemas.php
+++ b/app/Swagger/CompaniesSchemas.php
@@ -47,6 +47,24 @@ class PaginatedBaseCompaniesResponseSchema
 }
 
 #[OA\Schema(
+    schema: "FileDTO",
+    description: "File metadata payload produced by the File API after a successful upload",
+    required: ["filepath", "filename", "md5", "size"],
+    properties: [
+        new OA\Property(property: "filepath", type: "string", description: "Remote storage path of the uploaded file", example: "companies/1/tmp/logo.png"),
+        new OA\Property(property: "filename", type: "string", description: "Original file name", example: "logo.png"),
+        new OA\Property(property: "md5", type: "string", description: "MD5 hash of the file for integrity verification", example: "d41d8cd98f00b204e9800998ecf8427e"),
+        new OA\Property(property: "size", type: "integer", description: "File size in bytes", example: 204800),
+        new OA\Property(property: "mime_type", type: "string", nullable: true, description: "MIME type of the file", example: "image/png"),
+        new OA\Property(property: "source_bucket", type: "string", nullable: true, description: "Source storage bucket", example: "my-uploads-bucket"),
+    ],
+    type: "object"
+)]
+class FileDTOSchema
+{
+}
+
+#[OA\Schema(
     schema: "CompanyCreateRequest",
     description: "Request to create a Company",
     required: ["name"],
@@ -69,6 +87,8 @@ class PaginatedBaseCompaniesResponseSchema
         new OA\Property(property: "overview", type: "string", nullable: true, example: "Company overview"),
         new OA\Property(property: "commitment", type: "string", nullable: true, example: "Commitment to open source"),
         new OA\Property(property: "commitment_author", type: "string", nullable: true, example: "John Doe, CEO"),
+        new OA\Property(property: "logo", nullable: true, ref: "#/components/schemas/FileDTO", description: "Company logo (File API payload)"),
+        new OA\Property(property: "big_logo", nullable: true, ref: "#/components/schemas/FileDTO", description: "Company big logo (File API payload)"),
     ],
     type: "object"
 )]
@@ -98,6 +118,8 @@ class CompanyCreateRequestSchema
         new OA\Property(property: "overview", type: "string", nullable: true, example: "Company overview"),
         new OA\Property(property: "commitment", type: "string", nullable: true, example: "Commitment to open source"),
         new OA\Property(property: "commitment_author", type: "string", nullable: true, example: "John Doe, CEO"),
+        new OA\Property(property: "logo", nullable: true, ref: "#/components/schemas/FileDTO", description: "Company logo (File API payload)"),
+        new OA\Property(property: "big_logo", nullable: true, ref: "#/components/schemas/FileDTO", description: "Company big logo (File API payload)"),
     ],
     type: "object"
 )]

--- a/app/Swagger/FileDTOSchema.php
+++ b/app/Swagger/FileDTOSchema.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Swagger\schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: "FileDTO",
+    description: "File metadata payload produced by the File API after a successful upload",
+    required: ["filepath", "filename", "md5", "size"],
+    properties: [
+        new OA\Property(property: "filepath", type: "string", description: "Remote storage path of the uploaded file", example: "companies/1/tmp/logo.png"),
+        new OA\Property(property: "filename", type: "string", description: "Original file name", example: "logo.png"),
+        new OA\Property(property: "md5", type: "string", description: "MD5 hash of the file for integrity verification", example: "d41d8cd98f00b204e9800998ecf8427e"),
+        new OA\Property(property: "size", type: "integer", description: "File size in bytes", example: 204800),
+        new OA\Property(property: "mime_type", type: "string", nullable: true, description: "MIME type of the file", example: "image/png"),
+        new OA\Property(property: "source_bucket", type: "string", nullable: true, description: "Source storage bucket", example: "my-uploads-bucket"),
+    ],
+    type: "object"
+)]
+class FileDTOSchema
+{
+}

--- a/tests/Unit/Services/CompanyFileProcessingTest.php
+++ b/tests/Unit/Services/CompanyFileProcessingTest.php
@@ -1,0 +1,240 @@
+<?php namespace Tests\Unit\Services;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Services\FilePostProcessorService;
+use App\Services\Model\FileInfoDTO;
+use App\Services\Model\Imp\CompanyService;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Mockery;
+use models\exceptions\ValidationException;
+use models\main\Company;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Class CompanyFileProcessingTest
+ *
+ * Unit tests for the async file post-processing pipeline introduced for company
+ * logos. Covers the new behaviors that are hardest to exercise via integration:
+ *
+ *  - processFileForChildEntity: unknown owner_member_name -> InvalidArgumentException
+ *  - processFileForChildEntity: MD5 mismatch -> "MD5 mismatch" (not "unable to read")
+ *  - processFileForChildEntity: MD5 check skipped when md5 field is null
+ *  - FilePostProcessorService: unknown entity class -> throws (not silent false)
+ *  - FileInfoDTO: survives PHP queue serialization round-trip
+ *
+ * @package Tests\Unit\Services
+ */
+class CompanyFileProcessingTest extends TestCase
+{
+    private Container $app;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Minimal facade application so Log::debug/warning calls resolve without
+        // a full Laravel app or database. clearResolvedInstances() first to drop
+        // any cached instance from a prior test that booted the full app.
+        Facade::clearResolvedInstances();
+        $this->app = new Container();
+        $this->app->singleton('log', fn() => new NullLogger());
+        Container::setInstance($this->app);
+        Facade::setFacadeApplication($this->app);
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::setFacadeApplication(null);
+        Facade::clearResolvedInstances();
+        Container::setInstance(null);
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makeCompanyService(): CompanyService
+    {
+        // CompanyService is final with a multi-arg constructor. Skip the
+        // constructor entirely - processFileForChildEntity only uses static
+        // trait methods and $this->addCompanyLogo/addCompanyBigLogo, neither
+        // of which is reached by the paths tested here.
+        $ref = new \ReflectionClass(CompanyService::class);
+        return $ref->newInstanceWithoutConstructor();
+    }
+
+    /**
+     * Register Storage and Config fakes so getFileFromRemoteStorageOnTempStorage
+     * and cleanLocalAndRemoteFile resolve without hitting real cloud storage.
+     * The disk mock serves an empty stream, producing a 0-byte local temp file.
+     */
+    private function bindStorageFakes(string $remotePath): void
+    {
+        $emptyStream = fopen('php://temp', 'r+b');
+
+        $mockDisk = Mockery::mock();
+        $mockDisk->shouldReceive('exists')->with($remotePath)->andReturn(true);
+        $mockDisk->shouldReceive('readStream')->with($remotePath)->andReturn($emptyStream);
+        $mockDisk->shouldReceive('size')->with($remotePath)->andReturn(0); // matches 0-byte local copy
+        $mockDisk->shouldReceive('delete')->with($remotePath)->andReturn(true);
+
+        $mockFsFactory = Mockery::mock();
+        $mockFsFactory->shouldReceive('disk')->andReturn($mockDisk);
+
+        $mockConfig = Mockery::mock();
+        $mockConfig->shouldReceive('get')->with('file_upload.storage_driver')->andReturn('s3');
+        $mockConfig->shouldReceive('get')->withAnyArgs()->andReturn(null);
+
+        $this->app->singleton('filesystem', fn() => $mockFsFactory);
+        $this->app->singleton('config', fn() => $mockConfig);
+    }
+
+    private function makeLogoDto(string $memberName, ?string $md5 = null): FileInfoDTO
+    {
+        return new FileInfoDTO(
+            owner_entity_id: 1,
+            owner_entity_class: Company::class,
+            owner_member_name: $memberName,
+            filepath: 'companies/1/tmp/logo.png',
+            filename: 'logo.png',
+            size: 1024,
+            md5: $md5,
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // processFileForChildEntity - routing / default case
+    // -------------------------------------------------------------------------
+
+    public function testProcessFileForChildEntityThrowsForUnknownMemberName(): void
+    {
+        $service = $this->makeCompanyService();
+
+        $dto = $this->makeLogoDto('avatar');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/avatar/');
+
+        $service->processFileForChildEntity($dto);
+    }
+
+    // -------------------------------------------------------------------------
+    // processFileForChildEntity - MD5 verification logic
+    // -------------------------------------------------------------------------
+
+    /**
+     * When the provided MD5 does not match the downloaded file's hash,
+     * the exception message must say "MD5 mismatch", NOT "unable to read local
+     * temp file". This guards against the regression where md5_file() returning
+     * false and an actual mismatch produced the same error message.
+     */
+    public function testProcessFileForChildEntityThrowsMd5MismatchMessageOnHashDifference(): void
+    {
+        $remotePath = 'companies/1/tmp/logo.png';
+        $this->bindStorageFakes($remotePath);
+
+        $service = $this->makeCompanyService();
+
+        // md5 of a 0-byte file is d41d8cd98f00b204e9800998ecf8427e.
+        // Supplying a different hash triggers the mismatch branch.
+        $dto = $this->makeLogoDto('logo', 'ffffffffffffffffffffffffffffffff');
+
+        try {
+            $service->processFileForChildEntity($dto);
+            $this->fail('Expected ValidationException was not thrown.');
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('MD5 mismatch', $e->getMessage());
+            $this->assertStringNotContainsString('unable to read', $e->getMessage());
+        }
+    }
+
+    /**
+     * Same mismatch path for the big_logo member - ensures both switch cases
+     * share the same md5 check behaviour.
+     */
+    public function testProcessFileForChildEntityMd5MismatchAlsoWorksForBigLogo(): void
+    {
+        $remotePath = 'companies/1/tmp/logo.png';
+        $this->bindStorageFakes($remotePath);
+
+        $service = $this->makeCompanyService();
+
+        $dto = $this->makeLogoDto('big_logo', 'ffffffffffffffffffffffffffffffff');
+
+        try {
+            $service->processFileForChildEntity($dto);
+            $this->fail('Expected ValidationException was not thrown.');
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('MD5 mismatch', $e->getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // FilePostProcessorService - unknown entity class now throws, not silent false
+    // -------------------------------------------------------------------------
+
+    public function testPostProcessFileApiThrowsForUnknownEntityClass(): void
+    {
+        $service = new FilePostProcessorService();
+
+        $dto = new FileInfoDTO(
+            owner_entity_id: 1,
+            owner_entity_class: 'App\Models\SomeUnregisteredEntity',
+            owner_member_name: 'logo',
+            filepath: 'some/path',
+            filename: 'logo.png',
+            size: 1024,
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/SomeUnregisteredEntity/');
+
+        $service->postProcessFileFromFileApi($dto);
+    }
+
+    // -------------------------------------------------------------------------
+    // FileInfoDTO - queue serialization round-trip
+    // -------------------------------------------------------------------------
+
+    public function testFileInfoDTOSurvivesQueueSerialization(): void
+    {
+        $original = new FileInfoDTO(
+            owner_entity_id: 42,
+            owner_entity_class: Company::class,
+            owner_member_name: 'logo',
+            filepath: 'companies/42/tmp/abc.png',
+            filename: 'logo.png',
+            size: 2048,
+            md5: 'abc123def456abc123def456abc123de',
+            mime_type: 'image/png',
+            source_bucket: 'my-bucket',
+        );
+
+        /** @var FileInfoDTO $copy */
+        $copy = unserialize(serialize($original));
+
+        $this->assertSame(42, $copy->owner_entity_id);
+        $this->assertSame(Company::class, $copy->owner_entity_class);
+        $this->assertSame('logo', $copy->owner_member_name);
+        $this->assertSame('companies/42/tmp/abc.png', $copy->filepath);
+        $this->assertSame('logo.png', $copy->filename);
+        $this->assertSame(2048, $copy->size);
+        $this->assertSame('abc123def456abc123def456abc123de', $copy->md5);
+        $this->assertSame('image/png', $copy->mime_type);
+        $this->assertSame('my-bucket', $copy->source_bucket);
+    }
+}

--- a/tests/oauth2/OAuth2CompaniesApiTest.php
+++ b/tests/oauth2/OAuth2CompaniesApiTest.php
@@ -12,9 +12,12 @@
  * limitations under the License.
  **/
 
+use App\Jobs\FileProcessingJob;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
+use models\main\Company;
 
 class OAuth2CompaniesApiTest extends ProtectedApiTestCase
 {
@@ -247,6 +250,148 @@ class OAuth2CompaniesApiTest extends ProtectedApiTestCase
     public function testAddCompanyBigLogo(): void
     {
         $this->testAddCompanyBigLogoViaMultipartFile();
+    }
+
+    // -------------------------------------------------------------------------
+    // addCompany - logo dispatch path
+    // -------------------------------------------------------------------------
+
+    /**
+     * When addCompany receives a logo file_dto payload, a FileProcessingJob must
+     * be dispatched for the 'logo' member with the correct entity class.
+     */
+    public function testAddCompanyWithLogoPayloadDispatchesFileProcessingJob(): void
+    {
+        Config::set('file_upload.storage_driver', 'local');
+        Storage::fake('local');
+        Bus::fake();
+
+        $fakeFile   = UploadedFile::fake()->image('logo.png');
+        $content    = file_get_contents($fakeFile->getRealPath());
+        $remotePath = 'companies/tmp/logo.png';
+        Storage::disk('local')->put($remotePath, $content);
+
+        $headers = [
+            "HTTP_Authorization" => " Bearer " . $this->access_token,
+            "CONTENT_TYPE"       => "application/json",
+        ];
+
+        $data = [
+            'name'        => str_random(16) . '_company',
+            'description' => str_random(16) . '_description',
+            'logo'        => [
+                'filepath'  => $remotePath,
+                'filename'  => 'logo.png',
+                'md5'       => md5($content),
+                'size'      => strlen($content),
+                'mime_type' => 'image/png',
+            ],
+        ];
+
+        $this->action("POST", "OAuth2CompaniesApiController@add", [], [], [], [], $headers, json_encode($data));
+
+        $this->assertResponseStatus(201);
+
+        Bus::assertDispatched(FileProcessingJob::class, function (FileProcessingJob $job) {
+            return $job->fileInfoDTO->owner_member_name  === 'logo'
+                && $job->fileInfoDTO->owner_entity_class === Company::class;
+        });
+    }
+
+    /**
+     * When addCompany receives both logo and big_logo file_dto payloads, two
+     * separate FileProcessingJob instances must be dispatched - one per member.
+     */
+    public function testAddCompanyWithBothLogosDispatchesTwoFileProcessingJobs(): void
+    {
+        Config::set('file_upload.storage_driver', 'local');
+        Storage::fake('local');
+        Bus::fake();
+
+        $content = file_get_contents(UploadedFile::fake()->image('logo.png')->getRealPath());
+        Storage::disk('local')->put('companies/tmp/logo.png',     $content);
+        Storage::disk('local')->put('companies/tmp/big_logo.png', $content);
+
+        $headers = [
+            "HTTP_Authorization" => " Bearer " . $this->access_token,
+            "CONTENT_TYPE"       => "application/json",
+        ];
+
+        $data = [
+            'name'        => str_random(16) . '_company',
+            'description' => str_random(16) . '_description',
+            'logo' => [
+                'filepath'  => 'companies/tmp/logo.png',
+                'filename'  => 'logo.png',
+                'md5'       => md5($content),
+                'size'      => strlen($content),
+                'mime_type' => 'image/png',
+            ],
+            'big_logo' => [
+                'filepath'  => 'companies/tmp/big_logo.png',
+                'filename'  => 'big_logo.png',
+                'md5'       => md5($content),
+                'size'      => strlen($content),
+                'mime_type' => 'image/png',
+            ],
+        ];
+
+        $this->action("POST", "OAuth2CompaniesApiController@add", [], [], [], [], $headers, json_encode($data));
+
+        $this->assertResponseStatus(201);
+
+        Bus::assertDispatched(FileProcessingJob::class, function (FileProcessingJob $job) {
+            return $job->fileInfoDTO->owner_member_name === 'logo';
+        });
+        Bus::assertDispatched(FileProcessingJob::class, function (FileProcessingJob $job) {
+            return $job->fileInfoDTO->owner_member_name === 'big_logo';
+        });
+        Bus::assertDispatchedTimes(FileProcessingJob::class, 2);
+    }
+
+    /**
+     * Documents the known partial-commit behaviour: when addCompany's logo
+     * extension validation fails (runs after the DB transaction commits),
+     * the company is persisted but the caller receives a 412 error.
+     */
+    public function testAddCompanyWithInvalidLogoExtensionCommitsCompanyDespiteError(): void
+    {
+        Config::set('file_upload.storage_driver', 'local');
+        Storage::fake('local');
+
+        // .bmp is not in Company::LogoAllowedExtensions
+        Storage::disk('local')->put('companies/tmp/logo.bmp', 'fake-bmp-content');
+
+        $companyName = str_random(16) . '_company';
+
+        $headers = [
+            "HTTP_Authorization" => " Bearer " . $this->access_token,
+            "CONTENT_TYPE"       => "application/json",
+        ];
+
+        $data = [
+            'name'        => $companyName,
+            'description' => str_random(16) . '_description',
+            'logo'        => [
+                'filepath'  => 'companies/tmp/logo.bmp',
+                'filename'  => 'logo.bmp',
+                'md5'       => md5('fake-bmp-content'),
+                'size'      => strlen('fake-bmp-content'),
+                'mime_type' => 'image/bmp',
+            ],
+        ];
+
+        $this->action("POST", "OAuth2CompaniesApiController@add", [], [], [], [], $headers, json_encode($data));
+
+        // Extension validation throws after the company transaction commits -> 412
+        $this->assertResponseStatus(412);
+
+        // The company was already persisted: a second attempt with the same name
+        // must fail with 412 "Company X already exists".
+        $this->action("POST", "OAuth2CompaniesApiController@add", [], [], [], [], $headers,
+            json_encode(['name' => $companyName, 'description' => 'retry']));
+        $this->assertResponseStatus(412);
+        $this->assertStringContainsString('already exists', $this->response->getContent());
     }
 
 }

--- a/tests/oauth2/OAuth2CompaniesApiTest.php
+++ b/tests/oauth2/OAuth2CompaniesApiTest.php
@@ -12,6 +12,9 @@
  * limitations under the License.
  **/
 
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
 class OAuth2CompaniesApiTest extends ProtectedApiTestCase
 {
 
@@ -71,8 +74,176 @@ class OAuth2CompaniesApiTest extends ProtectedApiTestCase
         return $company;
     }
 
-    public function testAddCompanyBigLogo(){
+    // -------------------------------------------------------------------------
+    // Logo - dual flow (multipart + JSON payload)
+    // -------------------------------------------------------------------------
 
+    public function testAddCompanyLogoViaMultipartFile(): void
+    {
+        Storage::fake('public');
+        Storage::fake('assets');
+
+        $company = $this->testAddCompany();
+
+        $headers = [
+            "HTTP_Authorization" => " Bearer " . $this->access_token,
+            "CONTENT_TYPE"       => "multipart/form-data",
+        ];
+
+        $response = $this->action(
+            "POST",
+            "OAuth2CompaniesApiController@addCompanyLogo",
+            ['id' => $company->id],
+            [],
+            [],
+            ['file' => UploadedFile::fake()->image('logo.png')],
+            $headers
+        );
+
+        $this->assertResponseStatus(201);
+        $logo = json_decode($response->getContent());
+        $this->assertNotNull($logo);
+    }
+
+    public function testAddCompanyLogoViaJsonPayload(): void
+    {
+        Storage::fake('local');
+        Storage::fake('public');
+        Storage::fake('assets');
+
+        $company = $this->testAddCompany();
+
+        $fakeFile    = UploadedFile::fake()->image('logo.png');
+        $content     = file_get_contents($fakeFile->getRealPath());
+        $remotePath  = 'companies/' . $company->id . '/tmp/logo.png';
+        Storage::disk('local')->put($remotePath, $content);
+
+        $headers = [
+            "HTTP_Authorization" => " Bearer " . $this->access_token,
+            "CONTENT_TYPE"       => "application/json",
+        ];
+
+        $response = $this->action(
+            "POST",
+            "OAuth2CompaniesApiController@addCompanyLogo",
+            ['id' => $company->id],
+            [],
+            [],
+            [],
+            $headers,
+            json_encode([
+                'filepath'   => $remotePath,
+                'filename'   => 'logo.png',
+                'md5'        => md5($content),
+                'size'       => strlen($content),
+                'mime_type'  => 'image/png',
+            ])
+        );
+
+        $this->assertResponseStatus(201);
+        $logo = json_decode($response->getContent());
+        $this->assertNotNull($logo);
+    }
+
+    public function testAddCompanyLogoJsonPayloadReturnsPreconditionFailedOnMissingFields(): void
+    {
+        $company = $this->testAddCompany();
+
+        $headers = [
+            "HTTP_Authorization" => " Bearer " . $this->access_token,
+            "CONTENT_TYPE"       => "application/json",
+        ];
+
+        // No file in request, and JSON body is missing all required fields
+        $response = $this->action(
+            "POST",
+            "OAuth2CompaniesApiController@addCompanyLogo",
+            ['id' => $company->id],
+            [],
+            [],
+            [],
+            $headers,
+            json_encode(['mime_type' => 'image/png'])
+        );
+
+        $this->assertResponseStatus(412);
+    }
+
+    // -------------------------------------------------------------------------
+    // Big logo - dual flow (multipart + JSON payload)
+    // -------------------------------------------------------------------------
+
+    public function testAddCompanyBigLogoViaMultipartFile(): void
+    {
+        Storage::fake('public');
+        Storage::fake('assets');
+
+        $company = $this->testAddCompany();
+
+        $headers = [
+            "HTTP_Authorization" => " Bearer " . $this->access_token,
+            "CONTENT_TYPE"       => "multipart/form-data",
+        ];
+
+        $response = $this->action(
+            "POST",
+            "OAuth2CompaniesApiController@addCompanyBigLogo",
+            ['id' => $company->id],
+            [],
+            [],
+            ['file' => UploadedFile::fake()->image('big_logo.png')],
+            $headers
+        );
+
+        $this->assertResponseStatus(201);
+        $logo = json_decode($response->getContent());
+        $this->assertNotNull($logo);
+    }
+
+    public function testAddCompanyBigLogoViaJsonPayload(): void
+    {
+        Storage::fake('local');
+        Storage::fake('public');
+        Storage::fake('assets');
+
+        $company = $this->testAddCompany();
+
+        $fakeFile    = UploadedFile::fake()->image('big_logo.png');
+        $content     = file_get_contents($fakeFile->getRealPath());
+        $remotePath  = 'companies/' . $company->id . '/tmp/big_logo.png';
+        Storage::disk('local')->put($remotePath, $content);
+
+        $headers = [
+            "HTTP_Authorization" => " Bearer " . $this->access_token,
+            "CONTENT_TYPE"       => "application/json",
+        ];
+
+        $response = $this->action(
+            "POST",
+            "OAuth2CompaniesApiController@addCompanyBigLogo",
+            ['id' => $company->id],
+            [],
+            [],
+            [],
+            $headers,
+            json_encode([
+                'filepath'   => $remotePath,
+                'filename'   => 'big_logo.png',
+                'md5'        => md5($content),
+                'size'       => strlen($content),
+                'mime_type'  => 'image/png',
+            ])
+        );
+
+        $this->assertResponseStatus(201);
+        $logo = json_decode($response->getContent());
+        $this->assertNotNull($logo);
+    }
+
+    // Kept for backward compatibility with any @depends on this method name
+    public function testAddCompanyBigLogo(): void
+    {
+        $this->testAddCompanyBigLogoViaMultipartFile();
     }
 
 }

--- a/tests/oauth2/OAuth2CompaniesApiTest.php
+++ b/tests/oauth2/OAuth2CompaniesApiTest.php
@@ -13,6 +13,7 @@
  **/
 
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
 
 class OAuth2CompaniesApiTest extends ProtectedApiTestCase
@@ -107,6 +108,7 @@ class OAuth2CompaniesApiTest extends ProtectedApiTestCase
 
     public function testAddCompanyLogoViaJsonPayload(): void
     {
+        Config::set('file_upload.storage_driver', 'local');
         Storage::fake('local');
         Storage::fake('public');
         Storage::fake('assets');
@@ -202,6 +204,7 @@ class OAuth2CompaniesApiTest extends ProtectedApiTestCase
 
     public function testAddCompanyBigLogoViaJsonPayload(): void
     {
+        Config::set('file_upload.storage_driver', 'local');
         Storage::fake('local');
         Storage::fake('public');
         Storage::fake('assets');

--- a/tests/oauth2/OAuth2CompaniesApiTest.php
+++ b/tests/oauth2/OAuth2CompaniesApiTest.php
@@ -308,7 +308,8 @@ class OAuth2CompaniesApiTest extends ProtectedApiTestCase
         Storage::fake('local');
         Bus::fake();
 
-        $content = file_get_contents(UploadedFile::fake()->image('logo.png')->getRealPath());
+        $fakeFile = UploadedFile::fake()->image('logo.png');
+        $content  = file_get_contents($fakeFile->getRealPath());
         Storage::disk('local')->put('companies/tmp/logo.png',     $content);
         Storage::disk('local')->put('companies/tmp/big_logo.png', $content);
 


### PR DESCRIPTION
ref:https://app.clickup.com/t/9014802374/86bah99tf
- Add FileInfoDTO (owner entity class/id/member, filepath, md5, size, mime_type, source_bucket)
- Add FileProcessingJob (ShouldQueue) dispatching to FilePostProcessorService
- Add FilePostProcessorService with locateService() switch dispatch; throws InvalidArgumentException for unknown entity classes instead of silent false
- Add IFilePostProcessorService / IFilePostProcessorForChildEntity interfaces
- Add CompanyService::processFileForChildEntity() handling 'logo' and 'big_logo' members: downloads from remote storage, verifies size and MD5, builds UploadedFile, cleans up temp files in finally block
- Fix md5_file() false detection: I/O failure and hash mismatch now produce distinct error messages
- Use Company::LogoAllowedExtensions constant in addCompanyLogo/addCompanyBigLogo (removed local copies)
- Update OAuth2CompaniesApiController: addCompanyLogo/addCompanyBigLogo now accept both multipart/form-data (file upload) and application/json (async file-api payload); intval() cast on company_id
- Update OpenAPI specs for both endpoints: dual RequestBody with multipart and JSON MediaType entries; 412 removed; description updated
- Fix CompanyValidationRulesFactory::buildForFileInfo() signature (remove unused $data param)
- Remove unused Illuminate\Support\Facades\Request import from controller
- Register FilePostProcessorService in AppServiceProvider and ModelServicesProvider

Tests:
- Add CompanyFileProcessingTest (5 unit tests): unknown member name, MD5 mismatch vs I/O error distinction, big_logo mismatch, unknown entity class throws, FileInfoDTO queue serialization round-trip
- Add OAuth2CompaniesApiTest dual-flow functional tests (6 tests): logo multipart, logo JSON payload, logo JSON missing fields -> 412, big_logo multipart, big_logo JSON payload, backward-compat shim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Company logos now support dual upload methods (multipart file upload or JSON payload referencing a previously stored file), including small and big logos.
  * File metadata support added (MD5, MIME type, source bucket), and logo processing can run asynchronously in the background.
* **Bug Fixes**
  * Improved validation and error handling during logo file processing, including clearer MD5 mismatch reporting.
* **Documentation**
  * Updated OpenAPI/Swagger schemas for company logo requests and the shared FileDTO payload.
* **Tests**
  * Added/expanded tests for multipart and JSON logo uploads plus async post-processing validation and DTO serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->