### PR TITLE
fix: gate public presentation serialization on display_on_site for media uploads

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -68,7 +68,7 @@ jobs:
                     - { name: "CacheOptimizations", filter: "--filter '(PresentationSpeakerCacheTest|ResourceServerContextTest)'" }
                     # Named by path because no job in this matrix runs the tests/ root, only its
                     # subdirectories - a file added there runs nowhere unless it is listed here.
-                    - { name: "PresentationMediaUploads", filter: "tests/PresentationMediaUploadsTest.php tests/PresentationMediaUploadsVisibilityTest.php" }
+                    - { name: "PresentationMediaUploads", filter: "tests/PresentationMediaUploadsTest.php tests/PresentationMediaUploadsVisibilityTest.php tests/PresentationSerializerCacheKeyTest.php" }
         env:
             OTEL_SERVICE_ENABLED: false
             APP_ENV: testing

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,6 +66,9 @@ jobs:
                     - { name: "Repositories", filter: "tests/Repositories/" }
                     - { name: "Services", filter: "tests/Unit/Services/" }
                     - { name: "CacheOptimizations", filter: "--filter '(PresentationSpeakerCacheTest|ResourceServerContextTest)'" }
+                    # Named by path because no job in this matrix runs the tests/ root, only its
+                    # subdirectories - a file added there runs nowhere unless it is listed here.
+                    - { name: "PresentationMediaUploads", filter: "tests/PresentationMediaUploadsTest.php tests/PresentationMediaUploadsVisibilityTest.php" }
         env:
             OTEL_SERVICE_ENABLED: false
             APP_ENV: testing

--- a/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
@@ -91,6 +91,26 @@ class PresentationSerializer extends SummitEventSerializer
         return $serializerType;
     }
 
+    /**
+     * Media uploads visible to the resolved serializer type. A Public caller (no admin/editor
+     * privilege on this presentation) only ever sees uploads marked display_on_site=true — an
+     * uploaded-but-not-yet-approved draft (display_on_site=false, the model's own default) must
+     * never reach an unauthenticated/public response, even via ?expand=media_uploads on the
+     * public events/published endpoints.
+     * @return \Doctrine\Common\Collections\Collection|PresentationMediaUpload[]
+     */
+    protected function getVisibleMediaUploads()
+    {
+        $presentation = $this->object;
+        $mediaUploads = $presentation->getMediaUploads();
+        if ($this->getMediaUploadsSerializerType() === SerializerRegistry::SerializerType_Private) {
+            return $mediaUploads;
+        }
+        return $mediaUploads->filter(function ($mediaUpload) {
+            return $mediaUpload->getDisplayOnSite();
+        });
+    }
+
 
     /**
      * @param null $expand
@@ -130,7 +150,7 @@ class PresentationSerializer extends SummitEventSerializer
                         {
                             $media_uploads = [];
 
-                            foreach ($presentation->getMediaUploads() as $mediaUpload) {
+                            foreach ($this->getVisibleMediaUploads() as $mediaUpload) {
                                 $media_uploads[] = SerializerRegistry::getInstance()->getSerializer
                                 (
                                     $mediaUpload, $this->getMediaUploadsSerializerType()
@@ -195,7 +215,7 @@ class PresentationSerializer extends SummitEventSerializer
         if(in_array('media_uploads', $relations))
         {
             $media_uploads = [];
-            foreach ($presentation->getMediaUploads() as $mediaUpload) {
+            foreach ($this->getVisibleMediaUploads() as $mediaUpload) {
                 $media_uploads[] = $mediaUpload->getId();
             }
 
@@ -337,7 +357,7 @@ class PresentationSerializer extends SummitEventSerializer
                     case 'media_uploads':{
                         $media_uploads = [];
 
-                        foreach ($presentation->getMediaUploads() as $mediaUpload) {
+                        foreach ($this->getVisibleMediaUploads() as $mediaUpload) {
                             $media_uploads[] = SerializerRegistry::getInstance()->getSerializer
                             (
                                 $mediaUpload, $this->getMediaUploadsSerializerType()

--- a/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
@@ -224,10 +224,18 @@ class PresentationSerializer extends SummitEventSerializer
 
         $use_cache = $params['use_cache'] ?? false;
 
-        if($use_cache && Cache::has($key)){
-            $values = json_decode(Cache::get($key), true);
-            Log::debug(sprintf("PresentationSerializer::serialize cache hit for presentation %s", $presentation->getId()));
-            return $this->withMediaUploads($values, $expand, $fields, $relations);
+        if($use_cache){
+            // One read, not Cache::has() followed by Cache::get(): the entry can expire on its
+            // own TTL, be evicted, or be flushed in the window between the two, and the second
+            // call would then hand back null for a key the first call vouched for. Anything that
+            // does not decode to an array - a miss, that race, a truncated write - falls through
+            // and is rebuilt.
+            $cached = Cache::get($key);
+            $values = is_string($cached) ? json_decode($cached, true) : null;
+            if(is_array($values)){
+                Log::debug(sprintf("PresentationSerializer::serialize cache hit for presentation %s", $presentation->getId()));
+                return $this->withMediaUploads($values, $expand, $fields, $relations);
+            }
         }
 
         $values = parent::serialize($expand, $fields, $relations, $params);

--- a/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
@@ -209,17 +209,55 @@ class PresentationSerializer extends SummitEventSerializer
         $presentation = $this->object;
         if(!$presentation instanceof Presentation) return [];
 
-        // Include last_edited timestamp so a presentation update naturally busts the cache
-        // without needing an explicit Cache::forget — the old key just ages out via TTL.
+        // fields and relations are read with in_array() throughout, so their order cannot change
+        // the payload and sorting lets two spellings of one request share an entry. $expand is
+        // deliberately NOT sorted: its relations are dispatched in the order given, and the
+        // speakers and moderator cases both write $values['moderator'] while disagreeing about
+        // moderator_speaker_id, so the order is capable of changing the result.
+        $cache_fields = $fields;
+        $cache_relations = $relations;
+        sort($cache_fields);
+        sort($cache_relations);
+
+        // The digest covers everything that shapes the payload and is not already named in the
+        // readable part of the key. static::class is in it because this method is inherited:
+        // AdminPresentationSerializer and the track-chair and CSV serializers all cache through
+        // here, and their merged $array_mappings add fields the public serializer never emits.
+        //
+        // INVARIANT: anything the payload depends on either appears here or stays out of the
+        // cache. static::class covers audience today only because the remaining differences are
+        // class-determined - the mappings are static, getSerializerType() returns a constant per
+        // class, and media_uploads, the one per-user field, is stripped before Cache::put. A
+        // per-user value added to the mappings, or read before parent::serialize() rather than
+        // after it the way AdminPresentationCSVSerializer and TrackChairPresentationSerializer
+        // do, would silently break that.
+        //
+        // json_encode rather than concatenation: the parts contain "_" and "," themselves
+        // (media_uploads, extra_questions, selection_plan), so joining them on those characters
+        // let distinct requests render one key. sha256 rather than md5 because the parts come
+        // from the query string and a collision here means serving one audience's payload to
+        // another - the exact failure the class component is here to prevent.
+        //
+        // last_edited stays readable so a presentation update naturally busts every entry it has
+        // without an explicit Cache::forget, and so an operator can still scan or drop one
+        // presentation's entries by pattern.
         $key =
             sprintf
             (
-                "public_presentation_%s_%s_%s_%s_%s",
+                "presentation_%s_%s_%s",
                 $presentation->getId(),
                 $presentation->getLastEditedUTC()?->getTimestamp() ?? 0,
-                $expand ?? "",
-                implode(",",$fields),
-                implode(",", $relations)
+                hash
+                (
+                    'sha256',
+                    json_encode
+                    ([
+                        'serializer' => static::class,
+                        'expand'     => $expand ?? "",
+                        'fields'     => $cache_fields,
+                        'relations'  => $cache_relations,
+                    ])
+                )
             );
 
         $use_cache = $params['use_cache'] ?? false;

--- a/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
@@ -12,9 +12,11 @@
  * limitations under the License.
  **/
 
+use App\Security\SummitScopes;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Libs\ModelSerializers\AbstractSerializer;
+use models\oauth2\IResourceServerContext;
 use models\summit\Presentation;
 use models\summit\PresentationType;
 
@@ -79,13 +81,40 @@ class PresentationSerializer extends SummitEventSerializer
     ];
 
     /**
+     * Resolves who is allowed to see every media upload attached to this presentation, approved
+     * or not. Kept aligned with OAuth2SummitEventsApiController::getSerializerType(), which is
+     * what decides the serializer type of the presentation itself - when the two disagree the
+     * presentation is served Private while its uploads are served Public, which is the bug this
+     * method used to have for summit admins and for service accounts.
+     *
+     * Two distinct privileged callers:
+     *
+     * - Service accounts (client_credentials, so getCurrentUser() is null by construction) that
+     *   hold the dedicated snapshot scope. The content pipeline stages files pre-event, so it
+     *   needs unapproved uploads. Gated on the scope and not on ApplicationType_Service alone:
+     *   the application type on its own would hand drafts to every service client.
+     * - Members with an admin-level group, or with edit rights over this presentation
+     *   (creator / moderator / speaker).
+     *
      * @return string
      */
     protected function getMediaUploadsSerializerType():string{
+        // && short-circuits, so getCurrentScope() is only reached for service accounts
+        $isSnapshotClient =
+            $this->resource_server_context->getApplicationType() === IResourceServerContext::ApplicationType_Service
+            && in_array
+            (
+                SummitScopes::ReadAllPresentationMediaUploads,
+                $this->resource_server_context->getCurrentScope()
+            );
+
+        if ($isSnapshotClient)
+            return SerializerRegistry::SerializerType_Private;
+
         $serializerType = SerializerRegistry::SerializerType_Public;
         $currentUser = $this->resource_server_context->getCurrentUser();
         $presentation = $this->object;
-        if(!is_null($currentUser) && ( $currentUser->isAdmin() || $presentation->memberCanEdit($currentUser))){
+        if(!is_null($currentUser) && ( $currentUser->isAdmin() || $currentUser->isSummitAdmin() || $presentation->memberCanEdit($currentUser))){
             $serializerType = SerializerRegistry::SerializerType_Private;
         }
         return $serializerType;

--- a/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
@@ -28,6 +28,14 @@ class PresentationSerializer extends SummitEventSerializer
 {
     const CacheTTL = 1200;
 
+    /**
+     * Memo for getMediaUploadsSerializerType(). Instance-scoped on purpose - see that method.
+     * Private rather than protected: the subclasses that override the method answer with a
+     * constant and have nothing to memo.
+     * @var string|null
+     */
+    private ?string $media_uploads_serializer_type = null;
+
     protected static $array_mappings = [
         'CreatorId'               => 'creator_id:json_int',
         'ModeratorId'             => 'moderator_speaker_id:json_int',
@@ -82,10 +90,16 @@ class PresentationSerializer extends SummitEventSerializer
 
     /**
      * Resolves who is allowed to see every media upload attached to this presentation, approved
-     * or not. Kept aligned with OAuth2SummitEventsApiController::getSerializerType(), which is
-     * what decides the serializer type of the presentation itself - when the two disagree the
-     * presentation is served Private while its uploads are served Public, which is the bug this
-     * method used to have for summit admins and for service accounts.
+     * or not. The reference point is OAuth2SummitEventsApiController::getSerializerType(), which
+     * decides the serializer type of the presentation itself - where this method is narrower than
+     * that one the presentation is served Private while its uploads are served Public, which is
+     * the bug it used to have for summit admins and for service accounts.
+     *
+     * It is deliberately still narrower in one place. The controller grants Private to any
+     * ApplicationType_Service caller; here a service account additionally has to hold
+     * ReadAllPresentationMediaUploads, because these are unpublished files and the application
+     * type on its own would hand them to every service client. Members are aligned with the
+     * controller exactly.
      *
      * Two distinct privileged callers:
      *
@@ -99,6 +113,17 @@ class PresentationSerializer extends SummitEventSerializer
      * @return string
      */
     protected function getMediaUploadsSerializerType():string{
+        // Memoized per serializer instance, which is the correct scope and not merely the
+        // convenient one: memberCanEdit() below is answered against THIS presentation, so a
+        // caller can be a speaker on one and a stranger to the next. A request-wide memo would
+        // hand every presentation the first one's answer. SerializerRegistry builds a fresh
+        // serializer per object and none outlive the request, so per-instance already collapses
+        // the repeated work - this method is called once per media upload plus once per
+        // getVisibleMediaUploads(), and it reaches the member's speaker and this presentation's
+        // speaker collection each time.
+        if (!is_null($this->media_uploads_serializer_type))
+            return $this->media_uploads_serializer_type;
+
         // && short-circuits, so getCurrentScope() is only reached for service accounts
         $isSnapshotClient =
             $this->resource_server_context->getApplicationType() === IResourceServerContext::ApplicationType_Service
@@ -109,7 +134,7 @@ class PresentationSerializer extends SummitEventSerializer
             );
 
         if ($isSnapshotClient)
-            return SerializerRegistry::SerializerType_Private;
+            return $this->media_uploads_serializer_type = SerializerRegistry::SerializerType_Private;
 
         $serializerType = SerializerRegistry::SerializerType_Public;
         $currentUser = $this->resource_server_context->getCurrentUser();
@@ -117,7 +142,7 @@ class PresentationSerializer extends SummitEventSerializer
         if(!is_null($currentUser) && ( $currentUser->isAdmin() || $currentUser->isSummitAdmin() || $presentation->memberCanEdit($currentUser))){
             $serializerType = SerializerRegistry::SerializerType_Private;
         }
-        return $serializerType;
+        return $this->media_uploads_serializer_type = $serializerType;
     }
 
     /**

--- a/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
@@ -140,6 +140,62 @@ class PresentationSerializer extends SummitEventSerializer
         });
     }
 
+    /**
+     * Sets media_uploads on an already-built payload for whoever is asking right now, in the
+     * shape the request asked for: an id list for ?relations=media_uploads, serialized objects
+     * for ?expand=media_uploads, expand winning when both are present.
+     *
+     * This is the only place that decides the value, and it runs on every path - including
+     * after a cache read - because getMediaUploadsSerializerType() resolves per user and per
+     * scope, which nothing in the cache key expresses. Two callers can share a key and still
+     * disagree here: a speaker on the presentation and a plain attendee both serialize through
+     * PresentationSerializer, and a service account holding ReadAllPresentationMediaUploads and
+     * one without it both serialize through AdminPresentationSerializer. Adding the serializer
+     * class to the key would not separate either pair.
+     *
+     * @param array $values
+     * @param null $expand
+     * @param array $fields
+     * @param array $relations
+     * @return array
+     */
+    private function withMediaUploads(array $values, $expand, array $fields, array $relations): array
+    {
+        // Nothing asked for it: drop whatever a cached payload may be carrying, so a stale
+        // entry can never contribute this field to a response that did not request it.
+        unset($values['media_uploads']);
+
+        if (in_array('media_uploads', $relations)) {
+            $media_uploads = [];
+            foreach ($this->getVisibleMediaUploads() as $mediaUpload) {
+                $media_uploads[] = $mediaUpload->getId();
+            }
+            $values['media_uploads'] = $media_uploads;
+        }
+
+        if (!empty($expand)) {
+            foreach (explode(',', $expand) as $relation) {
+                if (trim($relation) !== 'media_uploads') continue;
+
+                $media_uploads = [];
+                foreach ($this->getVisibleMediaUploads() as $mediaUpload) {
+                    $media_uploads[] = SerializerRegistry::getInstance()->getSerializer
+                    (
+                        $mediaUpload, $this->getMediaUploadsSerializerType()
+                    )->serialize
+                    (
+                        AbstractSerializer::filterExpandByPrefix($expand, 'media_uploads'),
+                        AbstractSerializer::filterFieldsByPrefix($fields, 'media_uploads'),
+                        AbstractSerializer::filterFieldsByPrefix($relations, 'media_uploads'),
+                    );
+                }
+                $values['media_uploads'] = $media_uploads;
+            }
+        }
+
+        return $values;
+    }
+
 
     /**
      * @param null $expand
@@ -171,32 +227,7 @@ class PresentationSerializer extends SummitEventSerializer
         if($use_cache && Cache::has($key)){
             $values = json_decode(Cache::get($key), true);
             Log::debug(sprintf("PresentationSerializer::serialize cache hit for presentation %s", $presentation->getId()));
-            if (!empty($expand)) {
-                foreach (explode(',', $expand) as $relation) {
-                    $relation = trim($relation);
-                    switch ($relation) {
-                        case 'media_uploads':
-                        {
-                            $media_uploads = [];
-
-                            foreach ($this->getVisibleMediaUploads() as $mediaUpload) {
-                                $media_uploads[] = SerializerRegistry::getInstance()->getSerializer
-                                (
-                                    $mediaUpload, $this->getMediaUploadsSerializerType()
-                                )->serialize
-                                (
-                                    AbstractSerializer::filterExpandByPrefix($expand, $relation),
-                                    AbstractSerializer::filterFieldsByPrefix($fields, $relation),
-                                    AbstractSerializer::filterFieldsByPrefix($relations, $relation),
-                                );
-                            }
-
-                            $values['media_uploads'] = $media_uploads;
-                        }
-                    }
-                }
-            }
-            return $values;
+            return $this->withMediaUploads($values, $expand, $fields, $relations);
         }
 
         $values = parent::serialize($expand, $fields, $relations, $params);
@@ -239,16 +270,6 @@ class PresentationSerializer extends SummitEventSerializer
                 $videos[] = $video->getId();
             }
             $values['videos'] = $videos;
-        }
-
-        if(in_array('media_uploads', $relations))
-        {
-            $media_uploads = [];
-            foreach ($this->getVisibleMediaUploads() as $mediaUpload) {
-                $media_uploads[] = $mediaUpload->getId();
-            }
-
-            $values['media_uploads'] = $media_uploads;
         }
 
         if(in_array('extra_questions', $relations))
@@ -383,24 +404,6 @@ class PresentationSerializer extends SummitEventSerializer
                         $values['videos'] = $videos;
                     }
                     break;
-                    case 'media_uploads':{
-                        $media_uploads = [];
-
-                        foreach ($this->getVisibleMediaUploads() as $mediaUpload) {
-                            $media_uploads[] = SerializerRegistry::getInstance()->getSerializer
-                            (
-                                $mediaUpload, $this->getMediaUploadsSerializerType()
-                            )->serialize
-                            (
-                                AbstractSerializer::filterExpandByPrefix($expand, $relation),
-                                AbstractSerializer::filterFieldsByPrefix($fields, $relation),
-                                AbstractSerializer::filterFieldsByPrefix($relations, $relation),
-                            );
-                        }
-
-                        $values['media_uploads'] = $media_uploads;
-                    }
-                    break;
                     case 'extra_questions':{
                         $answers = [];
                         foreach ($presentation->getExtraQuestionAnswers() as $answer) {
@@ -450,9 +453,16 @@ class PresentationSerializer extends SummitEventSerializer
             }
         }
 
-        if($use_cache)
-            Cache::put($key, json_encode($values), self::CacheTTL);
+        if($use_cache) {
+            // media_uploads is deliberately kept out of the stored payload: it is the one field
+            // here whose value depends on who is asking, and the key has no audience component.
+            // Storing it would make correctness depend on every future reader remembering to
+            // recompute it.
+            $cacheable = $values;
+            unset($cacheable['media_uploads']);
+            Cache::put($key, json_encode($cacheable), self::CacheTTL);
+        }
 
-        return $values;
+        return $this->withMediaUploads($values, $expand, $fields, $relations);
     }
 }

--- a/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/PresentationSerializer.php
@@ -266,26 +266,29 @@ class PresentationSerializer extends SummitEventSerializer
         // last_edited stays readable so a presentation update naturally busts every entry it has
         // without an explicit Cache::forget, and so an operator can still scan or drop one
         // presentation's entries by pattern.
+        // The parts come raw off the query string, and percent-decoding hands them over as
+        // bytes: a malformed sequence like %FF makes json_encode() return false, which hash()
+        // would silently coerce to "" - collapsing class, expand, fields and relations onto one
+        // shared digest per presentation, the exact cross-audience collision the digest exists
+        // to prevent. A request that cannot be keyed unambiguously bypasses the cache entirely.
+        $digest_source = json_encode
+        ([
+            'serializer' => static::class,
+            'expand'     => $expand ?? "",
+            'fields'     => $cache_fields,
+            'relations'  => $cache_relations,
+        ]);
+
         $key =
             sprintf
             (
                 "presentation_%s_%s_%s",
                 $presentation->getId(),
                 $presentation->getLastEditedUTC()?->getTimestamp() ?? 0,
-                hash
-                (
-                    'sha256',
-                    json_encode
-                    ([
-                        'serializer' => static::class,
-                        'expand'     => $expand ?? "",
-                        'fields'     => $cache_fields,
-                        'relations'  => $cache_relations,
-                    ])
-                )
+                hash('sha256', (string) $digest_source)
             );
 
-        $use_cache = $params['use_cache'] ?? false;
+        $use_cache = ($params['use_cache'] ?? false) && $digest_source !== false;
 
         if($use_cache){
             // One read, not Cache::has() followed by Cache::get(): the entry can expire on its

--- a/app/Security/SummitScopes.php
+++ b/app/Security/SummitScopes.php
@@ -22,6 +22,7 @@ final class SummitScopes
     const ReadSummitData = SCOPE_BASE_REALM.'/summits/read';
     const ReadAllSummitData = SCOPE_BASE_REALM.'/summits/read/all';
     const ReadOverflowEvents = SCOPE_BASE_REALM.'/summits/events/overflow/read';
+    const ReadAllPresentationMediaUploads = SCOPE_BASE_REALM.'/summits/presentations/media-uploads/read/all';
 
     // me
     const MeRead = SCOPE_BASE_REALM.'/me/read';

--- a/database/migrations/config/Version20260804120000.php
+++ b/database/migrations/config/Version20260804120000.php
@@ -1,0 +1,61 @@
+<?php namespace Database\Migrations\Config;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Security\SummitScopes;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Register the ReadAllPresentationMediaUploads scope.
+ *
+ * Adds 1 api_scopes row and NO endpoint association, on purpose: endpoint scopes are
+ * validated with array_intersect (any-of, see OAuth2BearerAccessTokenRequestValidator:193),
+ * so associating this scope with an existing endpoint would admit a token holding only
+ * this scope to that endpoint - widening access rather than narrowing it. The scope is a
+ * privilege modifier over endpoints that already exist, read straight off the token by
+ * PresentationSerializer::getMediaUploadsSerializerType(), which never consults
+ * endpoint_api_scopes.
+ *
+ * The registry that actually issues the token is openstackid's oauth2_api_scope. This row
+ * is convention and discoverability on the summit-api side; the scope still has to be
+ * created there and granted to the content-snapshot client for a token to carry it.
+ *
+ * Idempotent via WHERE NOT EXISTS.
+ */
+final class Version20260804120000 extends AbstractMigration
+{
+    use APIEndpointsMigrationHelper;
+
+    private const API_NAME = 'summits';
+
+    public function getDescription(): string
+    {
+        return 'Register ReadAllPresentationMediaUploads scope (no endpoint association).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql($this->insertApiScope(
+            self::API_NAME,
+            SummitScopes::ReadAllPresentationMediaUploads,
+            'Read All Presentation Media Uploads',
+            'Grants read access to presentation media uploads regardless of display_on_site, for trusted service accounts feeding the content pipeline'
+        ));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql($this->deleteApiScopes(self::API_NAME, [SummitScopes::ReadAllPresentationMediaUploads]));
+    }
+}

--- a/database/seeders/ApiScopesSeeder.php
+++ b/database/seeders/ApiScopesSeeder.php
@@ -69,6 +69,11 @@ final class ApiScopesSeeder extends Seeder
                 'description' => 'Grants read only access to published summit events currently in OVERFLOW occupancy, including overflow streaming URLs and tokens',
             ],
             [
+                'name' => SummitScopes::ReadAllPresentationMediaUploads,
+                'short_description' => 'Read All Presentation Media Uploads',
+                'description' => 'Grants read access to presentation media uploads regardless of display_on_site, for trusted service accounts feeding the content pipeline',
+            ],
+            [
                 'name' => SummitScopes::MeRead,
                 'short_description' => 'Get own summit member data',
                 'description' => 'Grants read only access for our own summit member data',

--- a/tests/PresentationMediaUploadsTest.php
+++ b/tests/PresentationMediaUploadsTest.php
@@ -19,9 +19,9 @@ use Doctrine\Persistence\ObjectRepository;
 use models\summit\Presentation;
 use models\summit\SummitMediaUploadType;
 /**
- * Class PresentationMediaUploadsTests
+ * Class PresentationMediaUploadsTest
  */
-class PresentationMediaUploadsTests
+class PresentationMediaUploadsTest
     extends ProtectedApiTestCase
 {
     use InsertSummitTestData;

--- a/tests/PresentationMediaUploadsTests.php
+++ b/tests/PresentationMediaUploadsTests.php
@@ -44,17 +44,32 @@ class PresentationMediaUploadsTests
     {
         parent::setUp();
         self::$media_file_type_repository = EntityManager::getRepository(SummitMediaFileType::class);
-        $types = self::$media_file_type_repository->findAll();
         self::insertSummitTestData();
+
+        // Built here rather than read from the repository: insertSummitTestData() opens with
+        // DELETE FROM SummitMediaFileType, so anything fetched before it is a detached row by
+        // the time we flush. It cannot reuse self::$default_media_file_type either - that one
+        // carries ".PDF", and SummitMediaUploadType::isValidExtension() compares
+        // strtoupper($ext) against explode('|', ...), so a leading dot never matches.
+        $media_file_type = new SummitMediaFileType();
+        $media_file_type->setName("PNG_".rand(1, 100));
+        $media_file_type->setDescription("PNG");
+        $media_file_type->setAllowedExtensions("PNG");
+        self::$em->persist($media_file_type);
+
         self::$media_upload_type = new SummitMediaUploadType();
-        self::$media_upload_type->setType($types[0]);
+        self::$media_upload_type->setType($media_file_type);
         self::$media_upload_type->setName('TEST');
         self::$media_upload_type->setDescription("TEST");
         self::$media_upload_type->setMaxSize(2048);
         self::$media_upload_type->setMinUploadsQty(2);
         self::$media_upload_type->setMaxUploadsQty(4);
-        self::$media_upload_type->setPrivateStorageType(\App\Models\Utils\IStorageTypesConstants::DropBox);
-        self::$media_upload_type->setPublicStorageType(\App\Models\Utils\IStorageTypesConstants::Swift);
+        self::$media_upload_type->setPrivateStorageType(\App\Models\Utils\IStorageTypesConstants::Local);
+        // Local, not Swift: serializing public_url builds a download strategy for whatever the
+        // type declares, and the Swift one needs an authUrl that neither this container nor CI
+        // provides. The assertion is about public_url being serialized at all, not about which
+        // backend serves it.
+        self::$media_upload_type->setPublicStorageType(\App\Models\Utils\IStorageTypesConstants::Local);
 
         self::$presentation = new Presentation();
         $event_types = self::$summit->getEventTypes();

--- a/tests/PresentationMediaUploadsVisibilityTest.php
+++ b/tests/PresentationMediaUploadsVisibilityTest.php
@@ -14,6 +14,7 @@
 
 use App\Security\SummitScopes;
 use Doctrine\Common\Collections\ArrayCollection;
+use Illuminate\Support\Facades\Cache;
 use models\main\Member;
 use models\oauth2\IResourceServerContext;
 use models\summit\Presentation;
@@ -122,15 +123,20 @@ final class PresentationMediaUploadsVisibilityTest extends TestCase
     /**
      * @param Presentation $presentation
      * @param IResourceServerContext $context
+     * @param array $params forwarded to serialize(), which is where use_cache is read.
      * @return array the media upload ids this caller receives
      */
-    private function serializeMediaUploadIds(Presentation $presentation, IResourceServerContext $context): array
+    private function serializeMediaUploadIds(
+        Presentation $presentation,
+        IResourceServerContext $context,
+        array $params = []
+    ): array
     {
         $serializer = new PresentationSerializer($presentation, $context);
         // fields is narrowed to id so the attribute-mapping loop in AbstractSerializer only
         // reaches Presentation::getId(); every other mapped getter is irrelevant here and would
         // otherwise have to be stubbed for no gain.
-        $values = $serializer->serialize(null, ['id'], ['media_uploads']);
+        $values = $serializer->serialize(null, ['id'], ['media_uploads'], $params);
 
         $this->assertArrayHasKey('media_uploads', $values);
         return $values['media_uploads'];
@@ -205,5 +211,63 @@ final class PresentationMediaUploadsVisibilityTest extends TestCase
         );
 
         $this->assertSame([self::ApprovedUploadId], $ids);
+    }
+
+    /**
+     * A cached entry that reports as present and then reads back as unavailable must degrade to
+     * a fresh build, not to an error. The entry can expire on its own TTL, be evicted under
+     * memory pressure, or be dropped by a cache flush, and none of that is rare enough on the
+     * voteable-presentation endpoints - the only ones that pass use_cache - to leave unhandled.
+     *
+     * The assertion is on the payload rather than on how the cache was consulted, so it holds
+     * whether the read is one call or two.
+     */
+    public function testUnavailableCachedValueIsTreatedAsAMiss()
+    {
+        Cache::shouldReceive('has')->zeroOrMoreTimes()->andReturn(true);
+        Cache::shouldReceive('get')->zeroOrMoreTimes()->andReturn(null);
+        Cache::shouldReceive('put')->zeroOrMoreTimes()->andReturn(true);
+
+        $context = Mockery::mock(IResourceServerContext::class);
+        $context->shouldReceive('getApplicationType')->andReturn('JS_CLIENT');
+        $context->shouldReceive('getCurrentUser')->andReturn(null);
+
+        $ids = $this->serializeMediaUploadIds(
+            $this->buildPresentation(90107),
+            $context,
+            ['use_cache' => true]
+        );
+
+        $this->assertSame([self::ApprovedUploadId], $ids);
+    }
+
+    /**
+     * The other side of that read: a decodable entry is still served from cache, and the
+     * media_uploads on it are still resolved for the caller asking now rather than taken from
+     * whoever populated the key. Without this the previous test would pass just as well against
+     * a serializer that had stopped reading the cache altogether.
+     */
+    public function testCacheHitIsServedButMediaUploadsAreResolvedFresh()
+    {
+        // A payload as it is stored: media_uploads is absent by construction, and the stale value
+        // is one no unprivileged caller may receive.
+        Cache::shouldReceive('has')->zeroOrMoreTimes()->andReturn(true);
+        Cache::shouldReceive('get')->zeroOrMoreTimes()->andReturn(
+            json_encode(['id' => 90108, 'title' => 'from cache', 'media_uploads' => [self::DraftUploadId]])
+        );
+        Cache::shouldReceive('put')->zeroOrMoreTimes()->andReturn(true);
+
+        $context = Mockery::mock(IResourceServerContext::class);
+        $context->shouldReceive('getApplicationType')->andReturn('JS_CLIENT');
+        $context->shouldReceive('getCurrentUser')->andReturn(null);
+
+        $serializer = new PresentationSerializer($this->buildPresentation(90108), $context);
+        $values = $serializer->serialize(null, ['id'], ['media_uploads'], ['use_cache' => true]);
+
+        // Came off the cached payload: parent::serialize() was never reached, and it does not
+        // produce this field under fields=['id'] anyway.
+        $this->assertSame('from cache', $values['title']);
+        // ...but this one did not.
+        $this->assertSame([self::ApprovedUploadId], $values['media_uploads']);
     }
 }

--- a/tests/PresentationMediaUploadsVisibilityTest.php
+++ b/tests/PresentationMediaUploadsVisibilityTest.php
@@ -1,0 +1,209 @@
+<?php namespace Tests;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Security\SummitScopes;
+use Doctrine\Common\Collections\ArrayCollection;
+use models\main\Member;
+use models\oauth2\IResourceServerContext;
+use models\summit\Presentation;
+use models\summit\PresentationMediaUpload;
+use ModelSerializers\PresentationSerializer;
+use Mockery;
+
+/**
+ * One test per branch of PresentationSerializer::getMediaUploadsSerializerType(), asserted
+ * through the observable output of serialize() rather than through the serializer-type string
+ * that method returns: what the PR this covers is actually about is which uploads reach which
+ * caller, and the type is only the mechanism.
+ *
+ * The relations=media_uploads shape is used throughout because it yields a bare id list, so an
+ * assertion names the exact uploads without dragging PresentationMediaUploadSerializer, storage
+ * backends and public_url generation into a unit test.
+ *
+ * @package Tests
+ */
+final class PresentationMediaUploadsVisibilityTest extends TestCase
+{
+    /**
+     * display_on_site = true. The only upload a caller without privilege may ever see.
+     */
+    const ApprovedUploadId = 101;
+
+    /**
+     * display_on_site = false, which is what PresentationMaterial::__construct defaults to, so
+     * this is the shape of every upload that has not been through the admin approval checkbox.
+     */
+    const DraftUploadId = 102;
+
+    public function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @param int $identifier unique per test method: the serializer builds its cache key from
+     * the presentation id, and although use_cache is off here, keeping ids distinct means a
+     * future caching change cannot make one test's result depend on another's having run.
+     * @param bool $member_can_edit what Presentation::memberCanEdit() answers for the member
+     * passed in the test - creator, moderator or speaker on this presentation.
+     * @return Presentation
+     */
+    private function buildPresentation(int $identifier, bool $member_can_edit = false): Presentation
+    {
+        $approved = Mockery::mock(PresentationMediaUpload::class);
+        $approved->shouldReceive('getId')->andReturn(self::ApprovedUploadId);
+        $approved->shouldReceive('getDisplayOnSite')->andReturn(true);
+
+        $draft = Mockery::mock(PresentationMediaUpload::class);
+        $draft->shouldReceive('getId')->andReturn(self::DraftUploadId);
+        $draft->shouldReceive('getDisplayOnSite')->andReturn(false);
+
+        $presentation = Mockery::mock(Presentation::class);
+        $presentation->shouldReceive('getId')->andReturn($identifier);
+        $presentation->shouldReceive('getLastEditedUTC')->andReturn(null);
+        $presentation->shouldReceive('getMediaUploads')
+            ->andReturn(new ArrayCollection([$approved, $draft]));
+        $presentation->shouldReceive('memberCanEdit')->andReturn($member_can_edit);
+
+        return $presentation;
+    }
+
+    /**
+     * A member-backed caller: a browser client carrying a user token.
+     * @param bool $is_admin global administrator.
+     * @param bool $is_summit_admin summit-front-end-administrators, the show-admin operators.
+     * @return IResourceServerContext
+     */
+    private function buildMemberContext(bool $is_admin = false, bool $is_summit_admin = false): IResourceServerContext
+    {
+        $member = Mockery::mock(Member::class);
+        $member->shouldReceive('isAdmin')->andReturn($is_admin);
+        $member->shouldReceive('isSummitAdmin')->andReturn($is_summit_admin);
+
+        $context = Mockery::mock(IResourceServerContext::class);
+        $context->shouldReceive('getApplicationType')->andReturn('JS_CLIENT');
+        $context->shouldReceive('getCurrentUser')->andReturn($member);
+
+        return $context;
+    }
+
+    /**
+     * A client_credentials caller. getCurrentUser() is null by construction - there is no user
+     * behind the token - which is why the scope, and not the member, is what grants access here.
+     * @param bool $with_scope whether the token carries ReadAllPresentationMediaUploads.
+     * @return IResourceServerContext
+     */
+    private function buildServiceContext(bool $with_scope): IResourceServerContext
+    {
+        $scopes = ['%s/summits/read'];
+        if ($with_scope) $scopes[] = SummitScopes::ReadAllPresentationMediaUploads;
+
+        $context = Mockery::mock(IResourceServerContext::class);
+        $context->shouldReceive('getApplicationType')
+            ->andReturn(IResourceServerContext::ApplicationType_Service);
+        $context->shouldReceive('getCurrentScope')->andReturn($scopes);
+        $context->shouldReceive('getCurrentUser')->andReturn(null);
+
+        return $context;
+    }
+
+    /**
+     * @param Presentation $presentation
+     * @param IResourceServerContext $context
+     * @return array the media upload ids this caller receives
+     */
+    private function serializeMediaUploadIds(Presentation $presentation, IResourceServerContext $context): array
+    {
+        $serializer = new PresentationSerializer($presentation, $context);
+        // fields is narrowed to id so the attribute-mapping loop in AbstractSerializer only
+        // reaches Presentation::getId(); every other mapped getter is irrelevant here and would
+        // otherwise have to be stubbed for no gain.
+        $values = $serializer->serialize(null, ['id'], ['media_uploads']);
+
+        $this->assertArrayHasKey('media_uploads', $values);
+        return $values['media_uploads'];
+    }
+
+    public function testAnonymousCallerSeesOnlyApprovedUploads()
+    {
+        $context = Mockery::mock(IResourceServerContext::class);
+        $context->shouldReceive('getApplicationType')->andReturn('JS_CLIENT');
+        $context->shouldReceive('getCurrentUser')->andReturn(null);
+
+        $ids = $this->serializeMediaUploadIds($this->buildPresentation(90101), $context);
+
+        $this->assertSame([self::ApprovedUploadId], $ids);
+    }
+
+    public function testPlainAttendeeSeesOnlyApprovedUploads()
+    {
+        $ids = $this->serializeMediaUploadIds(
+            $this->buildPresentation(90102, false),
+            $this->buildMemberContext()
+        );
+
+        $this->assertSame([self::ApprovedUploadId], $ids);
+    }
+
+    public function testSpeakerOnThePresentationSeesDraftUploads()
+    {
+        $ids = $this->serializeMediaUploadIds(
+            $this->buildPresentation(90103, true),
+            $this->buildMemberContext()
+        );
+
+        $this->assertSame([self::ApprovedUploadId, self::DraftUploadId], $ids);
+    }
+
+    /**
+     * The regression this pins: before the fix a summit admin resolved Public here while
+     * OAuth2SummitEventsApiController::getSerializerType() resolved Private for the presentation
+     * itself, so the summit-admin event grid stopped showing the upload whose display_on_site
+     * checkbox is the only way to approve it.
+     */
+    public function testSummitAdminSeesDraftUploads()
+    {
+        $ids = $this->serializeMediaUploadIds(
+            $this->buildPresentation(90104, false),
+            $this->buildMemberContext(false, true)
+        );
+
+        $this->assertSame([self::ApprovedUploadId, self::DraftUploadId], $ids);
+    }
+
+    public function testServiceAccountWithScopeSeesDraftUploads()
+    {
+        $ids = $this->serializeMediaUploadIds(
+            $this->buildPresentation(90105),
+            $this->buildServiceContext(true)
+        );
+
+        $this->assertSame([self::ApprovedUploadId, self::DraftUploadId], $ids);
+    }
+
+    /**
+     * The other half of that gate: the access is granted by the scope, not by the application
+     * type, so a service client without it stays where every other unprivileged caller is.
+     */
+    public function testServiceAccountWithoutScopeSeesOnlyApprovedUploads()
+    {
+        $ids = $this->serializeMediaUploadIds(
+            $this->buildPresentation(90106),
+            $this->buildServiceContext(false)
+        );
+
+        $this->assertSame([self::ApprovedUploadId], $ids);
+    }
+}

--- a/tests/PresentationSerializerCacheKeyTest.php
+++ b/tests/PresentationSerializerCacheKeyTest.php
@@ -1,0 +1,187 @@
+<?php namespace Tests;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Illuminate\Support\Facades\Cache;
+use models\oauth2\IResourceServerContext;
+use models\summit\Presentation;
+use ModelSerializers\AdminPresentationSerializer;
+use ModelSerializers\PresentationSerializer;
+use Mockery;
+
+/**
+ * What separates one cached presentation payload from another. Distinct from the media-uploads
+ * visibility suite: that one covers a field deliberately kept out of the cache, this one covers
+ * everything that stays in it and therefore has to be told apart by the key.
+ *
+ * Tests observe how many cache slots a sequence of requests consumes and what comes back out of
+ * them, never the key itself - the guarantee is that two requests deserving different payloads
+ * do not share an entry, not that the key is spelled any particular way.
+ *
+ * @package Tests
+ */
+final class PresentationSerializerCacheKeyTest extends TestCase
+{
+    /**
+     * Cache entries written during a test, keyed exactly as production wrote them.
+     * @var array
+     */
+    private array $store = [];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->store = [];
+        // A stateful fake rather than the configured driver: it keeps the test off redis/file,
+        // and the entry count is the whole point of these assertions.
+        Cache::shouldReceive('put')->andReturnUsing(function ($key, $value, $ttl = null) {
+            $this->store[$key] = $value;
+            return true;
+        });
+        Cache::shouldReceive('get')->andReturnUsing(function ($key, $default = null) {
+            return $this->store[$key] ?? $default;
+        });
+        Cache::shouldReceive('has')->andReturnUsing(function ($key) {
+            return array_key_exists($key, $this->store);
+        });
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @param int $identifier
+     * @return Presentation
+     */
+    private function buildPresentation(int $identifier): Presentation
+    {
+        $presentation = Mockery::mock(Presentation::class);
+        $presentation->shouldReceive('getId')->andReturn($identifier);
+        $presentation->shouldReceive('getLastEditedUTC')->andReturn(null);
+        $presentation->shouldReceive('getTitle')->andReturn('a presentation');
+        $presentation->shouldReceive('getRank')->andReturn(7);
+        $presentation->shouldReceive('getMediaUploads')->andReturn(new ArrayCollection([]));
+        $presentation->shouldReceive('getSlides')->andReturn([]);
+        $presentation->shouldReceive('memberCanEdit')->andReturn(false);
+        // Reached only by testExpandOrderIsNotNormalised. getType() answering null short-circuits
+        // the moderator case before it asks for a moderator, which keeps the fixture to the two
+        // getters the expand dispatch actually needs.
+        $presentation->shouldReceive('getSpeakers')->andReturn([]);
+        $presentation->shouldReceive('getType')->andReturn(null);
+        return $presentation;
+    }
+
+    /**
+     * An unauthenticated caller: whatever ends up in the cache, this is who must not receive the
+     * admin shape of it.
+     * @return IResourceServerContext
+     */
+    private function buildPublicContext(): IResourceServerContext
+    {
+        $context = Mockery::mock(IResourceServerContext::class);
+        $context->shouldReceive('getApplicationType')->andReturn('JS_CLIENT');
+        $context->shouldReceive('getCurrentUser')->andReturn(null);
+        return $context;
+    }
+
+    /**
+     * The reason this ticket exists. AdminPresentationSerializer does not override serialize(),
+     * so it writes through the inherited caching path, and its attribute mappings are merged on
+     * top of the public ones - rank, selection_status, streaming_url, etherpad_link,
+     * overflow_stream_key, chair scores and vote stats all land in the stored payload. With no
+     * class component in the key, a public caller repeating the same query params inside the TTL
+     * reads that payload back verbatim.
+     */
+    public function testAdminPayloadIsNotServedToAPublicCaller()
+    {
+        $presentation = $this->buildPresentation(90201);
+        $context = $this->buildPublicContext();
+        $arguments = [null, ['id', 'rank'], [], ['use_cache' => true]];
+
+        $admin = (new AdminPresentationSerializer($presentation, $context))->serialize(...$arguments);
+        // Sanity: the field really is admin-only, so the assertion below is about the cache and
+        // not about a field nobody emits.
+        $this->assertSame(7, $admin['rank']);
+
+        $public = (new PresentationSerializer($presentation, $context))->serialize(...$arguments);
+
+        $this->assertArrayNotHasKey('rank', $public);
+        $this->assertCount(2, $this->store);
+    }
+
+    /**
+     * The key's parts used to be joined with "_", a character that occurs inside the values it
+     * joins - media_uploads, extra_questions, selection_plan, public_comments. Two different
+     * requests could therefore render the same key: expand=media_uploads&fields=x and
+     * expand=media&fields=uploads_x both flattened to "..._media_uploads_x_".
+     *
+     * Here the second request asks for a field that matches no mapping, so its correct payload is
+     * empty; anything it comes back with was somebody else's.
+     */
+    public function testRequestsThatFlattenAlikeDoNotShareAnEntry()
+    {
+        $presentation = $this->buildPresentation(90202);
+        $context = $this->buildPublicContext();
+
+        $first = (new PresentationSerializer($presentation, $context))
+            ->serialize(null, ['id'], ['media_uploads'], ['use_cache' => true]);
+        $this->assertSame(90202, $first['id']);
+
+        $second = (new PresentationSerializer($presentation, $context))
+            ->serialize(null, ['id_media'], ['uploads'], ['use_cache' => true]);
+
+        $this->assertArrayNotHasKey('id', $second);
+        $this->assertCount(2, $this->store);
+    }
+
+    /**
+     * fields and relations are both consumed with in_array(), so their order cannot change the
+     * payload. Leaving them unsorted just spends a second entry on a request already answered.
+     */
+    public function testFieldAndRelationOrderReuseTheSameEntry()
+    {
+        $presentation = $this->buildPresentation(90203);
+        $context = $this->buildPublicContext();
+
+        (new PresentationSerializer($presentation, $context))
+            ->serialize(null, ['id', 'title'], ['slides', 'media_uploads'], ['use_cache' => true]);
+        (new PresentationSerializer($presentation, $context))
+            ->serialize(null, ['title', 'id'], ['media_uploads', 'slides'], ['use_cache' => true]);
+
+        $this->assertCount(1, $this->store);
+    }
+
+    /**
+     * expand is deliberately left alone. Its relations are dispatched in the order given, and the
+     * speakers and moderator cases both write $values['moderator'] while disagreeing about
+     * moderator_speaker_id - speakers reads it, moderator unsets it - so the order is capable of
+     * changing the result. Normalising it would quietly merge two payloads that are allowed to
+     * differ, which is the failure this whole ticket is about.
+     */
+    public function testExpandOrderIsNotNormalised()
+    {
+        $presentation = $this->buildPresentation(90204);
+        $context = $this->buildPublicContext();
+
+        (new PresentationSerializer($presentation, $context))
+            ->serialize('speakers,moderator', ['id'], [], ['use_cache' => true]);
+        (new PresentationSerializer($presentation, $context))
+            ->serialize('moderator,speakers', ['id'], [], ['use_cache' => true]);
+
+        $this->assertCount(2, $this->store);
+    }
+}

--- a/tests/PresentationSerializerCacheKeyTest.php
+++ b/tests/PresentationSerializerCacheKeyTest.php
@@ -184,4 +184,32 @@ final class PresentationSerializerCacheKeyTest extends TestCase
 
         $this->assertCount(2, $this->store);
     }
+
+    /**
+     * The digest parts come raw off the query string, and percent-decoding hands them over as
+     * bytes: expand=%FF arrives as "\xFF", which is not valid UTF-8, so json_encode() returns
+     * false - and hash() coerces that false to "" without a warning. Every request carrying any
+     * malformed byte then shares one digest per presentation, serializer class included, which
+     * is exactly the admin-payload-to-public-caller collision the class component exists to
+     * prevent. A request that cannot be keyed unambiguously must not touch the cache at all.
+     */
+    public function testMalformedUtf8RequestsDoNotCollideOnOneEntry()
+    {
+        $presentation = $this->buildPresentation(90205);
+        $context = $this->buildPublicContext();
+
+        $admin = (new AdminPresentationSerializer($presentation, $context))
+            ->serialize(null, ['id', 'rank', "\xFF"], [], ['use_cache' => true]);
+        // Sanity, mirroring testAdminPayloadIsNotServedToAPublicCaller: the admin payload
+        // really carries the field whose leak is asserted below.
+        $this->assertSame(7, $admin['rank']);
+
+        $public = (new PresentationSerializer($presentation, $context))
+            ->serialize(null, ['id', "\xFE"], [], ['use_cache' => true]);
+
+        // Before the guard both digests collapsed to hash("") and this came back with the
+        // admin-shaped payload, rank included.
+        $this->assertArrayNotHasKey('rank', $public);
+        $this->assertSame(90205, $public['id']);
+    }
 }


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bb7zx8t

ref: https://app.clickup.com/t/9014802374/86bb6aem0

## Summary

Public/anonymous callers to the events/published endpoints could pull full
`PresentationMediaUpload` data — including live public S3 URLs — for **draft**
(`display_on_site=false`) uploads via `?expand=media_uploads`, because
`PresentationSerializer` read the unfiltered media uploads collection with no
visibility check.

Reported externally: a third party's calendar/speaker-scraping AI agent recovered
pre-event draft slide decks this way, with no malicious intent — it just added
`expand=media_uploads` to a normal public schedule call.

Closing that hole exposed three further defects in the same serializer, all fixed
here: privileged callers were losing uploads they were entitled to, the response
cache had no audience component, and the cache read had a check-then-act race.

## Root cause

- `GET /summits/{id}/events/published` and `GET /summits/{id}/events/{event_id}/published`
  are fully public/unauthenticated and forward a caller-supplied `expand` with no allowlist.
- `PresentationSerializer::serialize()` handled `expand=media_uploads` (and the
  `relations` id-list path) by calling `Presentation::getMediaUploads()` — unfiltered —
  and serializing every attached upload's `public_url` regardless of draft state.
- `display_on_site` exists on `PresentationMaterial`/`PresentationMediaUpload` for exactly
  this distinction (defaults `false`), and
  `SummitMediaUploadType::getMediaUploadsToDisplayOnSite()` was even built to filter on it —
  but had zero callers in the API/serializer stack.

## What changed

**1. Public callers only see approved uploads** (`90904aa91`)

`getVisibleMediaUploads()` filters to `display_on_site=true` whenever the resolved
serializer type is Public. `AdminPresentationCSVSerializer` is intentionally untouched.

**2. Privileged callers get their uploads back** (`7455f6006`)

`getMediaUploadsSerializerType()` only recognised `isAdmin() || memberCanEdit()`, so two
callers that `OAuth2SummitEventsApiController::getSerializerType()` already treats as
privileged fell through to Public and lost every upload once the filter landed:

- **summit admins** (`summit-front-end-administrators`). The event grid requests
  `media_uploads.display_on_site`, so the operator could no longer see the upload whose
  checkbox is the only thing that would make it visible again — circular.
- **the content-snapshot service account.** pub-api reads with a `client_credentials`
  token, which carries no `user_id`, so `getCurrentUser()` is null by construction.

Service accounts are gated on a **new scope**, `ReadAllPresentationMediaUploads`, rather
than on `ApplicationType_Service` alone, which would have handed drafts to every service
client. The scope is registered with **no endpoint association** on purpose: endpoint
scopes are matched with `array_intersect` (any-of), so associating it would admit a token
holding only this scope to that endpoint.

**3. `media_uploads` is never cached** (`b4079911e`)

Visibility is resolved per user and per scope, but the cache key has no audience
component, so a payload built for one caller could be served to another. Adding the
serializer class to the key does not fix this case — a speaker and a plain attendee both
use `PresentationSerializer`, and a service account with and without the scope both use
`AdminPresentationSerializer`. So the field is stripped before `Cache::put` and recomputed
on every return through a new `withMediaUploads()`, on both the hit and miss paths.

**4. The cache read no longer races** (`e09b148f3`)

`Cache::has()` followed by `Cache::get()` returns null if the entry expires or is evicted
between the two, and `json_decode(null, true)` reaching `withMediaUploads(array $values)`
raised a `TypeError`. One `Cache::get()`; anything that does not decode to an array falls
through and is rebuilt.

**5. The cache key gained a serializer and an unambiguous encoding** (`dea76db68`) —
closes ClickUp 86bb6aem0

`serialize()` is inherited, not overridden, by `AdminPresentationSerializer` and the
track-chair and CSV serializers, and `getAttributeMappings()` merges mappings across the
hierarchy — so the stored payload carried `rank`, `selection_status`, `streaming_url`,
`etherpad_link`, `overflow_stream_key`, chair scores and vote stats. With no class in the
key, a public caller repeating an admin's query params inside the 1200s TTL read that
payload back verbatim.

The key is now `presentation_{id}_{lastEditedTs}_{sha256}`, with the digest over
`static::class`, `expand`, `fields` and `relations`. The parts are `json_encode`d rather
than joined on `_`, which also occurs inside `media_uploads`, `extra_questions` and
`selection_plan` — `expand=media_uploads&fields=x` and `expand=media&fields=uploads_x`
previously rendered the same key. `fields` and `relations` are sorted first; `expand` is
deliberately not, because its relations are dispatched in order and the `speakers` and
`moderator` cases interact through `moderator_speaker_id`.

**6. Serializer-type resolution memoized** (`23a45c253`)

It ran once per media upload plus once per `getVisibleMediaUploads()` — 12 executions for
a ten-upload presentation, measured — and it reaches `memberCanEdit()`, which touches the
member's speaker and this presentation's speaker collection. Memoized **per serializer
instance**, not per request: `memberCanEdit()` is answered against *this* presentation, so
a request-wide memo would hand every presentation in a list the first one's answer.

## Deployment steps

⚠️ **Order matters.** Merging this before steps 1 and 2 empties the content snapshot: the
service account resolves Public, `media_uploads` comes back empty in `events.json` and
`presentations.json`, pub-api does not validate response shape so `SnapshotCompleted` still
fires, and dropbox-materializer stages nothing for every session — silently.

**1. openstackid — register and grant the scope** *(outside this repo)*

Register `{SCOPE_BASE_REALM}/summits/presentations/media-uploads/read/all` on the
summit-api resource server and grant it to the **content-snapshot** client.
`SCOPE_BASE_REALM` is `config('app.scope_base_realm')` per environment, e.g.
`https://api.dev.fnopen.com/summits/presentations/media-uploads/read/all` on dev.

**2. pub-api — request the scope** *(outside this repo)*

Append the same value to `CONTENT_SNAPSHOT_OAUTH2_SCOPES`
(`backend/.env.template:22`, read at `backend/settings.py:321`; space-separated) and
redeploy. Safe to do before summit-api ships — the current code simply ignores the extra
scope on the token.

**3. summit-api — deploy this branch, then run the config migration**

```
php artisan doctrine:migrations:migrate --em=config
```

`Version20260804120000` registers the scope in `api_scopes`. It is idempotent
(`WHERE NOT EXISTS`) and reversible via `down()`. No `endpoint_api_scopes` row is created,
by design — see above. `ApiScopesSeeder` carries the same entry for fresh installs only.

**4. Cache — no action**

The key format change orphans existing entries; they age out on the 1200s TTL and rebuild
on demand. No flush, no coordination.

**5. Verify after deploy**

- Anonymous `?expand=media_uploads` on a published event returns only
  `display_on_site=true` uploads.
- A summit admin loading the summit-admin event grid sees draft uploads again.
- The next content snapshot has non-empty `media_uploads`, and dropbox-materializer stages
  files.

## Test plan

Automated — `tests/PresentationMediaUploadsVisibilityTest.php`,
`tests/PresentationSerializerCacheKeyTest.php`, `tests/PresentationMediaUploadsTest.php`
(13 tests). CI runs them via the new `PresentationMediaUploads` matrix entry in `push.yml`;
the files sit in the `tests/` root, which no existing job covered.

- [x] Public/anonymous, plain attendee, and a service account without the scope see only
      `display_on_site=true` uploads
- [x] Speaker on the presentation, summit admin, and a service account holding the scope see
      drafts too
- [x] An admin-shaped cached payload is not served to a public caller
- [x] Two requests that previously flattened to one key no longer share an entry
- [x] `fields`/`relations` order reuses one entry; `expand` order does not
- [x] An unavailable cached value degrades to a fresh build rather than a 500
- [x] A cache hit is still served, with `media_uploads` resolved fresh
- [x] Manual: summit-admin event grid shows draft uploads after deploy
- [x] Manual: content snapshot non-empty and dropbox-materializer stages files

Each automated test was checked against a deliberately broken implementation, so it is known
to fail when the behaviour regresses rather than assumed to.

`OAuth2PresentationApiTest` is unchanged from `main`: 42 tests, 204 assertions, 6 failures,
2 skipped. Those 6 are pre-existing (`Doctrine\ORM\EntityNotFoundException` on `Member`) and
untouched by this branch.

## Out of scope / follow-up

- This stops the URL from being served going forward — it does **not** revoke the
  public-read ACL already on previously-uploaded draft files. Rotating/regenerating
  already-exposed files (`use_temporary_links_on_public_storage` + the existing
  `presentations-regenerate-media-uploads-temporal-public-urls` command, or a longer-term
  private-storage migration) is a separate ops decision for @smarcet.
- No `display_on_site` backfill. Data audit: 707 rows at `1`, 4514 at `0`; every summit since
  63 is at exactly zero approved. `DocumentsComponent.js:23` filters the same flag client-side,
  so event-site already renders zero media uploads for those shows — the files have always been
  in the payload and never displayed. A blanket backfill would publish material deliberately
  left unapproved on 12/31/63, and on the shows at zero the flag means "never triaged" rather
  than "reviewed and rejected".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controlled access for presentation media uploads, including support for authorized service accounts with the appropriate read-all permission.
  * Public viewers and unauthorized callers see only approved, site-visible uploads.
* **Bug Fixes**
  * Improved presentation response caching so media-upload visibility is evaluated for each request and private data is not inadvertently shared.
  * Cache handling now distinguishes requests with different access levels and expansion options.
* **Tests**
  * Added coverage for media-upload visibility across viewer roles, permissions, and cached responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
