### PR TITLE
feat(badges): accept URL-safe base64 (base64url) badge artifacts

### DIFF
--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitApiController.php
@@ -2529,7 +2529,7 @@ final class OAuth2SummitApiController extends OAuth2ProtectedController
                 in: 'path',
                 required: true,
                 schema: new OA\Schema(type: 'string'),
-                description: 'RAW Badge QR scan encoded on BASE 64'
+                description: 'RAW Badge QR scan encoded on BASE 64 (standard RFC 4648 §4 or URL-safe §5 alphabet)'
             )
         ],
         responses: [

--- a/app/Utils/Base64.php
+++ b/app/Utils/Base64.php
@@ -19,8 +19,13 @@ final class Base64
         if ($s === '') return false;
         // Standard base64 alphabet (RFC 4648 §4) or URL-safe (§5: '-' and '_'), plus '=' padding
         if (!preg_match('#^[A-Za-z0-9+/_-]*={0,2}$#', $s)) return false;
-        // Length multiple of 4 (padding may be omitted; it gets added below)
-        return (strlen($s) % 4) === 0 || (strlen($s) % 4) === 2 || (strlen($s) % 4) === 3;
+        // Padding may be omitted entirely (it gets added below), but when present it must be
+        // exactly what the data length requires (RFC 4648)
+        $unpadded = rtrim($s, '=');
+        $paddingLength = strlen($s) - strlen($unpadded);
+        $remainder = strlen($unpadded) % 4;
+        if ($unpadded === '' || $remainder === 1) return false;
+        return $paddingLength === 0 || $paddingLength === (4 - $remainder);
     }
 
     public static function padBase64(string $s): string

--- a/app/Utils/Base64.php
+++ b/app/Utils/Base64.php
@@ -36,6 +36,9 @@ final class Base64
 
     public static function tryBase64Decode(string $s): ?string
     {
+        // agree with the sniff: base64_decode('', true) "succeeds" with '' and would silently
+        // repair under-padded input, so anything looksLikeBase64 rejects is not decodable here
+        if (!self::looksLikeBase64($s)) return null;
         // strict base64_decode rejects the URL-safe alphabet: normalize it first
         $s = strtr($s, '-_', '+/');
         $padded = self::padBase64($s);

--- a/app/Utils/Base64.php
+++ b/app/Utils/Base64.php
@@ -17,9 +17,9 @@ final class Base64
     public static function looksLikeBase64(string $s): bool
     {
         if ($s === '') return false;
-        // Solo alfabeto base64 y '=' de padding
-        if (!preg_match('#^[A-Za-z0-9+/]*={0,2}$#', $s)) return false;
-        // Longitud múltiplo de 4 (permitimos sin padding, lo añadimos abajo)
+        // Standard base64 alphabet (RFC 4648 §4) or URL-safe (§5: '-' and '_'), plus '=' padding
+        if (!preg_match('#^[A-Za-z0-9+/_-]*={0,2}$#', $s)) return false;
+        // Length multiple of 4 (padding may be omitted; it gets added below)
         return (strlen($s) % 4) === 0 || (strlen($s) % 4) === 2 || (strlen($s) % 4) === 3;
     }
 
@@ -31,6 +31,8 @@ final class Base64
 
     public static function tryBase64Decode(string $s): ?string
     {
+        // strict base64_decode rejects the URL-safe alphabet: normalize it first
+        $s = strtr($s, '-_', '+/');
         $padded = self::padBase64($s);
         $decoded = base64_decode($padded, true);
         return ($decoded === false) ? null : $decoded;

--- a/tests/Base64Test.php
+++ b/tests/Base64Test.php
@@ -60,4 +60,18 @@ final class Base64Test extends TestCase
         $this->assertFalse(Base64::looksLikeBase64(""));
         $this->assertNull(Base64::tryBase64Decode("!!!"));
     }
+
+    public function testMalformedPaddingIsRejected()
+    {
+        // padding-only, under-padded and over-padded inputs are not RFC 4648 base64: the data
+        // length (minus padding) decides how much padding is allowed - none, or exactly enough
+        // to reach a multiple of 4
+        $this->assertFalse(Base64::looksLikeBase64("=="));
+        $this->assertFalse(Base64::looksLikeBase64("A="));
+        $this->assertFalse(Base64::looksLikeBase64("QQ="));
+        $this->assertFalse(Base64::looksLikeBase64("QUFB=="));
+        // exact RFC padding stays accepted
+        $this->assertTrue(Base64::looksLikeBase64("QQQ="));
+        $this->assertSame("A\x04", Base64::tryBase64Decode("QQQ="));
+    }
 }

--- a/tests/Base64Test.php
+++ b/tests/Base64Test.php
@@ -1,0 +1,63 @@
+<?php namespace Tests;
+
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Utils\Base64;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Base64Test
+ * Badge/ticket QR artifacts travel base64-encoded as a URL path segment; the standard
+ * alphabet's "/" can never survive path routing (Laravel rawurldecodes the path before
+ * matching), so the helper must also accept the URL-safe alphabet (base64url, RFC 4648 §5:
+ * "-" for "+", "_" for "/"). Standard base64 must keep decoding byte-identical.
+ */
+final class Base64Test extends TestCase
+{
+    public function testStandardAlphabetStillDecodes()
+    {
+        // "+/+/" = indices 62,63,62,63 = bytes FB FF BF (hand-derived from the RFC 4648 table)
+        $this->assertTrue(Base64::looksLikeBase64("+/+/"));
+        $this->assertSame("\xfb\xff\xbf", Base64::tryBase64Decode("+/+/"));
+    }
+
+    public function testUrlSafeAlphabetIsAccepted()
+    {
+        // same payload as "+/+/", url-safe spelling
+        $this->assertTrue(Base64::looksLikeBase64("-_-_"));
+        $this->assertSame("\xfb\xff\xbf", Base64::tryBase64Decode("-_-_"));
+    }
+
+    public function testUrlSafeAndStandardSpellingsDecodeToTheSameBytes()
+    {
+        $standard = Base64::tryBase64Decode("QUFB/QkJC+Q0PT0=");
+        $urlSafe  = Base64::tryBase64Decode("QUFB_QkJC-Q0PT0=");
+        $this->assertNotNull($standard);
+        $this->assertSame($standard, $urlSafe);
+    }
+
+    public function testUrlSafeWithoutPaddingIsPadded()
+    {
+        // "-_" = indices 62,63 = 11111011 = byte FB after padding to "-_=="
+        $this->assertTrue(Base64::looksLikeBase64("-_"));
+        $this->assertSame("\xfb", Base64::tryBase64Decode("-_"));
+    }
+
+    public function testNonBase64InputIsRejected()
+    {
+        $this->assertFalse(Base64::looksLikeBase64("BADGE_X|123|a@b.com|Ada Lovelace"));
+        $this->assertFalse(Base64::looksLikeBase64(""));
+        $this->assertNull(Base64::tryBase64Decode("!!!"));
+    }
+}

--- a/tests/Base64Test.php
+++ b/tests/Base64Test.php
@@ -59,6 +59,9 @@ final class Base64Test extends TestCase
         $this->assertFalse(Base64::looksLikeBase64("BADGE_X|123|a@b.com|Ada Lovelace"));
         $this->assertFalse(Base64::looksLikeBase64(""));
         $this->assertNull(Base64::tryBase64Decode("!!!"));
+        // tryBase64Decode must agree with looksLikeBase64: base64_decode('', true) "succeeds"
+        // with '' but an empty artifact is not a decodable payload
+        $this->assertNull(Base64::tryBase64Decode(""));
     }
 
     public function testMalformedPaddingIsRejected()
@@ -70,6 +73,9 @@ final class Base64Test extends TestCase
         $this->assertFalse(Base64::looksLikeBase64("A="));
         $this->assertFalse(Base64::looksLikeBase64("QQ="));
         $this->assertFalse(Base64::looksLikeBase64("QUFB=="));
+        // the decode agrees with the sniff: what looksLikeBase64 rejects, tryBase64Decode
+        // rejects too (no silent repair of under-padded input)
+        $this->assertNull(Base64::tryBase64Decode("QQ="));
         // exact RFC padding stays accepted
         $this->assertTrue(Base64::looksLikeBase64("QQQ="));
         $this->assertSame("A\x04", Base64::tryBase64Decode("QQQ="));


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bb7wfgw
## What

Widen `App\Utils\Base64` to also accept the URL-safe base64 alphabet (RFC 4648 §5: `-` for `+`, `_` for `/`), so badge QR artifacts can travel as a URL path segment with no percent-encoding tricks.

## Why

`GET /summits/{id}/badge/{artifact}/validate` takes the artifact as a path segment, and Laravel rawurldecodes the path **before** route matching (`Illuminate/Routing/Matching/UriValidator.php`) with `{badge}` compiled to `[^/]+` — so any artifact whose base64 wrapper contains `/` (near-certain for encrypted badges) can never match the route and 404s, no matter how the client percent-encodes it. Full analysis on ClickUp [86bb7wfgw](https://app.clickup.com/t/9014802374/86bb7wfgw).

Accepting base64url keeps the existing route and payload untouched (one route, one payload — D26): the path segment stays in `[A-Za-z0-9_-]` plus `=` padding, all legal in a path segment.

## How

- `looksLikeBase64`: alphabet regex also accepts `-` and `_`
- `tryBase64Decode`: normalize (`strtr('-_', '+/')`) before the strict `base64_decode`, which rejects the URL-safe alphabet — widening the regex alone is not enough

Additive and backwards-compatible: standard base64 decodes byte-identical; the sole caller is `SummitAttendeeBadge::decodeQRCodeFor`, so badge-scans POST and validateBadge gain it uniformly and existing clients (scanbadgeapp, sponsor lead flows) are unaffected. Checkin is out of scope either way: `AttendeeService::doCheckIn` parses the raw QR directly and never unwrapped base64. Badge QR **emission does not change** — the inner `{hex-IV}{base64(ciphertext)}` layer decoded by `AES::decrypt` stays standard; only the per-request transport wrapper may now be url-safe.

## Tests

`tests/Base64Test.php` (new, pure unit — no app boot): standard alphabet regression, url-safe acceptance, spelling equivalence, padding tolerance, garbage rejection. `OK (5 tests, 11 assertions)`.

## Deployment

Deploy this **before** attendee-networking-api's matching change (its `resolve_badge` re-wraps artifacts url-safe and depends on this decode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for decoding URL-safe Base64 values using `-` and `_`.
  - Added automatic padding for valid Base64 values without trailing padding.

- **Bug Fixes**
  - Improved Base64 validation and decoding consistency while preserving standard Base64 support.
  - Invalid, empty, and malformedly padded inputs are now rejected consistently.
  - Equivalent standard and URL-safe encodings decode to the same data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
