### PR TITLE
fix: dispatch original entity id in DeletedEventDTO, not a post-flush getId()

### DIFF
--- a/app/Events/SponsorServices/DeletedEventDTO.php
+++ b/app/Events/SponsorServices/DeletedEventDTO.php
@@ -27,6 +27,11 @@ class DeletedEventDTO
         return new self($entity->getId());
     }
 
+    public static function fromId(int $id): self
+    {
+        return new self($id);
+    }
+
     public function serialize(): array
     {
         return [

--- a/app/Services/Model/Imp/SummitMediaFileTypeService.php
+++ b/app/Services/Model/Imp/SummitMediaFileTypeService.php
@@ -117,7 +117,7 @@ extends AbstractModelService
         });
 
         PublishSponsorServiceDomainEventsJob::dispatch(
-            DeletedEventDTO::fromEntity($type)->serialize(),
+            DeletedEventDTO::fromId($id)->serialize(),
             SummitMediaFileTypeDomainEvents::SummitMediaFileTypeDeleted);
     }
 }

--- a/app/Services/Model/Imp/SummitService.php
+++ b/app/Services/Model/Imp/SummitService.php
@@ -1719,7 +1719,7 @@ final class SummitService
         });
 
         PublishSponsorServiceDomainEventsJob::dispatch(
-            DeletedEventDTO::fromEntity($summit)->serialize(), SummitDomainEvents::SummitDeleted);
+            DeletedEventDTO::fromId($summit_id)->serialize(), SummitDomainEvents::SummitDeleted);
     }
 
     /**

--- a/app/Services/Model/Imp/SummitSponsorService.php
+++ b/app/Services/Model/Imp/SummitSponsorService.php
@@ -444,7 +444,7 @@ final class SummitSponsorService
         });
 
         PublishSponsorServiceDomainEventsJob::dispatch(
-            DeletedEventDTO::fromEntity($sponsor)->serialize(),
+            DeletedEventDTO::fromId($sponsor_id)->serialize(),
             SponsorDomainEvents::SponsorDeleted);
     }
 

--- a/app/Services/Model/Imp/SummitSponsorshipService.php
+++ b/app/Services/Model/Imp/SummitSponsorshipService.php
@@ -113,7 +113,7 @@ final class SummitSponsorshipService extends AbstractService implements ISummitS
             SponsorDomainEvents::SponsorUpdated);
 
         PublishSponsorServiceDomainEventsJob::dispatch(
-            DeletedEventDTO::fromEntity($sponsorship)->serialize(),
+            DeletedEventDTO::fromId($sponsorship_id)->serialize(),
             SponsorDomainEvents::SponsorshipRemoved);
     }
 
@@ -253,7 +253,7 @@ final class SummitSponsorshipService extends AbstractService implements ISummitS
             SponsorDomainEvents::SponsorshipUpdated);
 
         PublishSponsorServiceDomainEventsJob::dispatch(
-            DeletedEventDTO::fromEntity($add_on)->serialize(),
+            DeletedEventDTO::fromId($add_on_id)->serialize(),
             SponsorDomainEvents::SponsorshipAddOnRemoved);
     }
 

--- a/tests/Unit/Services/SummitMediaFileTypeServiceEventDispatchTest.php
+++ b/tests/Unit/Services/SummitMediaFileTypeServiceEventDispatchTest.php
@@ -1,0 +1,78 @@
+<?php namespace Tests\Unit\Services;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Events\SponsorServices\SummitMediaFileTypeDomainEvents;
+use App\Jobs\SponsorServices\PublishSponsorServiceDomainEventsJob;
+use App\Services\Model\ISummitMediaFileTypeService;
+use Illuminate\Support\Facades\Queue;
+use models\summit\SummitMediaFileType;
+use Tests\InsertSummitTestData;
+use Tests\TestCase;
+
+/**
+ * Class SummitMediaFileTypeServiceEventDispatchTest
+ *
+ * Regression coverage for the same 'id' => 0 dispatch bug fixed in
+ * SummitSponsorshipServiceEventDispatchTest: SummitMediaFileTypeService::delete()
+ * removes the entity inside the transaction (real Doctrine remove(), not a
+ * soft-delete), which flushes before the domain event dispatch. Doctrine nulls
+ * the identifier on the deleted entity, so DeletedEventDTO::fromEntity($type)
+ * read a stale getId(). The fix builds the DTO from the id captured before
+ * removal (DeletedEventDTO::fromId($id)).
+ *
+ * @package Tests\Unit\Services
+ */
+class SummitMediaFileTypeServiceEventDispatchTest extends TestCase
+{
+    use InsertSummitTestData;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::insertSummitTestData();
+    }
+
+    public function tearDown(): void
+    {
+        self::clearSummitTestData();
+        parent::tearDown();
+    }
+
+    private function getService(): ISummitMediaFileTypeService
+    {
+        return app(ISummitMediaFileTypeService::class);
+    }
+
+    public function testDeleteDispatchesSummitMediaFileTypeDeletedWithOriginalId(): void
+    {
+        $type = new SummitMediaFileType();
+        $type->setName('Test Type ' . str_random(6));
+        $type->setDescription('desc');
+        $type->setAllowedExtensions('.PDF');
+        self::$em->persist($type);
+        self::$em->flush();
+        $id = $type->getId();
+
+        Queue::fake();
+
+        $this->getService()->delete($id);
+
+        $jobs = Queue::pushed(PublishSponsorServiceDomainEventsJob::class, function ($job) {
+            return $job->getEventType() === SummitMediaFileTypeDomainEvents::SummitMediaFileTypeDeleted;
+        })->all();
+
+        $this->assertCount(1, $jobs, 'Expected 1 SummitMediaFileTypeDeleted');
+        $this->assertSame($id, $jobs[0]->getPayload()['id'], 'Dispatched id must be the removed type id, not 0');
+    }
+}

--- a/tests/Unit/Services/SummitServiceEventDispatchTest.php
+++ b/tests/Unit/Services/SummitServiceEventDispatchTest.php
@@ -1,0 +1,69 @@
+<?php namespace Tests\Unit\Services;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Events\SponsorServices\SummitDomainEvents;
+use App\Jobs\SponsorServices\PublishSponsorServiceDomainEventsJob;
+use Illuminate\Support\Facades\Queue;
+use services\model\ISummitService;
+use Tests\InsertSummitTestData;
+use Tests\TestCase;
+
+/**
+ * Class SummitServiceEventDispatchTest
+ *
+ * Companion to SummitSponsorshipServiceEventDispatchTest: verifies the
+ * dispatched 'id' for SummitDeleted matches the original summit id. Unlike
+ * the sponsorship/add-on/media-file-type cases, deleteSummit() only flips a
+ * soft-delete flag (no Doctrine remove()), so this is a characterization test
+ * confirming the id was never actually zeroed here - see test body.
+ *
+ * @package Tests\Unit\Services
+ */
+class SummitServiceEventDispatchTest extends TestCase
+{
+    use InsertSummitTestData;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::insertSummitTestData();
+    }
+
+    public function tearDown(): void
+    {
+        self::clearSummitTestData();
+        parent::tearDown();
+    }
+
+    private function getService(): ISummitService
+    {
+        return app(ISummitService::class);
+    }
+
+    public function testDeleteSummitDispatchesSummitDeletedWithOriginalId(): void
+    {
+        $summit_id = self::$summit->getId();
+
+        Queue::fake();
+
+        $this->getService()->deleteSummit($summit_id);
+
+        $jobs = Queue::pushed(PublishSponsorServiceDomainEventsJob::class, function ($job) {
+            return $job->getEventType() === SummitDomainEvents::SummitDeleted;
+        })->all();
+
+        $this->assertCount(1, $jobs, 'Expected 1 SummitDeleted');
+        $this->assertSame($summit_id, $jobs[0]->getPayload()['id'], 'Dispatched id must be the deleted summit id, not 0');
+    }
+}

--- a/tests/Unit/Services/SummitSponsorServiceEventDispatchTest.php
+++ b/tests/Unit/Services/SummitSponsorServiceEventDispatchTest.php
@@ -205,4 +205,31 @@ class SummitSponsorServiceEventDispatchTest extends TestCase
 
         $this->assertLessThan($created_idx, $removed_idx, 'SponsorshipRemoved must be dispatched before SponsorshipCreated');
     }
+
+    // -------------------------------------------------------------------------
+    // deleteSponsor - regression: dispatched id must be the removed sponsor id,
+    // not 0 (Doctrine nulls the identifier after the orphan-removal flush, so
+    // building the DTO from the entity after the transaction closed read a
+    // stale getId(); the fix builds it from the id captured before removal).
+    // -------------------------------------------------------------------------
+
+    public function testDeleteSponsorDispatchesSponsorDeletedWithOriginalId(): void
+    {
+        // Fixture sponsors may have a SponsorSummitRegistrationDiscountCode FK
+        // attached (InsertSummitTestData assigns them randomly), which blocks a
+        // hard delete. Use a fresh, unrelated sponsor instead.
+        $sponsor = $this->getService()->addSponsor(self::$summit, [
+            'company_id'     => self::$companies_without_sponsor[0]->getId(),
+            'sponsorship_id' => self::$default_summit_sponsor_type->getId(),
+        ]);
+        $sponsor_id = $sponsor->getId();
+
+        Queue::fake();
+
+        $this->getService()->deleteSponsor(self::$summit, $sponsor_id);
+
+        $jobs = $this->jobsFor(SponsorDomainEvents::SponsorDeleted);
+        $this->assertCount(1, $jobs, 'Expected 1 SponsorDeleted');
+        $this->assertSame($sponsor_id, $jobs[0]->getPayload()['id'], 'Dispatched id must be the removed sponsor id, not 0');
+    }
 }

--- a/tests/Unit/Services/SummitSponsorshipServiceEventDispatchTest.php
+++ b/tests/Unit/Services/SummitSponsorshipServiceEventDispatchTest.php
@@ -1,0 +1,98 @@
+<?php namespace Tests\Unit\Services;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Events\SponsorServices\SponsorDomainEvents;
+use App\Jobs\SponsorServices\PublishSponsorServiceDomainEventsJob;
+use App\Services\Model\ISummitSponsorshipService;
+use Illuminate\Support\Facades\Queue;
+use Tests\InsertSummitTestData;
+use Tests\TestCase;
+
+/**
+ * Class SummitSponsorshipServiceEventDispatchTest
+ *
+ * Regression coverage for a bug where SponsorshipRemoved/SponsorshipAddOnRemoved
+ * jobs were dispatched with 'id' => 0: the removed entity had already been
+ * flushed (Doctrine nulls the identifier on a deleted entity), so building the
+ * DeletedEventDTO from the entity (DeletedEventDTO::fromEntity($entity)) after
+ * the transaction closed read a stale getId(). The fix builds the DTO from the
+ * id captured before removal (DeletedEventDTO::fromId($id)).
+ *
+ * @package Tests\Unit\Services
+ */
+class SummitSponsorshipServiceEventDispatchTest extends TestCase
+{
+    use InsertSummitTestData;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::insertSummitTestData();
+    }
+
+    public function tearDown(): void
+    {
+        self::clearSummitTestData();
+        parent::tearDown();
+    }
+
+    private function getService(): ISummitSponsorshipService
+    {
+        return app(ISummitSponsorshipService::class);
+    }
+
+    /**
+     * @return PublishSponsorServiceDomainEventsJob[]
+     */
+    private function jobsFor(string $event_type): array
+    {
+        return Queue::pushed(PublishSponsorServiceDomainEventsJob::class, function ($job) use ($event_type) {
+            return $job->getEventType() === $event_type;
+        })->all();
+    }
+
+    public function testRemoveSponsorshipDispatchesSponsorshipRemovedWithOriginalId(): void
+    {
+        $sponsor = self::$sponsors[0];
+        $sponsorship = $sponsor->getSponsorships()->first();
+        $this->assertNotFalse($sponsorship, 'Pre-condition: sponsor must have a sponsorship');
+        $sponsorship_id = $sponsorship->getId();
+
+        Queue::fake();
+
+        $this->getService()->removeSponsorship(self::$summit, $sponsor->getId(), $sponsorship_id);
+
+        $jobs = $this->jobsFor(SponsorDomainEvents::SponsorshipRemoved);
+        $this->assertCount(1, $jobs, 'Expected 1 SponsorshipRemoved');
+        $this->assertSame($sponsorship_id, $jobs[0]->getPayload()['id'], 'Dispatched id must be the removed sponsorship id, not 0');
+    }
+
+    public function testRemoveAddOnDispatchesSponsorshipAddOnRemovedWithOriginalId(): void
+    {
+        $sponsor = self::$sponsors[0];
+        $sponsorship = $sponsor->getSponsorships()->first();
+        $this->assertNotFalse($sponsorship, 'Pre-condition: sponsor must have a sponsorship');
+        $add_on = $sponsorship->getAddOns()->first();
+        $this->assertNotFalse($add_on, 'Pre-condition: sponsorship must have an add-on');
+        $add_on_id = $add_on->getId();
+
+        Queue::fake();
+
+        $this->getService()->removeAddOn(self::$summit, $sponsor->getId(), $sponsorship->getId(), $add_on_id);
+
+        $jobs = $this->jobsFor(SponsorDomainEvents::SponsorshipAddOnRemoved);
+        $this->assertCount(1, $jobs, 'Expected 1 SponsorshipAddOnRemoved');
+        $this->assertSame($add_on_id, $jobs[0]->getPayload()['id'], 'Dispatched id must be the removed add-on id, not 0');
+    }
+}


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bb35agx

Doctrine nulls an entity's identifier field via reflection after a hard delete is flushed (UnitOfWork::executeDeletions). DeletedEventDTO::fromEntity() was being called after the owning transaction closed, so it read that stale, zeroed id and dispatched 'id' => 0 in the domain event payload.

Added DeletedEventDTO::fromId() and switched the affected dispatch call sites to build the DTO from the id captured before removal:

- SummitSponsorshipService::removeSponsorship / removeAddOn
- SummitSponsorService::deleteSponsor
- SummitMediaFileTypeService::delete

Also applied the same fromId() call in SummitService::deleteSummit for consistency, though that path only flips a soft-delete flag (no em->remove()), so it never actually reproduced the zeroed-id bug.

Added regression tests for all four dispatch paths, verified against the pre-fix code to confirm they fail with the original id => 0 defect (SummitService's stays green either way, per the note above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected deletion events so they consistently include the original record ID.
  - Improved event accuracy for deleted summits, sponsors, sponsorships, add-ons, and media file types.
  - Prevented deleted-record events from containing missing, zero, or outdated identifiers.

- **Tests**
  - Added coverage validating deletion event payloads across supported sponsor service operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->