### PR TITLE
Fix inverted badge type null check on ticket data import

### DIFF
--- a/app/Services/Model/Imp/SummitOrderService.php
+++ b/app/Services/Model/Imp/SummitOrderService.php
@@ -4614,7 +4614,7 @@ final class SummitOrderService
 
                 if (!$ticket->hasBadge()) {
                     // create it
-                    if (!is_null($badge_type)) {
+                    if (is_null($badge_type)) {
                         Log::warning("SummitOrderService::processTicketData badge type is null stop current row processing.");
                         return;
                     }

--- a/tests/SummitOrderServiceTest.php
+++ b/tests/SummitOrderServiceTest.php
@@ -678,4 +678,23 @@ CSV;
         $this->assertNotNull($answer);
         $this->assertEquals('Vegan', $answer->getValue());
     }
+
+    public function testImportTicketDataCreatesBadgeWhenTicketHasNone()
+    {
+        Queue::fake();
+
+        $ticket = $this->getUnassignedTicket();
+        $this->assertFalse($ticket->hasBadge());
+
+        $csv_content = <<<CSV
+number,attendee_email,attendee_first_name,attendee_last_name,badge_type_name
+{$ticket->getNumber()},new.attendee@nowhere.com,New,Attendee,BADGE TYPE1
+CSV;
+
+        $service = $this->buildTicketDataImportService($csv_content);
+        $service->processTicketData(self::$summit->getId(), 'tickets.csv');
+
+        $this->assertTrue($ticket->hasBadge());
+        $this->assertEquals('BADGE TYPE1', $ticket->getBadge()->getType()->getName());
+    }
 }

--- a/tests/SummitOrderServiceTest.php
+++ b/tests/SummitOrderServiceTest.php
@@ -683,7 +683,34 @@ CSV;
     {
         Queue::fake();
 
-        $ticket = $this->getUnassignedTicket();
+        // every fixture ticket type carries a badge type, so SummitTicketType::applyTo
+        // auto-creates a badge at setTicketType time — build a ticket from a type with
+        // no badge type to get a genuinely badge-less ticket
+        $ticket_type = new SummitTicketType();
+        $ticket_type->setName('NO BADGE TICKET TYPE');
+        $ticket_type->setCost(100);
+        $ticket_type->setCurrency('USD');
+        $ticket_type->setQuantity2Sell(10);
+        $ticket_type->setAudience(SummitTicketType::Audience_All);
+        self::$summit->addTicketType($ticket_type);
+
+        $order = new SummitOrder();
+        $order->setOwner(self::$defaultMember);
+        $order->setSummit(self::$summit);
+        self::$summit->addOrder($order);
+
+        $ticket = new SummitAttendeeTicket();
+        $ticket->setTicketType($ticket_type);
+        $ticket->activate();
+        $order->addTicket($ticket);
+        $order->setPaid();
+        $order->generateNumber();
+        $ticket->generateNumber();
+        $ticket->generateQRCode();
+
+        self::$em->persist(self::$summit);
+        self::$em->flush();
+
         $this->assertFalse($ticket->hasBadge());
 
         $csv_content = <<<CSV


### PR DESCRIPTION
## Summary
`SummitOrderService::processTicketData` badge creation for tickets without a badge had an inverted null check: it returned early when a badge type **was** provided, and would throw a `TypeError` on `SummitBadgeType::buildBadgeFromType(null)` when it wasn't. Net effect: import could never create a badge — only tickets that already had one could have their badge updated.

One-line fix (`!is_null` → `is_null`) plus a regression test that imports a row for a badge-less ticket with `badge_type_name` set and asserts the badge is created with the right type.

Stacked on #567 (the test reuses its import-test helpers). Retarget to `main` after that merges, or merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)