### PR TITLE
feat: add per-activity CFP reopen, an admin-set time-boxed submission override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,9 @@ CFP_APP_BASE_URL=
 CFP_SUPPORT_EMAIL=
 CFP_OAUTH2_SCOPES=
 CFP_OAUTH2_CLIENT_ID=
+# ceiling and default for an admin-granted per-presentation submission reopen window, in hours
+CFP_MAX_REOPEN_HOURS=168
+CFP_DEFAULT_REOPEN_HOURS=24
 
 # RABBIT MQ
 RABBITMQ_EXCHANGE_NAME=databus-exchange

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,6 +59,7 @@ jobs:
                     - { name: "SummitRSVPServiceTest", filter: "--filter SummitRSVPServiceTest" }
                     - { name: "SummitRSVPInvitationServiceTest", filter: "--filter SummitRSVPInvitationServiceTest" }
                     - { name: "EntityModelUnitTests", filter: "tests/Unit/Entities/" }
+                    - { name: "ModelUnitTests", filter: "tests/Unit/Models/" }
                     - { name: "AuditUnitTests", filter: "tests/Unit/Audit/" }
                     - { name: "AuditOtlpStrategyTest", filter: "--filter AuditOtlpStrategyTest" }
                     - { name: "AuditEventTypesTest", filter: "--filter AuditEventTypesTest" }
@@ -68,7 +69,7 @@ jobs:
                     - { name: "CacheOptimizations", filter: "--filter '(PresentationSpeakerCacheTest|ResourceServerContextTest)'" }
                     # Named by path because no job in this matrix runs the tests/ root, only its
                     # subdirectories - a file added there runs nowhere unless it is listed here.
-                    - { name: "PresentationMediaUploads", filter: "tests/PresentationMediaUploadsTest.php tests/PresentationMediaUploadsVisibilityTest.php tests/PresentationSerializerCacheKeyTest.php" }
+                    - { name: "PresentationMediaUploads", filter: "tests/PresentationMediaUploadsTest.php tests/PresentationMediaUploadsVisibilityTest.php tests/PresentationSerializerCacheKeyTest.php tests/PresentationReopenModelTest.php tests/PresentationReopenApiTest.php tests/PresentationReopenAuthzTest.php" }
         env:
             OTEL_SERVICE_ENABLED: false
             APP_ENV: testing

--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2PresentationApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2PresentationApiController.php
@@ -593,7 +593,11 @@ final class OAuth2PresentationApiController extends OAuth2ProtectedController
             // unknown type silently falls back to Public, stripping the reopen fields.
             return $this->updated(SerializerRegistry::getInstance()->getSerializer(
                 $presentation, SerializerRegistry::SerializerType_Private
-            )->serialize());
+            )->serialize(
+                SerializerUtils::getExpand(),
+                SerializerUtils::getFields(),
+                SerializerUtils::getRelations()
+            ));
         });
     }
 

--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2PresentationApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2PresentationApiController.php
@@ -43,6 +43,7 @@ use ModelSerializers\IPresentationSerializerTypes;
 use ModelSerializers\SerializerRegistry;
 use OpenApi\Attributes as OA;
 use services\model\IPresentationService;
+use services\model\IPresentationSubmissionReopenService;
 use utils\Filter;
 use utils\FilterElement;
 use utils\FilterParser;
@@ -85,6 +86,11 @@ final class OAuth2PresentationApiController extends OAuth2ProtectedController
     private $presentation_comments_repository;
 
     /**
+     * @var IPresentationSubmissionReopenService
+     */
+    private $presentation_submission_reopen_service;
+
+    /**
      * OAuth2PresentationApiController constructor.
      * @param IPresentationService $presentation_service
      * @param ISummitRepository $summit_repository
@@ -92,6 +98,7 @@ final class OAuth2PresentationApiController extends OAuth2ProtectedController
      * @param IMemberRepository $member_repository
      * @param ISummitPresentationCommentRepository $presentation_comments_repository
      * @param IResourceServerContext $resource_server_context
+     * @param IPresentationSubmissionReopenService $presentation_submission_reopen_service
      */
     public function __construct
     (
@@ -100,7 +107,8 @@ final class OAuth2PresentationApiController extends OAuth2ProtectedController
         ISummitEventRepository               $presentation_repository,
         IMemberRepository                    $member_repository,
         ISummitPresentationCommentRepository $presentation_comments_repository,
-        IResourceServerContext               $resource_server_context
+        IResourceServerContext               $resource_server_context,
+        IPresentationSubmissionReopenService  $presentation_submission_reopen_service
     )
     {
         parent::__construct($resource_server_context);
@@ -109,6 +117,7 @@ final class OAuth2PresentationApiController extends OAuth2ProtectedController
         $this->member_repository = $member_repository;
         $this->summit_repository = $summit_repository;
         $this->presentation_comments_repository = $presentation_comments_repository;
+        $this->presentation_submission_reopen_service = $presentation_submission_reopen_service;
     }
 
     //presentations
@@ -522,6 +531,109 @@ final class OAuth2PresentationApiController extends OAuth2ProtectedController
                 SerializerUtils::getFields(),
                 SerializerUtils::getRelations()
             ));
+        });
+    }
+
+    #[OA\Put(
+        path: "/api/v1/summits/{id}/presentations/{presentation_id}/submission-period/reopen",
+        summary: "Admin-only: reopen the submission period for a presentation",
+        operationId: "reopenSubmissionPeriod",
+        security: [['summit_presentations_auth' => [SummitScopes::WriteSummitData, SummitScopes::WriteEventData, SummitScopes::WritePresentationData]]],
+        tags: ['Presentations'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: 'presentation_id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        requestBody: new OA\RequestBody(
+            required: false,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'hours', type: 'integer'),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: Response::HTTP_CREATED,
+                description: "Created",
+                content: new OA\JsonContent(ref: "#/components/schemas/Presentation")
+            ),
+            new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
+            new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
+            new OA\Response(response: Response::HTTP_NOT_FOUND, description: "Not Found"),
+            new OA\Response(response: Response::HTTP_PRECONDITION_FAILED, description: "Validation Error"),
+            new OA\Response(response: Response::HTTP_INTERNAL_SERVER_ERROR, description: "Server Error"),
+        ]
+    )]
+    public function reopenSubmissionPeriod($summit_id, $presentation_id)
+    {
+        return $this->processRequest(function () use ($summit_id, $presentation_id) {
+
+            $summit = SummitFinderStrategyFactory::build($this->summit_repository, $this->resource_server_context)->find($summit_id);
+            if (is_null($summit)) return $this->error404();
+
+            $current_member = $this->resource_server_context->getCurrentUser();
+            if (is_null($current_member)) return $this->error403();
+
+            $isAdmin = $current_member->isAdmin()
+                || $current_member->hasPermissionForOnGroup($summit, IGroup::SummitAdministrators);
+            if (!$isAdmin) return $this->error403();
+
+            $payload = $this->getJsonPayload(['hours' => 'sometimes|integer|min:1']);
+
+            // null, not the default: the hours rule (default AND ceiling) lives in the service.
+            $presentation = $this->presentation_submission_reopen_service->reopen(
+                $summit,
+                intval($presentation_id),
+                isset($payload['hours']) ? intval($payload['hours']) : null,
+                $current_member
+            );
+
+            // Private, NOT Admin: SerializerRegistry has no Admin key for Presentation and an
+            // unknown type silently falls back to Public, stripping the reopen fields.
+            return $this->updated(SerializerRegistry::getInstance()->getSerializer(
+                $presentation, SerializerRegistry::SerializerType_Private
+            )->serialize());
+        });
+    }
+
+    #[OA\Delete(
+        path: "/api/v1/summits/{id}/presentations/{presentation_id}/submission-period/reopen",
+        summary: "Admin-only: close the reopened submission period for a presentation",
+        operationId: "closeSubmissionPeriod",
+        security: [['summit_presentations_auth' => [SummitScopes::WriteSummitData, SummitScopes::WriteEventData, SummitScopes::WritePresentationData]]],
+        tags: ['Presentations'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: 'presentation_id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(response: Response::HTTP_NO_CONTENT, description: "No Content"),
+            new OA\Response(response: Response::HTTP_UNAUTHORIZED, description: "Unauthorized"),
+            new OA\Response(response: Response::HTTP_FORBIDDEN, description: "Forbidden"),
+            new OA\Response(response: Response::HTTP_NOT_FOUND, description: "Not Found"),
+            new OA\Response(response: Response::HTTP_INTERNAL_SERVER_ERROR, description: "Server Error"),
+        ]
+    )]
+    public function closeSubmissionPeriod($summit_id, $presentation_id)
+    {
+        return $this->processRequest(function () use ($summit_id, $presentation_id) {
+
+            $summit = SummitFinderStrategyFactory::build($this->summit_repository, $this->resource_server_context)->find($summit_id);
+            if (is_null($summit)) return $this->error404();
+
+            $current_member = $this->resource_server_context->getCurrentUser();
+            if (is_null($current_member)) return $this->error403();
+
+            $isAdmin = $current_member->isAdmin()
+                || $current_member->hasPermissionForOnGroup($summit, IGroup::SummitAdministrators);
+            if (!$isAdmin) return $this->error403();
+
+            $this->presentation_submission_reopen_service->closeNow(
+                $summit, intval($presentation_id), $current_member
+            );
+
+            return $this->deleted();
         });
     }
 

--- a/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitSpeakersApiController.php
+++ b/app/Http/Controllers/Apis/Protected/Summit/OAuth2SummitSpeakersApiController.php
@@ -31,6 +31,7 @@ use models\summit\ISpeakerRepository;
 use models\summit\ISummitEventRepository;
 use models\summit\ISummitRepository;
 use models\summit\PresentationSpeaker;
+use ModelSerializers\IPresentationSerializerTypes;
 use ModelSerializers\ISerializerTypeSelector;
 use ModelSerializers\SerializerRegistry;
 use services\model\ISpeakerService;
@@ -2342,7 +2343,9 @@ final class OAuth2SummitSpeakersApiController extends OAuth2ProtectedController
             return $this->ok($response->toArray(
                 SerializerUtils::getExpand(),
                 SerializerUtils::getFields(),
-                SerializerUtils::getRelations()
+                SerializerUtils::getRelations(),
+                [],
+                IPresentationSerializerTypes::Submission
             ));
         });
     }
@@ -2449,7 +2452,9 @@ final class OAuth2SummitSpeakersApiController extends OAuth2ProtectedController
             return $this->ok($response->toArray(
                 SerializerUtils::getExpand(),
                 SerializerUtils::getFields(),
-                SerializerUtils::getRelations()
+                SerializerUtils::getRelations(),
+                [],
+                IPresentationSerializerTypes::Submission
             ));
         });
     }

--- a/app/ModelSerializers/Summit/Presentation/AdminPresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/AdminPresentationSerializer.php
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+use Libs\ModelSerializers\One2ManyExpandSerializer;
 use models\summit\Presentation;
 
 /**
@@ -43,7 +44,27 @@ class AdminPresentationSerializer extends PresentationSerializer
         'TrackChairAvgScoresPerRakingType' => 'track_chair_scores_avg:json_string_array',
         'SubmissionReopenedUntil' => 'submission_reopened_until:datetime_epoch',
         'SubmissionReopenedById' => 'submission_reopened_by_id:json_int',
-        'SubmissionReopenedByNice' => 'submission_reopened_by:json_string',
+    ];
+
+    /**
+     * Declared HERE and not on the base PresentationSerializer on purpose. getExpandsMappings()
+     * merges parent into child only, and SubmissionPresentationSerializer is a SIBLING of this
+     * class (both extend PresentationSerializer), so this relation is unreachable from the
+     * Submission and Public variants. A case in the base expand switch would not be -- that is
+     * the leak the Admin-only design exists to prevent, and why the SDS rejected id+expand when
+     * a base-class switch was the only mechanism considered.
+     *
+     * serializer_type is explicit because One2ManyExpandSerializer defaults to Public, which
+     * blanks the actor's email.
+     */
+    protected static $expand_mappings = [
+        'submission_reopened_by' => [
+            'type' => One2ManyExpandSerializer::class,
+            'original_attribute' => 'submission_reopened_by_id',
+            'getter' => 'getSubmissionReopenedBy',
+            'has' => 'hasSubmissionReopenedBy',
+            'serializer_type' => SerializerRegistry::SerializerType_Private,
+        ],
     ];
 
     protected static $allowed_fields = [
@@ -70,6 +91,9 @@ class AdminPresentationSerializer extends PresentationSerializer
         'overflow_stream_key',
         'submission_reopened_until',
         'submission_reopened_by_id',
+    ];
+
+    protected static $allowed_relations = [
         'submission_reopened_by',
     ];
 

--- a/app/ModelSerializers/Summit/Presentation/AdminPresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/AdminPresentationSerializer.php
@@ -41,6 +41,9 @@ class AdminPresentationSerializer extends PresentationSerializer
         'OverflowStreamIsSecure' => 'overflow_stream_is_secure:json_boolean',
         'OverflowStreamKey' => 'overflow_stream_key:json_string',
         'TrackChairAvgScoresPerRakingType' => 'track_chair_scores_avg:json_string_array',
+        'SubmissionReopenedUntil' => 'submission_reopened_until:datetime_epoch',
+        'SubmissionReopenedById' => 'submission_reopened_by_id:json_int',
+        'SubmissionReopenedByNice' => 'submission_reopened_by:json_string',
     ];
 
     protected static $allowed_fields = [
@@ -64,7 +67,10 @@ class AdminPresentationSerializer extends PresentationSerializer
         'etherpad_link',
         'overflow_streaming_url',
         'overflow_stream_is_secure',
-        'overflow_stream_key'
+        'overflow_stream_key',
+        'submission_reopened_until',
+        'submission_reopened_by_id',
+        'submission_reopened_by',
     ];
 
     /**

--- a/app/ModelSerializers/Summit/Presentation/SubmissionPresentationSerializer.php
+++ b/app/ModelSerializers/Summit/Presentation/SubmissionPresentationSerializer.php
@@ -21,6 +21,14 @@ use ModelSerializers\SerializerRegistry;
  */
 class SubmissionPresentationSerializer extends PresentationSerializer
 {
+    protected static $array_mappings = [
+        'SubmissionReopenedUntil' => 'submission_reopened_until:datetime_epoch',
+    ];
+
+    protected static $allowed_fields = [
+        'submission_reopened_until',
+    ];
+
     /**
      * @param string|null $relation
      * @return string

--- a/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
@@ -49,6 +49,23 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
 
     use OrderableChilds;
 
+    /**
+     * Redeclared, not extended: a child property SHADOWS the parent default, so SummitEvent's
+     * created_by/updated_by entries must be repeated here or getCreatedById()/getUpdatedById()
+     * stop resolving through One2ManyPropertyTrait::__call.
+     */
+    protected $getIdMappings = [
+        'getCreatedById' => 'created_by',
+        'getUpdatedById' => 'updated_by',
+        'getSubmissionReopenedById' => 'submission_reopened_by',
+    ];
+
+    protected $hasPropertyMappings = [
+        'hasCreatedBy' => 'created_by',
+        'hasUpdatedBy' => 'updated_by',
+        'hasSubmissionReopenedBy' => 'submission_reopened_by',
+    ];
+
     const ClassName = 'Presentation';
 
     const FieldProblemAddressed = 'problem_addressed';
@@ -2564,35 +2581,6 @@ SQL;
     public function getSubmissionReopenedBy(): ?Member
     {
         return $this->submission_reopened_by;
-    }
-
-    public function getSubmissionReopenedById(): int
-    {
-        try {
-            return is_null($this->submission_reopened_by) ? 0 : $this->submission_reopened_by->getId();
-        } catch (\Exception $ex) {
-            return 0;
-        }
-    }
-
-    /**
-     * Preformatted for Show Admin. Serialized as a plain string because an $array_mappings
-     * entry invokes scalar getters only and cannot serialize a Member.
-     *
-     * Yes, this departs from the repo's usual "who did this" idiom (a *_by_id scalar plus an
-     * expand case, e.g. CreatedById on SummitEventSerializer). That idiom was considered and
-     * REJECTED by the signed-off SDS, because the expand switch lives in the base
-     * PresentationSerializer, so a case added there is reachable from the Public and Submission
-     * variants too -- which is the exact leak the Admin-only design exists to prevent. The SDS
-     * mandates this shape ("no expand needed"), and Show Admin reads the field straight off the
-     * getEvent payload. If a relation is ever wanted, the safe mechanism is a subclass-local
-     * $expand_mappings, never a base-class switch case. Do not "correct" this to id+expand.
-     */
-    public function getSubmissionReopenedByNice(): ?string
-    {
-        $member = $this->submission_reopened_by;
-        if (is_null($member)) return null;
-        return sprintf("%s (%s)", $member->getFullName(), $member->getEmail());
     }
 
     /**

--- a/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
+++ b/app/Models/Foundation/Summit/Events/Presentations/Presentation.php
@@ -232,6 +232,25 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
     protected $custom_order;
 
     /**
+     * @var int|null the raw admin-granted duration; the window end is derived, never stored
+     */
+    #[ORM\Column(name: 'SubmissionReopenedHours', type: 'integer', nullable: true)]
+    protected $submission_reopened_hours = null;
+
+    /**
+     * @var \DateTime|null
+     */
+    #[ORM\Column(name: 'SubmissionReopenedDate', type: 'datetime', nullable: true)]
+    protected $submission_reopened_date = null;
+
+    /**
+     * @var Member|null
+     */
+    #[ORM\JoinColumn(name: 'SubmissionReopenedByID', referencedColumnName: 'ID', onDelete: 'SET NULL')]
+    #[ORM\ManyToOne(targetEntity: \models\main\Member::class, fetch: 'EXTRA_LAZY')]
+    protected $submission_reopened_by = null;
+
+    /**
      * @var PresentationSpeaker
      */
     #[ORM\JoinColumn(name: 'ModeratorID', referencedColumnName: 'ID', onDelete: 'SET NULL')]
@@ -363,6 +382,9 @@ class Presentation extends SummitEvent implements IPublishableEventWithSpeakerCo
         $this->attending_media = false;
         $this->will_all_speakers_attend = false;
         $this->disclaimer_accepted_date = null;
+        $this->submission_reopened_hours = null;
+        $this->submission_reopened_date = null;
+        $this->submission_reopened_by = null;
         $this->custom_order = 0;
         $this->track_chairs_scores = new ArrayCollection();
     }
@@ -2524,12 +2546,117 @@ SQL;
         return $review_status;
     }
 
+    public function getSubmissionReopenedHours(): ?int
+    {
+        return $this->submission_reopened_hours;
+    }
+
+    public function getSubmissionReopenedDate(): ?\DateTime
+    {
+        return $this->submission_reopened_date;
+    }
+
+    public function setSubmissionReopenedDate(?\DateTime $date): void
+    {
+        $this->submission_reopened_date = $date;
+    }
+
+    public function getSubmissionReopenedBy(): ?Member
+    {
+        return $this->submission_reopened_by;
+    }
+
+    public function getSubmissionReopenedById(): int
+    {
+        try {
+            return is_null($this->submission_reopened_by) ? 0 : $this->submission_reopened_by->getId();
+        } catch (\Exception $ex) {
+            return 0;
+        }
+    }
+
+    /**
+     * Preformatted for Show Admin. Serialized as a plain string because an $array_mappings
+     * entry invokes scalar getters only and cannot serialize a Member.
+     *
+     * Yes, this departs from the repo's usual "who did this" idiom (a *_by_id scalar plus an
+     * expand case, e.g. CreatedById on SummitEventSerializer). That idiom was considered and
+     * REJECTED by the signed-off SDS, because the expand switch lives in the base
+     * PresentationSerializer, so a case added there is reachable from the Public and Submission
+     * variants too -- which is the exact leak the Admin-only design exists to prevent. The SDS
+     * mandates this shape ("no expand needed"), and Show Admin reads the field straight off the
+     * getEvent payload. If a relation is ever wanted, the safe mechanism is a subclass-local
+     * $expand_mappings, never a base-class switch case. Do not "correct" this to id+expand.
+     */
+    public function getSubmissionReopenedByNice(): ?string
+    {
+        $member = $this->submission_reopened_by;
+        if (is_null($member)) return null;
+        return sprintf("%s (%s)", $member->getFullName(), $member->getEmail());
+    }
+
+    /**
+     * Derived, never stored — so hours and date cannot drift out of lockstep.
+     */
+    public function getSubmissionReopenedUntil(): ?\DateTime
+    {
+        if (is_null($this->submission_reopened_date) || is_null($this->submission_reopened_hours))
+            return null;
+        return (clone $this->submission_reopened_date)
+            ->add(new \DateInterval(sprintf("PT%dH", $this->submission_reopened_hours)));
+    }
+
+    /**
+     * A grant is only honored on a plan that is assigned, enabled, and whose submission
+     * window has actually ended. Deadline alone would grant edits before the CFP opened,
+     * and (via the isSubmissionClosed() fold) would open speaker deletes on a plan disabled
+     * after the grant — the delete path never re-checks IsEnabled() itself.
+     */
+    public function isSubmissionReopened(): bool
+    {
+        $selection_plan = $this->selection_plan;
+        if (is_null($selection_plan)) return false;
+        if (!$selection_plan->IsEnabled()) return false;
+
+        $submission_end_date = $selection_plan->getSubmissionEndDate();
+        if (is_null($submission_end_date)) return false;
+
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+        // window not ended yet (pre-open or still open): there is nothing to reopen
+        if ($now <= $submission_end_date) return false;
+
+        $until = $this->getSubmissionReopenedUntil();
+        return !is_null($until) && $now < $until;
+    }
+
+    public function reopenSubmission(int $hours, Member $actor): void
+    {
+        $this->submission_reopened_hours = $hours;
+        $this->submission_reopened_date = new \DateTime('now', new \DateTimeZone('UTC'));
+        $this->submission_reopened_by = $actor;
+    }
+
+    /**
+     * Deliberately exempt from the invariants above: a stale grant must always be clearable.
+     */
+    public function closeSubmissionNow(): void
+    {
+        $this->submission_reopened_hours = null;
+        $this->submission_reopened_date = null;
+        $this->submission_reopened_by = null;
+    }
+
     /**
      * @return bool
      * @throws \Exception
      */
     public function isSubmissionClosed(): bool
     {
+        // Fold: covers both production callers (PresentationService::deletePresentation and
+        // SummitService) with no change at either call site. Review-status-safe because
+        // getReviewStatus() recomputes submission_closed inline rather than calling this.
+        if ($this->isSubmissionReopened()) return false;
+
         $selection_plan = $this->selection_plan;
         if (is_null($selection_plan)) return false;
 

--- a/app/Services/Model/IPresentationSubmissionReopenService.php
+++ b/app/Services/Model/IPresentationSubmissionReopenService.php
@@ -1,0 +1,49 @@
+<?php namespace services\model;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use models\summit\Summit;
+use models\main\Member;
+use models\summit\Presentation;
+use models\exceptions\EntityNotFoundException;
+use models\exceptions\ValidationException;
+
+/**
+ * Interface IPresentationSubmissionReopenService
+ * @package services\model
+ */
+interface IPresentationSubmissionReopenService
+{
+    /**
+     * $hours null means "unspecified" -- the service resolves cfp.default_reopen_hours. The whole
+     * hours rule (default + ceiling) lives in the service so no caller has to re-derive half of it.
+     *
+     * Declared ?int with no default on purpose: a default here would sit before the required $actor
+     * and PHP 8 deprecates "optional parameter declared before required parameter".
+     *
+     * @throws EntityNotFoundException if the presentation is not in $summit
+     * @throws ValidationException     if $hours is out of range or the plan cannot host a reopen
+     */
+    public function reopen(Summit $summit, int $presentation_id, ?int $hours, Member $actor): Presentation;
+
+    /**
+     * Clears any grant. Deliberately tolerant of plan state so a stale grant is always clearable.
+     *
+     * $actor is unused by the implementation and is kept because the signed-off SDS specifies it:
+     * clearing nulls the ByID column rather than restamping it, and the caller is already captured
+     * by generic request auditing. Do not "tidy" it away without amending the SDS.
+     *
+     * @throws EntityNotFoundException if the presentation is not in $summit
+     */
+    public function closeNow(Summit $summit, int $presentation_id, Member $actor): void;
+}

--- a/app/Services/Model/IPresentationSubmissionReopenService.php
+++ b/app/Services/Model/IPresentationSubmissionReopenService.php
@@ -39,9 +39,8 @@ interface IPresentationSubmissionReopenService
     /**
      * Clears any grant. Deliberately tolerant of plan state so a stale grant is always clearable.
      *
-     * $actor is unused by the implementation and is kept because the signed-off SDS specifies it:
-     * clearing nulls the ByID column rather than restamping it, and the caller is already captured
-     * by generic request auditing. Do not "tidy" it away without amending the SDS.
+     * $actor is logged as the revoking member in the audit line this method emits. Removing it
+     * silently drops that attribution from the revocation record.
      *
      * @throws EntityNotFoundException if the presentation is not in $summit
      */

--- a/app/Services/Model/Imp/PresentationService.php
+++ b/app/Services/Model/Imp/PresentationService.php
@@ -544,7 +544,7 @@ final class PresentationService
                 throw new ValidationException(sprintf("Submission Period is Closed."));
             }
 
-            if (!$current_selection_plan->isSubmissionOpen()) {
+            if (!$current_selection_plan->isSubmissionOpen() && !$presentation->isSubmissionReopened()) {
                 throw new ValidationException(sprintf("Submission Period is Closed."));
             }
 
@@ -668,7 +668,7 @@ final class PresentationService
                 throw new ValidationException(sprintf("Submission Period is Closed."));
             }
 
-            if (!$current_selection_plan->isSubmissionOpen()) {
+            if (!$current_selection_plan->isSubmissionOpen() && !$presentation->isSubmissionReopened()) {
                 throw new ValidationException(sprintf("Submission Period is Closed."));
             }
 

--- a/app/Services/Model/Imp/PresentationSubmissionReopenService.php
+++ b/app/Services/Model/Imp/PresentationSubmissionReopenService.php
@@ -38,9 +38,16 @@ final class PresentationSubmissionReopenService
             if (!$presentation instanceof Presentation)
                 throw new EntityNotFoundException(sprintf("Presentation %s not found.", $presentation_id));
 
+            $max = intval(Config::get('cfp.max_reopen_hours', 168));
+
             // whole hours rule in one place: null means "unspecified", so the default is resolved
             // here rather than in the controller, right next to the ceiling it has to respect.
-            $hours = $hours ?? intval(Config::get('cfp.default_reopen_hours', 24));
+            // The resolved default is clamped to the ceiling on purpose: a deployment that
+            // configures default_reopen_hours above max_reopen_hours would otherwise reject every
+            // request that omits hours, which is a config error the caller cannot see or fix.
+            // An explicitly supplied $hours is still validated strictly below, never clamped.
+            if (is_null($hours))
+                $hours = min(intval(Config::get('cfp.default_reopen_hours', 24)), $max);
 
             // The lower bound is currently unreachable over HTTP -- the endpoint validates
             // 'hours' => 'sometimes|integer|min:1' and refuses first -- but it is deliberate, not
@@ -48,7 +55,6 @@ final class PresentationSubmissionReopenService
             // service), and a persisted non-positive value would make
             // Presentation::getSubmissionReopenedUntil() throw on every read, since
             // new \DateInterval('PT-1H') is invalid. Do not remove it as unused.
-            $max = intval(Config::get('cfp.max_reopen_hours', 168));
             if ($hours < 1 || $hours > $max)
                 throw new ValidationException(sprintf("hours must be between 1 and %s.", $max));
 

--- a/app/Services/Model/Imp/PresentationSubmissionReopenService.php
+++ b/app/Services/Model/Imp/PresentationSubmissionReopenService.php
@@ -83,29 +83,44 @@ final class PresentationSubmissionReopenService
 
     public function closeNow(Summit $summit, int $presentation_id, Member $actor): void
     {
-        $this->tx_service->transaction(function () use ($summit, $presentation_id, $actor) {
+        // closeSubmissionNow() nulls all three columns, the granting actor included, so the audit
+        // fields have to be read before the write and carried out of the closure. The line itself
+        // is emitted only after transaction() returns: flush and commit happen after the closure,
+        // and a retryable failure re-runs it, so logging inside would announce a revocation that
+        // had not happened yet and could announce it more than once.
+        $audit = $this->tx_service->transaction(function () use ($summit, $presentation_id) {
 
             $presentation = $summit->getEvent($presentation_id);
             if (!$presentation instanceof Presentation)
                 throw new EntityNotFoundException(sprintf("Presentation %s not found.", $presentation_id));
 
-            // closeSubmissionNow() nulls all three columns, the granting actor included, so the
-            // revocation is only auditable if it is recorded BEFORE the write. Both ends of the
-            // privilege go in one line: who granted it and until when, and who revoked it.
             $granted_until = $presentation->getSubmissionReopenedUntil();
-            Log::info(
-                sprintf(
-                    "PresentationSubmissionReopenService::closeNow summit %s presentation %s revoked by member %s (granted by member %s, ran until %s).",
-                    $summit->getId(),
-                    $presentation_id,
-                    $actor->getId(),
-                    $presentation->getSubmissionReopenedById(),
-                    is_null($granted_until) ? 'n/a' : $granted_until->format('Y-m-d H:i:s')
-                )
-            );
+            $granted_by_id = $presentation->getSubmissionReopenedById();
 
             // no plan-state checks on purpose: a stale grant must always be clearable
             $presentation->closeSubmissionNow();
+
+            return [
+                // the accessor returns 0, not null, for an absent relation, and closing with no
+                // active grant is a legitimate no-op rather than a member whose id is zero
+                'granted_by' => $granted_by_id > 0 ? sprintf("member %s", $granted_by_id) : 'no active grant',
+                // stamped UTC on write; normalized again here because Doctrine hydrates datetimes
+                // in the application default timezone
+                'granted_until' => is_null($granted_until)
+                    ? 'n/a'
+                    : $granted_until->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z'),
+            ];
         });
+
+        Log::info(
+            sprintf(
+                "PresentationSubmissionReopenService::closeNow summit %s presentation %s revoked by member %s (granted by %s, ran until %s).",
+                $summit->getId(),
+                $presentation_id,
+                $actor->getId(),
+                $audit['granted_by'],
+                $audit['granted_until']
+            )
+        );
     }
 }

--- a/app/Services/Model/Imp/PresentationSubmissionReopenService.php
+++ b/app/Services/Model/Imp/PresentationSubmissionReopenService.php
@@ -1,0 +1,89 @@
+<?php namespace services\model;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Services\Model\AbstractService;
+use Illuminate\Support\Facades\Config;
+use models\exceptions\EntityNotFoundException;
+use models\exceptions\ValidationException;
+use models\main\Member;
+use models\summit\Presentation;
+use models\summit\Summit;
+
+/**
+ * Class PresentationSubmissionReopenService
+ * @package services\model
+ */
+final class PresentationSubmissionReopenService
+    extends AbstractService
+    implements IPresentationSubmissionReopenService
+{
+    public function reopen(Summit $summit, int $presentation_id, ?int $hours, Member $actor): Presentation
+    {
+        return $this->tx_service->transaction(function () use ($summit, $presentation_id, $hours, $actor) {
+
+            // summit-scoped unconditionally for every caller role -- deliberately stricter than
+            // the media-endpoint precedent, which scopes only its non-admin branch.
+            $presentation = $summit->getEvent($presentation_id);
+            if (!$presentation instanceof Presentation)
+                throw new EntityNotFoundException(sprintf("Presentation %s not found.", $presentation_id));
+
+            // whole hours rule in one place: null means "unspecified", so the default is resolved
+            // here rather than in the controller, right next to the ceiling it has to respect.
+            $hours = $hours ?? intval(Config::get('cfp.default_reopen_hours', 24));
+
+            // The lower bound is currently unreachable over HTTP -- the endpoint validates
+            // 'hours' => 'sometimes|integer|min:1' and refuses first -- but it is deliberate, not
+            // dead code: this is the only guard for any non-HTTP caller (job, console, another
+            // service), and a persisted non-positive value would make
+            // Presentation::getSubmissionReopenedUntil() throw on every read, since
+            // new \DateInterval('PT-1H') is invalid. Do not remove it as unused.
+            $max = intval(Config::get('cfp.max_reopen_hours', 168));
+            if ($hours < 1 || $hours > $max)
+                throw new ValidationException(sprintf("hours must be between 1 and %s.", $max));
+
+            // Same invariants isSubmissionReopened() enforces, checked up front so the admin
+            // gets a clear error rather than a grant that silently never activates.
+            $selection_plan = $presentation->getSelectionPlan();
+            if (is_null($selection_plan))
+                throw new ValidationException("Presentation is not assigned to any selection plan.");
+            if (!$selection_plan->IsEnabled())
+                throw new ValidationException("Selection plan is not enabled.");
+
+            $submission_end_date = $selection_plan->getSubmissionEndDate();
+            if (is_null($submission_end_date))
+                throw new ValidationException("Selection plan has no submission end date.");
+
+            $now = new \DateTime('now', new \DateTimeZone('UTC'));
+            if ($now <= $submission_end_date)
+                throw new ValidationException("Submission period has not ended yet; nothing to reopen.");
+
+            $presentation->reopenSubmission($hours, $actor);
+
+            return $presentation;
+        });
+    }
+
+    public function closeNow(Summit $summit, int $presentation_id, Member $actor): void
+    {
+        $this->tx_service->transaction(function () use ($summit, $presentation_id) {
+
+            $presentation = $summit->getEvent($presentation_id);
+            if (!$presentation instanceof Presentation)
+                throw new EntityNotFoundException(sprintf("Presentation %s not found.", $presentation_id));
+
+            // no plan-state checks on purpose: a stale grant must always be clearable
+            $presentation->closeSubmissionNow();
+        });
+    }
+}

--- a/app/Services/Model/Imp/PresentationSubmissionReopenService.php
+++ b/app/Services/Model/Imp/PresentationSubmissionReopenService.php
@@ -14,6 +14,7 @@
 
 use App\Services\Model\AbstractService;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
 use models\exceptions\EntityNotFoundException;
 use models\exceptions\ValidationException;
 use models\main\Member;
@@ -82,11 +83,26 @@ final class PresentationSubmissionReopenService
 
     public function closeNow(Summit $summit, int $presentation_id, Member $actor): void
     {
-        $this->tx_service->transaction(function () use ($summit, $presentation_id) {
+        $this->tx_service->transaction(function () use ($summit, $presentation_id, $actor) {
 
             $presentation = $summit->getEvent($presentation_id);
             if (!$presentation instanceof Presentation)
                 throw new EntityNotFoundException(sprintf("Presentation %s not found.", $presentation_id));
+
+            // closeSubmissionNow() nulls all three columns, the granting actor included, so the
+            // revocation is only auditable if it is recorded BEFORE the write. Both ends of the
+            // privilege go in one line: who granted it and until when, and who revoked it.
+            $granted_until = $presentation->getSubmissionReopenedUntil();
+            Log::info(
+                sprintf(
+                    "PresentationSubmissionReopenService::closeNow summit %s presentation %s revoked by member %s (granted by member %s, ran until %s).",
+                    $summit->getId(),
+                    $presentation_id,
+                    $actor->getId(),
+                    $presentation->getSubmissionReopenedById(),
+                    is_null($granted_until) ? 'n/a' : $granted_until->format('Y-m-d H:i:s')
+                )
+            );
 
             // no plan-state checks on purpose: a stale grant must always be clearable
             $presentation->closeSubmissionNow();

--- a/app/Services/ModelServicesProvider.php
+++ b/app/Services/ModelServicesProvider.php
@@ -149,6 +149,7 @@ use Illuminate\Support\ServiceProvider;
 use services\model\ChatTeamService;
 use services\model\IChatTeamService;
 use services\model\IPresentationService;
+use services\model\IPresentationSubmissionReopenService;
 use services\model\ISpeakerService;
 use services\model\ISubmitterService;
 use services\model\ISummitAttendeeBadgePrintService;
@@ -156,6 +157,7 @@ use services\model\ISummitPromoCodeService;
 use services\model\ISummitService;
 use services\model\ISummitSponsorService;
 use services\model\PresentationService;
+use services\model\PresentationSubmissionReopenService;
 use services\model\SpeakerService;
 use services\model\SubmitterService;
 use services\model\SummitAttendeeBadgePrintService;
@@ -192,6 +194,8 @@ final class ModelServicesProvider extends ServiceProvider
         App::singleton(ISubmitterService::class, SubmitterService::class);
 
         App::singleton(IPresentationService::class, PresentationService::class);
+
+        App::singleton(IPresentationSubmissionReopenService::class, PresentationSubmissionReopenService::class);
 
         App::singleton(IChatTeamService::class, ChatTeamService::class);
 

--- a/config/cfp.php
+++ b/config/cfp.php
@@ -17,4 +17,8 @@ return [
     'support_email' => env('CFP_SUPPORT_EMAIL', null),
     'client_id' => env('CFP_OAUTH2_CLIENT_ID', null),
     'scopes' => env('CFP_OAUTH2_SCOPES', null),
+
+    // ceiling on an admin-granted per-presentation reopen window
+    'max_reopen_hours'     => (int) env('CFP_MAX_REOPEN_HOURS', 168), // 7 days
+    'default_reopen_hours' => (int) env('CFP_DEFAULT_REOPEN_HOURS', 24),
 ];

--- a/database/migrations/config/Version20260807130000.php
+++ b/database/migrations/config/Version20260807130000.php
@@ -1,0 +1,76 @@
+<?php namespace Database\Migrations\Config;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Security\SummitScopes;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Register the two per-activity CFP reopen endpoints.
+ *
+ * ApiEndpointsSeeder covers fresh installs only -- the k8s deploy flow does not re-run
+ * seeders -- and OAuth2BearerAccessTokenRequestValidator rejects any route missing from
+ * api_endpoints with a 400 before the controller runs. A deployed environment therefore
+ * needs these rows inserted by migration or the endpoints are unreachable.
+ *
+ * Scopes are the same OR-trio the sibling submission endpoints use; validation is any-of,
+ * so this admits existing Show Admin tokens. No authz_groups: the routes do not use
+ * auth.user, and the controller performs the summit-aware admin check itself.
+ *
+ * Idempotent via WHERE NOT EXISTS inside the helper.
+ */
+final class Version20260807130000 extends AbstractMigration
+{
+    use APIEndpointsMigrationHelper;
+
+    private const API_NAME = 'summits';
+
+    private const ENDPOINTS = [
+        [
+            'name' => 'reopen-presentation-submission-period',
+            'route' => '/api/v1/summits/{id}/presentations/{presentation_id}/submission-period/reopen',
+            'http_method' => 'PUT',
+            'scopes' => [
+                SummitScopes::WriteSummitData,
+                SummitScopes::WriteEventData,
+                SummitScopes::WritePresentationData,
+            ],
+        ],
+        [
+            'name' => 'close-presentation-submission-period',
+            'route' => '/api/v1/summits/{id}/presentations/{presentation_id}/submission-period/reopen',
+            'http_method' => 'DELETE',
+            'scopes' => [
+                SummitScopes::WriteSummitData,
+                SummitScopes::WriteEventData,
+                SummitScopes::WritePresentationData,
+            ],
+        ],
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Register the per-activity CFP reopen/close endpoints.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->registerEndpoints(self::API_NAME, self::ENDPOINTS);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->unregisterEndpoints(self::API_NAME, array_column(self::ENDPOINTS, 'name'));
+    }
+}

--- a/database/migrations/config/Version20260807130000.php
+++ b/database/migrations/config/Version20260807130000.php
@@ -12,6 +12,7 @@
  * limitations under the License.
  **/
 
+use App\Models\Foundation\Main\IGroup;
 use App\Security\SummitScopes;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -25,8 +26,14 @@ use Doctrine\Migrations\AbstractMigration;
  * needs these rows inserted by migration or the endpoints are unreachable.
  *
  * Scopes are the same OR-trio the sibling submission endpoints use; validation is any-of,
- * so this admits existing Show Admin tokens. No authz_groups: the routes do not use
- * auth.user, and the controller performs the summit-aware admin check itself.
+ * so this admits existing Show Admin tokens.
+ *
+ * The authz groups back the auth.user middleware on both routes, and mirror update-event's list
+ * minus the track-chair roles, which have no business reopening a submission window. They are a
+ * GLOBAL membership check; the summit-scoped admin check still runs in the controller.
+ *
+ * DEPLOY ORDER: this migration must land with or before the application. auth.user reads these
+ * rows, and an endpoint registered without them 403s every authenticated member.
  *
  * Idempotent via WHERE NOT EXISTS inside the helper.
  */
@@ -46,6 +53,11 @@ final class Version20260807130000 extends AbstractMigration
                 SummitScopes::WriteEventData,
                 SummitScopes::WritePresentationData,
             ],
+            'authz_groups' => [
+                IGroup::SuperAdmins,
+                IGroup::Administrators,
+                IGroup::SummitAdministrators,
+            ],
         ],
         [
             'name' => 'close-presentation-submission-period',
@@ -55,6 +67,11 @@ final class Version20260807130000 extends AbstractMigration
                 SummitScopes::WriteSummitData,
                 SummitScopes::WriteEventData,
                 SummitScopes::WritePresentationData,
+            ],
+            'authz_groups' => [
+                IGroup::SuperAdmins,
+                IGroup::Administrators,
+                IGroup::SummitAdministrators,
             ],
         ],
     ];

--- a/database/migrations/model/Version20260807120000.php
+++ b/database/migrations/model/Version20260807120000.php
@@ -1,0 +1,73 @@
+<?php namespace Database\Migrations\Model;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Per-Activity CFP Reopen: per-presentation, time-boxed submission override.
+ *
+ * Stores the raw granted duration plus the stamp date; the window end is derived on read
+ * (Presentation::getSubmissionReopenedUntil), never stored, so the two cannot drift.
+ *
+ * All statements are raw addSql() on purpose. Mixing Builder schema-diff with addSql() in one
+ * migration reorders them -- addSql() runs first, the diff last (see Version20260615000001) --
+ * which would execute the FK before its column exists.
+ *
+ * Presentation is the JOINED-inheritance child table of SummitEvent, so these columns belong
+ * on Presentation, not SummitEvent.
+ */
+final class Version20260807120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add per-presentation CFP reopen override columns to Presentation.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<SQL
+            ALTER TABLE `Presentation`
+                ADD COLUMN `SubmissionReopenedHours` INT NULL DEFAULT NULL,
+                ADD COLUMN `SubmissionReopenedDate` DATETIME NULL DEFAULT NULL,
+                ADD COLUMN `SubmissionReopenedByID` INT NULL DEFAULT NULL
+        SQL);
+
+        $this->addSql('CREATE INDEX `SubmissionReopenedByID` ON `Presentation` (`SubmissionReopenedByID`)');
+
+        $this->addSql(<<<SQL
+            ALTER TABLE `Presentation`
+                ADD CONSTRAINT `FK_Presentation_SubmissionReopenedBy`
+                    FOREIGN KEY (`SubmissionReopenedByID`) REFERENCES `Member` (`ID`)
+                    ON DELETE SET NULL
+        SQL);
+    }
+
+    /**
+     * NOTE: this is data-destructive. Rolling the migration back drops live grants and the
+     * durable actor/date audit trail. Rolling back the *application* alone is safe -- the
+     * columns are additive and inert when null -- so prefer that.
+     */
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `Presentation` DROP FOREIGN KEY `FK_Presentation_SubmissionReopenedBy`');
+        $this->addSql('DROP INDEX `SubmissionReopenedByID` ON `Presentation`');
+        $this->addSql(<<<SQL
+            ALTER TABLE `Presentation`
+                DROP COLUMN `SubmissionReopenedHours`,
+                DROP COLUMN `SubmissionReopenedDate`,
+                DROP COLUMN `SubmissionReopenedByID`
+        SQL);
+    }
+}

--- a/database/migrations/model/Version20260807120000.php
+++ b/database/migrations/model/Version20260807120000.php
@@ -14,6 +14,8 @@
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
+use LaravelDoctrine\Migrations\Schema\Builder;
+use LaravelDoctrine\Migrations\Schema\Table;
 
 /**
  * Per-Activity CFP Reopen: per-presentation, time-boxed submission override.
@@ -21,15 +23,20 @@ use Doctrine\Migrations\AbstractMigration;
  * Stores the raw granted duration plus the stamp date; the window end is derived on read
  * (Presentation::getSubmissionReopenedUntil), never stored, so the two cannot drift.
  *
- * All statements are raw addSql() on purpose. Mixing Builder schema-diff with addSql() in one
- * migration reorders them -- addSql() runs first, the diff last (see Version20260615000001) --
- * which would execute the FK before its column exists.
+ * up() is entirely Builder and down() is entirely addSql(); neither MIXES the two. That matters:
+ * within one migration, addSql() statements all run before the Builder schema diff (see
+ * Version20260615000001), so a mixed up() would execute the FK before its column existed.
+ * Staying on one mechanism per direction removes the ordering question instead of managing it.
  *
  * Presentation is the JOINED-inheritance child table of SummitEvent, so these columns belong
  * on Presentation, not SummitEvent.
  */
 final class Version20260807120000 extends AbstractMigration
 {
+    private const TableName   = 'Presentation';
+    private const ActorColumn = 'SubmissionReopenedByID';
+    private const FkName      = 'FK_Presentation_SubmissionReopenedBy';
+
     public function getDescription(): string
     {
         return 'Add per-presentation CFP reopen override columns to Presentation.';
@@ -37,21 +44,40 @@ final class Version20260807120000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql(<<<SQL
-            ALTER TABLE `Presentation`
-                ADD COLUMN `SubmissionReopenedHours` INT NULL DEFAULT NULL,
-                ADD COLUMN `SubmissionReopenedDate` DATETIME NULL DEFAULT NULL,
-                ADD COLUMN `SubmissionReopenedByID` INT NULL DEFAULT NULL
-        SQL);
+        $builder = new Builder($schema);
+        $current = $schema->getTable(self::TableName);
 
-        $this->addSql('CREATE INDEX `SubmissionReopenedByID` ON `Presentation` (`SubmissionReopenedByID`)');
+        // Each component is guarded on ITSELF, not on the column. DDL does not roll back, so a
+        // run interrupted between the ADD COLUMN and the ADD CONSTRAINT leaves the columns in
+        // place with the migration unrecorded; a column-only guard would then skip straight past
+        // the missing FK and record the migration as complete. Re-running instead repairs.
+        $needs_hours = !$current->hasColumn('SubmissionReopenedHours');
+        $needs_date  = !$current->hasColumn('SubmissionReopenedDate');
+        $needs_actor = !$current->hasColumn(self::ActorColumn);
+        $needs_index = !$current->hasIndex(self::ActorColumn);
+        $needs_fk    = !$current->hasForeignKey(self::FkName);
 
-        $this->addSql(<<<SQL
-            ALTER TABLE `Presentation`
-                ADD CONSTRAINT `FK_Presentation_SubmissionReopenedBy`
-                    FOREIGN KEY (`SubmissionReopenedByID`) REFERENCES `Member` (`ID`)
-                    ON DELETE SET NULL
-        SQL);
+        if (!$needs_hours && !$needs_date && !$needs_actor && !$needs_index && !$needs_fk) return;
+
+        $builder->table(
+            self::TableName,
+            function (Table $table) use ($needs_hours, $needs_date, $needs_actor, $needs_index, $needs_fk) {
+                if ($needs_hours) $table->integer('SubmissionReopenedHours', false, false)->setNotnull(false);
+                if ($needs_date) $table->dateTime('SubmissionReopenedDate')->setNotnull(false);
+                if ($needs_actor) $table->integer(self::ActorColumn, false, false)->setNotnull(false);
+
+                if ($needs_index) $table->index(self::ActorColumn, self::ActorColumn);
+                if ($needs_fk) {
+                    $table->foreign(
+                        'Member',
+                        self::ActorColumn,
+                        'ID',
+                        ['onDelete' => 'SET NULL'],
+                        self::FkName
+                    );
+                }
+            }
+        );
     }
 
     /**
@@ -61,8 +87,9 @@ final class Version20260807120000 extends AbstractMigration
      */
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `Presentation` DROP FOREIGN KEY `FK_Presentation_SubmissionReopenedBy`');
-        $this->addSql('DROP INDEX `SubmissionReopenedByID` ON `Presentation`');
+        // addSql() only, so the drop order (FK, then index, then columns) is the order written.
+        $this->addSql('ALTER TABLE `Presentation` DROP FOREIGN KEY `' . self::FkName . '`');
+        $this->addSql('DROP INDEX `' . self::ActorColumn . '` ON `Presentation`');
         $this->addSql(<<<SQL
             ALTER TABLE `Presentation`
                 DROP COLUMN `SubmissionReopenedHours`,

--- a/database/migrations/model/Version20260807120000.php
+++ b/database/migrations/model/Version20260807120000.php
@@ -18,15 +18,21 @@ use LaravelDoctrine\Migrations\Schema\Builder;
 use LaravelDoctrine\Migrations\Schema\Table;
 
 /**
- * Per-Activity CFP Reopen: per-presentation, time-boxed submission override.
+ * Per-Activity CFP Reopen: per-presentation, time-boxed submission override. Columns and index.
  *
  * Stores the raw granted duration plus the stamp date; the window end is derived on read
  * (Presentation::getSubmissionReopenedUntil), never stored, so the two cannot drift.
  *
- * up() is entirely Builder and down() is entirely addSql(); neither MIXES the two. That matters:
- * within one migration, addSql() statements all run before the Builder schema diff (see
- * Version20260615000001), so a mixed up() would execute the FK before its column existed.
- * Staying on one mechanism per direction removes the ordering question instead of managing it.
+ * The foreign key is deliberately NOT here; it lives in Version20260807120001, mirroring
+ * Version2026061500000{0,1}. Within one migration every addSql() statement runs before the
+ * Builder schema diff, so a migration doing both would execute the FK before its column existed.
+ * Splitting is the repo's answer to that ordering hazard, and it keeps this half entirely on
+ * Builder, where the existence guards live.
+ *
+ * Every component is guarded on ITSELF. MySQL DDL does not roll back and the statements commit
+ * separately, so a run interrupted between the columns and the index leaves the columns in place
+ * with the migration unrecorded; guarding on one column alone would skip the missing index on
+ * retry. Re-running repairs instead.
  *
  * Presentation is the JOINED-inheritance child table of SummitEvent, so these columns belong
  * on Presentation, not SummitEvent.
@@ -34,12 +40,13 @@ use LaravelDoctrine\Migrations\Schema\Table;
 final class Version20260807120000 extends AbstractMigration
 {
     private const TableName   = 'Presentation';
+    private const HoursColumn = 'SubmissionReopenedHours';
+    private const DateColumn  = 'SubmissionReopenedDate';
     private const ActorColumn = 'SubmissionReopenedByID';
-    private const FkName      = 'FK_Presentation_SubmissionReopenedBy';
 
     public function getDescription(): string
     {
-        return 'Add per-presentation CFP reopen override columns to Presentation.';
+        return 'Add per-presentation CFP reopen override columns and index to Presentation.';
     }
 
     public function up(Schema $schema): void
@@ -47,35 +54,23 @@ final class Version20260807120000 extends AbstractMigration
         $builder = new Builder($schema);
         $current = $schema->getTable(self::TableName);
 
-        // Each component is guarded on ITSELF, not on the column. DDL does not roll back, so a
-        // run interrupted between the ADD COLUMN and the ADD CONSTRAINT leaves the columns in
-        // place with the migration unrecorded; a column-only guard would then skip straight past
-        // the missing FK and record the migration as complete. Re-running instead repairs.
-        $needs_hours = !$current->hasColumn('SubmissionReopenedHours');
-        $needs_date  = !$current->hasColumn('SubmissionReopenedDate');
+        $needs_hours = !$current->hasColumn(self::HoursColumn);
+        $needs_date  = !$current->hasColumn(self::DateColumn);
         $needs_actor = !$current->hasColumn(self::ActorColumn);
         $needs_index = !$current->hasIndex(self::ActorColumn);
-        $needs_fk    = !$current->hasForeignKey(self::FkName);
 
-        if (!$needs_hours && !$needs_date && !$needs_actor && !$needs_index && !$needs_fk) return;
+        if (!$needs_hours && !$needs_date && !$needs_actor && !$needs_index) return;
 
         $builder->table(
             self::TableName,
-            function (Table $table) use ($needs_hours, $needs_date, $needs_actor, $needs_index, $needs_fk) {
-                if ($needs_hours) $table->integer('SubmissionReopenedHours', false, false)->setNotnull(false);
-                if ($needs_date) $table->dateTime('SubmissionReopenedDate')->setNotnull(false);
+            function (Table $table) use ($needs_hours, $needs_date, $needs_actor, $needs_index) {
+                if ($needs_hours) $table->integer(self::HoursColumn, false, false)->setNotnull(false);
+                if ($needs_date) $table->dateTime(self::DateColumn)->setNotnull(false);
                 if ($needs_actor) $table->integer(self::ActorColumn, false, false)->setNotnull(false);
 
+                // explicit rather than left to the FK: this is the index MySQL would create for
+                // the constraint anyway, and naming it keeps it recognizable in SHOW INDEX
                 if ($needs_index) $table->index(self::ActorColumn, self::ActorColumn);
-                if ($needs_fk) {
-                    $table->foreign(
-                        'Member',
-                        self::ActorColumn,
-                        'ID',
-                        ['onDelete' => 'SET NULL'],
-                        self::FkName
-                    );
-                }
             }
         );
     }
@@ -84,12 +79,14 @@ final class Version20260807120000 extends AbstractMigration
      * NOTE: this is data-destructive. Rolling the migration back drops live grants and the
      * durable actor/date audit trail. Rolling back the *application* alone is safe -- the
      * columns are additive and inert when null -- so prefer that.
+     *
+     * Version20260807120001::down() has already dropped the foreign key by the time this runs;
+     * MySQL would refuse to drop the index underneath a live constraint.
      */
     public function down(Schema $schema): void
     {
-        // addSql() only, so the drop order (FK, then index, then columns) is the order written.
-        $this->addSql('ALTER TABLE `Presentation` DROP FOREIGN KEY `' . self::FkName . '`');
-        $this->addSql('DROP INDEX `' . self::ActorColumn . '` ON `Presentation`');
+        // addSql() only, so the drop order (index, then columns) is the order written.
+        $this->addSql('DROP INDEX `' . self::ActorColumn . '` ON `' . self::TableName . '`');
         $this->addSql(<<<SQL
             ALTER TABLE `Presentation`
                 DROP COLUMN `SubmissionReopenedHours`,

--- a/database/migrations/model/Version20260807120001.php
+++ b/database/migrations/model/Version20260807120001.php
@@ -47,9 +47,22 @@ final class Version20260807120001 extends AbstractMigration
     {
         $table = $schema->getTable(self::TableName);
 
-        // the column is Version20260807120000's job; if it is absent that migration has not run,
-        // and adding the constraint here would fail on a missing column rather than explain itself
-        if (!$table->hasColumn(self::ActorColumn)) return;
+        // The column is Version20260807120000's job. Abort rather than return if it is missing:
+        // a plain return is the ordinary success path, so Doctrine would record THIS migration as
+        // applied and the constraint would never be created, leaving the column with no ON DELETE
+        // SET NULL and no migration left to add it. abortIf() throws AbortMigration, which stops
+        // the run and leaves the version unrecorded, so a repaired schema can re-run it.
+        // skipIf() would be wrong here for the same reason as the plain return: it records.
+        $this->abortIf(
+            !$table->hasColumn(self::ActorColumn),
+            sprintf(
+                'Presentation.%s is missing; Version20260807120000 has not run. Repair it, then re-run.',
+                self::ActorColumn
+            )
+        );
+
+        // already constrained: an idempotent no-op IS the correct outcome, so recording the
+        // version here is right
         if ($table->hasForeignKey(self::FkName)) return;
 
         $this->addSql(<<<SQL

--- a/database/migrations/model/Version20260807120001.php
+++ b/database/migrations/model/Version20260807120001.php
@@ -1,0 +1,73 @@
+<?php namespace Database\Migrations\Model;
+/*
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Per-Activity CFP Reopen: the foreign key from Presentation.SubmissionReopenedByID to Member.
+ *
+ * Separated from Version20260807120000 on purpose, mirroring Version2026061500000{0,1}: within one
+ * migration every addSql() statement runs before the Builder schema diff, so a migration that both
+ * added the column through Builder and added this constraint through addSql() would execute the
+ * constraint first, against a column that did not exist yet. Splitting removes the ordering
+ * question rather than managing it, and leaves this migration as pure addSql().
+ *
+ * The schema is only READ here, never mutated, so no schema diff is produced and the ordering
+ * hazard cannot reappear. The read is what makes the migration re-runnable after a partial
+ * failure, matching the guards in Version20260807120000.
+ *
+ * ON DELETE SET NULL: a deleted member must not take the presentation's grant with it. The grant
+ * then reads as ownerless rather than cascading, which is why closeNow() logs "no active grant"
+ * rather than naming member 0.
+ */
+final class Version20260807120001 extends AbstractMigration
+{
+    private const TableName   = 'Presentation';
+    private const ActorColumn = 'SubmissionReopenedByID';
+    private const FkName      = 'FK_Presentation_SubmissionReopenedBy';
+
+    public function getDescription(): string
+    {
+        return 'Add the Presentation.SubmissionReopenedByID foreign key to Member.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable(self::TableName);
+
+        // the column is Version20260807120000's job; if it is absent that migration has not run,
+        // and adding the constraint here would fail on a missing column rather than explain itself
+        if (!$table->hasColumn(self::ActorColumn)) return;
+        if ($table->hasForeignKey(self::FkName)) return;
+
+        $this->addSql(<<<SQL
+            ALTER TABLE `Presentation`
+                ADD CONSTRAINT `FK_Presentation_SubmissionReopenedBy`
+                    FOREIGN KEY (`SubmissionReopenedByID`) REFERENCES `Member` (`ID`)
+                    ON DELETE SET NULL
+        SQL);
+    }
+
+    /**
+     * Runs BEFORE Version20260807120000::down(), which drops the index this constraint sits on.
+     */
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable(self::TableName);
+        if (!$table->hasForeignKey(self::FkName)) return;
+
+        $this->addSql('ALTER TABLE `' . self::TableName . '` DROP FOREIGN KEY `' . self::FkName . '`');
+    }
+}

--- a/database/seeders/ApiEndpointsSeeder.php
+++ b/database/seeders/ApiEndpointsSeeder.php
@@ -7090,7 +7090,8 @@ class ApiEndpointsSeeder extends Seeder
                     SummitScopes::WritePresentationSlidesData
                 ],
             ],
-            // submission period reopen (admin-only; authorization enforced in the controller)
+            // submission period reopen (admin-only; the groups below are the coarse auth.user
+            // gate, the summit-scoped admin check runs in the controller)
             [
                 'name' => 'reopen-presentation-submission-period',
                 'route' => '/api/v1/summits/{id}/presentations/{presentation_id}/submission-period/reopen',
@@ -7100,6 +7101,11 @@ class ApiEndpointsSeeder extends Seeder
                     SummitScopes::WriteEventData,
                     SummitScopes::WritePresentationData
                 ],
+                'authz_groups' => [
+                    IGroup::SuperAdmins,
+                    IGroup::Administrators,
+                    IGroup::SummitAdministrators,
+                ]
             ],
             [
                 'name' => 'close-presentation-submission-period',
@@ -7110,6 +7116,11 @@ class ApiEndpointsSeeder extends Seeder
                     SummitScopes::WriteEventData,
                     SummitScopes::WritePresentationData
                 ],
+                'authz_groups' => [
+                    IGroup::SuperAdmins,
+                    IGroup::Administrators,
+                    IGroup::SummitAdministrators,
+                ]
             ],
             // presentation speakers
             [

--- a/database/seeders/ApiEndpointsSeeder.php
+++ b/database/seeders/ApiEndpointsSeeder.php
@@ -7090,6 +7090,27 @@ class ApiEndpointsSeeder extends Seeder
                     SummitScopes::WritePresentationSlidesData
                 ],
             ],
+            // submission period reopen (admin-only; authorization enforced in the controller)
+            [
+                'name' => 'reopen-presentation-submission-period',
+                'route' => '/api/v1/summits/{id}/presentations/{presentation_id}/submission-period/reopen',
+                'http_method' => 'PUT',
+                'scopes' => [
+                    SummitScopes::WriteSummitData,
+                    SummitScopes::WriteEventData,
+                    SummitScopes::WritePresentationData
+                ],
+            ],
+            [
+                'name' => 'close-presentation-submission-period',
+                'route' => '/api/v1/summits/{id}/presentations/{presentation_id}/submission-period/reopen',
+                'http_method' => 'DELETE',
+                'scopes' => [
+                    SummitScopes::WriteSummitData,
+                    SummitScopes::WriteEventData,
+                    SummitScopes::WritePresentationData
+                ],
+            ],
             // presentation speakers
             [
                 'name' => 'add-presentation-speaker',

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -860,6 +860,15 @@ Route::group(array('prefix' => 'summits'), function () {
                     });
                 });
 
+                // submission period (admin-only reopen; authorization is done in the controller,
+                // NOT via auth.user -- that middleware 403s any endpoint with no authz groups)
+                Route::group(['prefix' => 'submission-period'], function () {
+                    Route::group(['prefix' => 'reopen'], function () {
+                        Route::put('', 'OAuth2PresentationApiController@reopenSubmissionPeriod');
+                        Route::delete('', 'OAuth2PresentationApiController@closeSubmissionPeriod');
+                    });
+                });
+
                 // attendees votes
                 Route::group(['prefix' => 'attendee-votes'], function () {
                     Route::get('', ['uses' => 'OAuth2PresentationApiController@getAttendeeVotes']);

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -860,12 +860,13 @@ Route::group(array('prefix' => 'summits'), function () {
                     });
                 });
 
-                // submission period (admin-only reopen; authorization is done in the controller,
-                // NOT via auth.user -- that middleware 403s any endpoint with no authz groups)
+                // submission period (admin-only reopen). auth.user is the coarse gate -- it checks
+                // GLOBAL membership in the endpoint's authz groups, which the config migration and
+                // the seeder register. The summit-scoped check still happens in the controller.
                 Route::group(['prefix' => 'submission-period'], function () {
                     Route::group(['prefix' => 'reopen'], function () {
-                        Route::put('', 'OAuth2PresentationApiController@reopenSubmissionPeriod');
-                        Route::delete('', 'OAuth2PresentationApiController@closeSubmissionPeriod');
+                        Route::put('', ['middleware' => 'auth.user', 'uses' => 'OAuth2PresentationApiController@reopenSubmissionPeriod']);
+                        Route::delete('', ['middleware' => 'auth.user', 'uses' => 'OAuth2PresentationApiController@closeSubmissionPeriod']);
                     });
                 });
 

--- a/tests/PresentationReopenApiTest.php
+++ b/tests/PresentationReopenApiTest.php
@@ -462,9 +462,14 @@ class PresentationReopenApiTest extends ProtectedApiTestCase
     public function testReopenFieldsNeverAppearOnAPublicSerializedResponse()
     {
         $this->reopen(['hours' => 24]);
+        // without this the three absence assertions below hold vacuously: a failed reopen leaves
+        // no grant, so Public would omit the fields whether or not the mappings are Admin-only
+        $this->assertResponseStatus(201);
+        $reloaded = $this->reloadPresentation();
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist');
 
         $payload = SerializerRegistry::getInstance()->getSerializer(
-            $this->reloadPresentation(), SerializerRegistry::SerializerType_Public
+            $reloaded, SerializerRegistry::SerializerType_Public
         )->serialize();
 
         $this->assertArrayNotHasKey('submission_reopened_until', $payload);

--- a/tests/PresentationReopenApiTest.php
+++ b/tests/PresentationReopenApiTest.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Config;
 use LaravelDoctrine\ORM\Facades\Registry;
 use ModelSerializers\SerializerRegistry;
 use models\summit\Presentation;
+use models\summit\SummitEvent;
 use models\utils\SilverstripeBaseModel;
 
 /**
@@ -702,5 +703,262 @@ class PresentationReopenApiTest extends ProtectedApiTestCase
 
         $this->assertRefusedBySubmissionWindow($this->completeSubmission());
         $this->assertFalse($this->reloadPresentation()->isSubmitted());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Open-window parity (SDS §8, "the acceptance bar"; D7). The SDS states the bar as: while
+    // reopened, the editable surface is exactly what the selection plan defines during the open
+    // window. These tests SAMPLE that bar the way §8 asks -- one prohibited field, one permitted
+    // field, plus the media-upload set -- they do not enumerate the whole surface.
+    //
+    // Parity holds by construction: the diff ORs the time gate in two places
+    // (PresentationService.php:547 for update, :671 for complete) and changes nothing else on those
+    // paths, so curatePayloadByPresentationAllowedQuestions / checkPresentationAllowedEdtiable
+    // Questions (:555-556) still run unconditionally afterwards on the one shared code path. These
+    // tests are a tripwire, so a later change that widens the surface for the reopen case
+    // specifically cannot pass unnoticed.
+    //
+    // Fixture direction, which is the opposite of what it looks like: SelectionPlan::__construct
+    // calls seedAllowedPresentationQuestions() and seedAllowedEditablePresentationQuestions()
+    // (SelectionPlan.php:457-458), so a fresh plan permits EVERY allowed field, both as a question
+    // and as editable. The restrictive case therefore has to be built by removing one, not by adding
+    // one -- hence makeNonEditable() below.
+    //
+    // Run these with the whole file, not as a hand-picked --filter subset. Each of the five passes
+    // on its own, the full file is green (25 tests) and so is the whole push.yml shard (59), which
+    // is what CI runs -- but certain multi-test --filter subsets make the tests that expect a
+    // successful update return 500 instead. Observed failure: PresentationSerializer::
+    // getMediaUploadsSerializerType() (:142) calls isAdmin() on the resource-server context's Member
+    // and Doctrine raises EntityNotFoundException ("Unable to find Proxies\__CG__\models\main\Member
+    // entity identifier associated with the UnitOfWork"). Reproducible for the scalar pair below
+    // when the five are filtered together; not reproducible for any of them alone. The mechanism was
+    // not chased past that, so treat a red hand-picked subset here as unproven rather than as a
+    // regression, and reproduce against the full file before believing it.
+    //
+    // 'links' rather than a scalar for the enforcement pair, on purpose. areFieldsEqual() has two
+    // branches (SelectionPlan.php:1564-1571): the array branch is correct, and the scalar branch
+    // compares html_entity_decode($field1) to itself, so it always reports equal and the guard is
+    // dead for every scalar field. 'links' is array-typed in AllowedEditableFields and in
+    // getSnapshot() (FieldLinks => []), so it takes the working branch and these tests need no fix
+    // to that pre-existing defect. The scalar half of the SDS bullet cannot assert enforcement at
+    // all and is covered as parity only, by the last pair below.
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Drop one field from the plan's allowed-editable set, leaving the rest of the seeded set intact.
+     *
+     * SelectionPlan exposes no single-question remover -- only clearAllAllowedEditablePresentation
+     * Questions() (:490) -- so this drops the element straight off the collection returned by
+     * getAllowedEditablePresentationQuestions() (:485) rather than clearing and re-adding the other
+     * four. Safe against the DB either way: the association is mapped cascade persist+remove with
+     * orphanRemoval: true (:229), so the removed row is deleted rather than left behind to reappear
+     * on the next read -- which the isAllowedEditablePresentationQuestion() precondition assertion in
+     * each caller checks against a reloaded plan.
+     *
+     * Deliberately leaves the allowed-QUESTION set alone. curatePayloadByPresentationAllowedQuestions()
+     * returns the curated payload by value and both call sites discard the return
+     * (PresentationService.php:360 and :555), so curation is a no-op today. If that discard is ever
+     * fixed, a field missing from the question set would be stripped from the payload,
+     * isset($payload[$field]) would go false, and the editable check would never run -- so
+     * testNonEditableFieldIsRefusedUnderReopen would get a 201 against its asserted 412 and fail,
+     * even though stripping is the correct behavior at that point. Keeping the field an allowed
+     * question keeps these tests pinned on editability, which is what they are about, instead of
+     * making them a spurious casualty of that fix.
+     */
+    private function makeNonEditable(string $field): void
+    {
+        $questions = self::$default_selection_plan->getAllowedEditablePresentationQuestions();
+        foreach ($questions as $question) {
+            if ($question->getType() === $field) {
+                $questions->removeElement($question);
+            }
+        }
+        self::$em->flush();
+    }
+
+    private function updateSubmissionWithLinks(array $links)
+    {
+        $params = [
+            'id' => self::$summit->getId(),
+            'presentation_id' => self::$presentation->getId(),
+        ];
+        $headers = $this->getAuthHeaders(); // includes CONTENT_TYPE: application/json
+
+        return $this->action(
+            "PUT", "OAuth2PresentationApiController@updatePresentationSubmission",
+            $params, [], [], [], $headers,
+            json_encode(array_merge($this->validUpdatePayload(), ['links' => $links]))
+        );
+    }
+
+    /**
+     * The presentation starts with no links, so the snapshot's FieldLinks is [] -- still isset(),
+     * which is what checkPresentationAllowedEdtiableQuestions requires (:1594) -- and a one-element
+     * payload differs by count, so the array branch reports unequal and the guard fires.
+     */
+    public function testNonEditableFieldIsRefusedUnderReopen()
+    {
+        $this->makeNonEditable(Presentation::FieldLinks);
+        $this->grantWindow(24);
+
+        $reloaded = $this->reloadPresentation();
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist');
+        $this->assertTrue(
+            $reloaded->getSelectionPlan()->isAllowedPresentationQuestion(Presentation::FieldLinks),
+            'links must remain an allowed QUESTION, or this test survives a curation fix vacuously'
+        );
+        $this->assertFalse(
+            $reloaded->getSelectionPlan()->isAllowedEditablePresentationQuestion(Presentation::FieldLinks),
+            'fixture did not land: links is still editable, so a 412 below would prove nothing'
+        );
+
+        $response = $this->updateSubmissionWithLinks(['https://example.org/deck']);
+        $this->assertResponseStatus(412);
+        // the PLAN's message, not assertRefusedBySubmissionWindow()'s -- a window refusal here would
+        // mean the gate never opened, which is the opposite of what this test asserts
+        $this->assertErrorsContain(
+            $response,
+            sprintf(
+                'Field %s is not allowed for edition on Selection Plan %s.',
+                Presentation::FieldLinks,
+                self::$default_selection_plan->getName()
+            )
+        );
+
+        $this->assertCount(
+            0,
+            $this->reloadPresentation()->getLinks(),
+            'refused with 412 but the link was written anyway'
+        );
+    }
+
+    /**
+     * The other direction. No fixture change: the constructor already seeds links as editable, and
+     * the assertion below states that rather than assuming it.
+     */
+    public function testEditableFieldStaysEditableUnderReopen()
+    {
+        $this->grantWindow(24);
+
+        $reloaded = $this->reloadPresentation();
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist');
+        $this->assertTrue(
+            $reloaded->getSelectionPlan()->isAllowedEditablePresentationQuestion(Presentation::FieldLinks),
+            'links must BE an allowed editable question here'
+        );
+
+        $this->updateSubmissionWithLinks(['https://example.org/deck']);
+        $this->assertResponseStatus(201);
+
+        // the edit landed -- a 201 alone would also come back if the factory ignored the field
+        $links = [];
+        foreach ($this->reloadPresentation()->getLinks() as $link) {
+            $links[] = $link->getLink();
+        }
+        $this->assertEquals(['https://example.org/deck'], $links);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // The scalar half of the SDS bullet, as parity rather than as enforcement.
+    //
+    // A scalar change to a NON-editable field is accepted, because areFieldsEqual()'s scalar branch
+    // self-compares (SelectionPlan.php:1570). That defect is outside this diff and deliberately not
+    // fixed here, so the only honest assertion available is that reopen behaves exactly as the open
+    // window does -- which is what parity means. Neither test below claims the guard works.
+    //
+    // Two tests rather than one because this suite gets one SUCCESSFUL HTTP write per entity. Not a
+    // general BrowserKit law -- it is this app's wiring: DoctrineMiddleware closes the model entity
+    // manager after each request (app/Http/Middleware/DoctrineMiddleware.php:38-42) while the
+    // presentation service and its repositories are container singletons holding the manager they
+    // first resolved, so the second write mutates an untracked object and flush() persists nothing
+    // while still returning success (see grantWindow()). Doing both windows in one test would make
+    // the second arm assert nothing.
+    //
+    // Named "HandledIdentically", not "IsAccepted": the 201 each arm asserts is the comparator defect
+    // showing through, not a property worth preserving. When the comparator is fixed both arms move
+    // to 412 TOGETHER and both fail together -- that is expected, and the fix should update both. If
+    // only one moves, parity actually broke and that is the signal these two exist to give.
+    // ---------------------------------------------------------------------------------------------
+
+    public function testNonEditableScalarHandledIdenticallyInTheOpenWindow()
+    {
+        $this->makeNonEditable(SummitEvent::FieldTitle);
+        self::$default_selection_plan->setSubmissionEndDate(
+            (new \DateTime('now', new \DateTimeZone('UTC')))->add(new \DateInterval('P1D'))
+        );
+        self::$em->flush();
+
+        $reloaded = $this->reloadPresentation();
+        $this->assertTrue($reloaded->getSelectionPlan()->isSubmissionOpen(), 'window did not reopen');
+        $this->assertFalse($reloaded->isSubmissionReopened(), 'this arm must NOT ride on a grant');
+        $this->assertFalse(
+            $reloaded->getSelectionPlan()->isAllowedEditablePresentationQuestion(SummitEvent::FieldTitle),
+            'title must be non-editable for this to say anything'
+        );
+
+        $this->updateSubmission(); // validUpdatePayload() changes title
+        $this->assertResponseStatus(201);
+        $this->assertEquals('EDITED DURING REOPEN', $this->reloadPresentation()->getTitle());
+    }
+
+    public function testNonEditableScalarHandledIdenticallyUnderReopen()
+    {
+        $this->makeNonEditable(SummitEvent::FieldTitle);
+        $this->grantWindow(24);
+
+        $reloaded = $this->reloadPresentation();
+        $this->assertFalse(
+            $reloaded->getSelectionPlan()->isSubmissionOpen(),
+            'this arm must run against a CLOSED window, or it is a copy of the one above'
+        );
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist');
+        $this->assertFalse(
+            $reloaded->getSelectionPlan()->isAllowedEditablePresentationQuestion(SummitEvent::FieldTitle),
+            'title must be non-editable for this to say anything'
+        );
+
+        $this->updateSubmission();
+        $this->assertResponseStatus(201);
+        $this->assertEquals('EDITED DURING REOPEN', $this->reloadPresentation()->getTitle());
+    }
+
+    /**
+     * The third assertion of the SDS bullet, recorded as the structural guard it is rather than
+     * presented as coverage it is not.
+     *
+     * getAllowedMediaUploadTypes() (PresentationType.php:413) unconditionally returns the type's
+     * stored collection -- it takes no window, no selection plan and no presentation. The mutation
+     * path agrees: addMediaUploadTo (PresentationService.php:1083-1125) checks the media upload type,
+     * the presentation-type allowance and the max-qty cap, and never consults the submission window
+     * or the plan at all. Media and speaker subresource mutations are ungated in EVERY window -- open,
+     * closed, granted or not; adding that guard is ClickUp 86bba8388 and is out of scope here.
+     *
+     * So this asserts a property that cannot vary with the reopen state, and it would keep passing if
+     * the reopen gate broke entirely. It cannot detect a fixture change either -- both sides derive
+     * from the same fixture and would move together. It is kept only because the SDS bullet names
+     * the assertion explicitly. Do NOT read a green here as evidence that reopen leaves media uploads
+     * alone: what makes that true is 86bba8388 being unimplemented, not this test. It also says
+     * nothing about mutation behavior, only about the advertised set.
+     */
+    public function testAllowedMediaUploadTypesAreUnchangedUnderReopen()
+    {
+        $before = [];
+        foreach (self::$defaultPresentationType->getAllowedMediaUploadTypes() as $type) {
+            $before[] = $type->getId();
+        }
+        sort($before);
+        $this->assertNotEmpty($before, 'fixture attaches no media upload types; the comparison is vacuous');
+
+        $this->grantWindow(24);
+        $reloaded = $this->reloadPresentation();
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist');
+
+        $after = [];
+        foreach ($reloaded->getType()->getAllowedMediaUploadTypes() as $type) {
+            $after[] = $type->getId();
+        }
+        sort($after);
+
+        $this->assertEquals($before, $after);
     }
 }

--- a/tests/PresentationReopenApiTest.php
+++ b/tests/PresentationReopenApiTest.php
@@ -432,8 +432,33 @@ class PresentationReopenApiTest extends ProtectedApiTestCase
         // so a presence-only assertion proves nothing about the grant
         $this->assertArrayHasKey('submission_reopened_by_id', $payload);
         $this->assertEquals(self::$member->getId(), $payload['submission_reopened_by_id']);
-        $this->assertArrayHasKey('submission_reopened_by', $payload);
-        $this->assertIsString($payload['submission_reopened_by']);
+        // the actor is a relation, so it is absent until asked for
+        $this->assertArrayNotHasKey('submission_reopened_by', $payload);
+    }
+
+    public function testReopenActorIsExpandableOnTheAdminResponse()
+    {
+        $this->reopen(['hours' => 24]);
+        $this->assertResponseStatus(201);
+
+        $params = [
+            'id' => self::$summit->getId(),
+            'event_id' => self::$presentation->getId(),
+            'expand' => 'submission_reopened_by',
+        ];
+
+        $response = $this->action(
+            "GET", "OAuth2SummitEventsApiController@getEvent", $params, [], [], [], $this->getAuthHeaders()
+        );
+        $this->assertResponseStatus(200);
+
+        $payload = json_decode($response->getContent(), true);
+        // One2ManyExpandSerializer replaces the scalar with the relation, it does not add alongside
+        $this->assertArrayNotHasKey('submission_reopened_by_id', $payload, $response->getContent());
+        $this->assertArrayHasKey('submission_reopened_by', $payload, $response->getContent());
+        $this->assertEquals(self::$member->getId(), $payload['submission_reopened_by']['id']);
+        // Private, not Public: the admin console needs the actor's email, and Public blanks it
+        $this->assertArrayHasKey('email', $payload['submission_reopened_by']);
     }
 
     public function testByFieldsAreAbsentFromTheSubmissionSerializer()

--- a/tests/PresentationReopenApiTest.php
+++ b/tests/PresentationReopenApiTest.php
@@ -1,0 +1,701 @@
+<?php namespace Tests;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Illuminate\Support\Facades\Config;
+use LaravelDoctrine\ORM\Facades\Registry;
+use ModelSerializers\SerializerRegistry;
+use models\summit\Presentation;
+use models\utils\SilverstripeBaseModel;
+
+/**
+ * Class PresentationReopenApiTest
+ * @package Tests
+ */
+class PresentationReopenApiTest extends ProtectedApiTestCase
+{
+    use InsertSummitTestData;
+
+    /**
+     * @var Presentation
+     */
+    static $presentation;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::insertSummitTestData();
+
+        self::$presentation = new Presentation();
+        self::$presentation->setTitle("REOPEN API TEST");
+        self::$presentation->setType(self::$defaultPresentationType);
+        self::$presentation->setSelectionPlan(self::$default_selection_plan);
+        // Creator is set HERE, not in a later task: getPresentationSubmission (Task 6) and the
+        // role=creator table feeds (Task 7) both require it. memberCanEdit() recognizes only
+        // creator / moderator / assigned speaker (Presentation.php:1254-1261), so without this
+        // every read in Tasks 6-8 returns 403.
+        self::$presentation->setCreatedBy(self::$member);
+        // update/complete also need a track (SummitEventValidationRulesFactory requires track_id)
+        self::$presentation->setCategory(self::$defaultTrack);
+        self::$summit->addEvent(self::$presentation);
+
+        // the feature only applies once the window has ended
+        self::$default_selection_plan->setIsEnabled(true);
+        self::$default_selection_plan->setSubmissionBeginDate(
+            (new \DateTime('now', new \DateTimeZone('UTC')))->sub(new \DateInterval('P10D'))
+        );
+        self::$default_selection_plan->setSubmissionEndDate(
+            (new \DateTime('now', new \DateTimeZone('UTC')))->sub(new \DateInterval('P1D'))
+        );
+
+        self::$em->persist(self::$summit);
+        self::$em->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        self::clearSummitTestData();
+        parent::tearDown();
+    }
+
+    protected function reopen(array $payload, ?int $presentation_id = null, ?int $summit_id = null)
+    {
+        $params = [
+            'id' => $summit_id ?? self::$summit->getId(),
+            'presentation_id' => $presentation_id ?? self::$presentation->getId(),
+        ];
+        $headers = $this->getAuthHeaders(); // includes CONTENT_TYPE: application/json
+
+        return $this->action(
+            "PUT", "OAuth2PresentationApiController@reopenSubmissionPeriod",
+            $params, [], [], [], $headers, json_encode($payload)
+        );
+    }
+
+    protected function closeNow()
+    {
+        $params = [
+            'id' => self::$summit->getId(),
+            'presentation_id' => self::$presentation->getId(),
+        ];
+        $headers = $this->getAuthHeaders(); // includes CONTENT_TYPE: application/json
+
+        return $this->action(
+            "DELETE", "OAuth2PresentationApiController@closeSubmissionPeriod",
+            $params, [], [], [], $headers
+        );
+    }
+
+    /**
+     * Reload from the DB rather than reading the response body.
+     *
+     * These assertions deliberately do NOT read submission_reopened_until out of the response:
+     * the serializer mappings that would put it there do not exist until Task 6, so asserting
+     * on the response here would make Task 5's "the API test now passes" gate unreachable.
+     * Task 6 adds the response-shape assertions once the mappings land.
+     *
+     * Uses self::$em (the 'model' manager, set in InsertSummitTestData::insertSummitTestData
+     * via Registry::getManager(SilverstripeBaseModel::EntityManager)), NOT the bare EntityManager
+     * facade: the facade defaults to the 'config' manager (config/doctrine.php lists 'config'
+     * first with no default override), and Presentation lives in the 'model' DB, so the facade
+     * throws TableNotFoundException.
+     *
+     * Each simulated HTTP dispatch ($this->action(...)) closes the 'model' entity manager at
+     * request end (confirmed live: after $this->reopen(), self::$em->isOpen() is already false
+     * with no exception/retry logged -- this is normal per-request teardown, not an error path).
+     * A second request (e.g. closeNow()) then transparently reopens 'model' via its own
+     * Registry::resetManager() call -- but that only updates the framework's registry entry,
+     * not our locally-cached self::$em, so re-fetching self::$em from Registry::getManager()
+     * (not blindly resetManager()-ing our stale copy again, which would discard that
+     * already-open, already-correct instance and start a THIRD one) is required before reading.
+     * Mirrors the exact pattern InsertSummitTestData::insertSummitTestData() itself uses
+     * (tests/InsertSummitTestData.php:311-314) to pick up the current 'model' manager.
+     */
+    private function reloadPresentation(): Presentation
+    {
+        self::$em = Registry::getManager(SilverstripeBaseModel::EntityManager);
+        if (!self::$em->isOpen()) {
+            self::$em = Registry::resetManager(SilverstripeBaseModel::EntityManager);
+        }
+        self::$em->clear();
+        return self::$em->getRepository(Presentation::class)->find(self::$presentation->getId());
+    }
+
+    /**
+     * buildForSubmission(..., update: true) (SummitEventValidationRulesFactory.php:139-157) marks
+     * exactly four fields 'required': title, type_id, track_id, selection_plan_id. Everything else
+     * is 'sometimes'. A partial payload 400s in getJsonPayload BEFORE the reopen gate runs, which
+     * would make the success case fail and every refusal case pass for the wrong reason.
+     *
+     * type_id/track_id must additionally be on the selection plan: saveOrUpdatePresentation checks
+     * hasEventType() (PresentationService.php:427) and hasTrack() (:451). The fixture's
+     * defaultPresentationType and defaultTrack both are (InsertSummitTestData.php:687, :686 via
+     * defaultTrackGroup), and type_id must equal the presentation's current type or ":436" refuses
+     * the change.
+     */
+    private function validUpdatePayload(): array
+    {
+        return [
+            'title' => 'EDITED DURING REOPEN',
+            'type_id' => self::$defaultPresentationType->getId(),
+            'track_id' => self::$defaultTrack->getId(),
+            'selection_plan_id' => self::$default_selection_plan->getId(),
+        ];
+    }
+
+    protected function updateSubmission()
+    {
+        $params = [
+            'id' => self::$summit->getId(),
+            'presentation_id' => self::$presentation->getId(),
+        ];
+        $headers = $this->getAuthHeaders(); // includes CONTENT_TYPE: application/json
+
+        return $this->action(
+            "PUT", "OAuth2PresentationApiController@updatePresentationSubmission",
+            $params, [], [], [], $headers, json_encode($this->validUpdatePayload())
+        );
+    }
+
+    protected function completeSubmission()
+    {
+        $params = [
+            'id' => self::$summit->getId(),
+            'presentation_id' => self::$presentation->getId(),
+        ];
+        $headers = $this->getAuthHeaders(); // includes CONTENT_TYPE: application/json
+
+        return $this->action(
+            "PUT", "OAuth2PresentationApiController@completePresentationSubmission",
+            $params, [], [], [], $headers
+        );
+    }
+
+    /**
+     * A 412 alone does not prove the window gate refused: update/complete raise ValidationException
+     * (-> 412) from a dozen other places, and complete's post-gate media-upload and speaker checks
+     * are indistinguishable from the gate at the HTTP layer. Both window guards
+     * (PresentationService.php:542-548 for update, :666-672 for complete) carry the literal message
+     * "Submission Period is Closed.", which processRequest surfaces in `errors`
+     * (RequestProcessor.php:47 -> JsonController::error412 :140-144), so assert on that.
+     */
+    private function assertRefusedBySubmissionWindow($response): void
+    {
+        $this->assertResponseStatus(412);
+        $body = json_decode($response->getContent(), true);
+        $this->assertIsArray($body['errors'] ?? null, $response->getContent());
+        $this->assertContains(
+            'Submission Period is Closed.',
+            $body['errors'],
+            'refused with 412, but NOT by the submission-window gate: ' . $response->getContent()
+        );
+    }
+
+    private function assertErrorsContain($response, string $needle): void
+    {
+        $body = json_decode($response->getContent(), true);
+        $this->assertIsArray($body['errors'] ?? null, $response->getContent());
+        $this->assertContains($needle, $body['errors'], $response->getContent());
+    }
+
+    /**
+     * assertArrayHasKey() alone cannot catch a broken serializer mapping. AbstractSerializer
+     * (libs/ModelSerializers/AbstractSerializer.php) assigns $new_values[$mapping[0]] = $value
+     * UNCONDITIONALLY, and swallows a missing-getter exception into $value = null with only a log
+     * warning -- so renaming getSubmissionReopenedUntil() without updating the 'datetime_epoch'
+     * mapping would ship null to the Show Admin column and both speaker tables with the key still
+     * present and a presence-only assertion still green. Every caller below grants a window first,
+     * so the value must be a real epoch in the future.
+     */
+    private function assertFutureEpoch(array $payload, string $key, string $context = ''): void
+    {
+        $this->assertArrayHasKey($key, $payload, $context);
+        $this->assertNotNull(
+            $payload[$key],
+            sprintf('%s present but null -- the serializer mapping no longer resolves a getter. %s', $key, $context)
+        );
+        $this->assertIsInt(
+            $payload[$key],
+            sprintf('%s is not an epoch integer: %s', $key, var_export($payload[$key], true))
+        );
+        $this->assertGreaterThan(
+            time(),
+            $payload[$key],
+            sprintf('%s is not in the future; the granted window never reached the response', $key)
+        );
+    }
+
+    /**
+     * Grant the window directly on the model instead of through reopen().
+     *
+     * Same reason as testCloseNowClearsTheWindow below: a BrowserKit test cannot do two sequential
+     * HTTP-simulated writes against the same entity -- DoctrineMiddleware::handle closes the 'model'
+     * entity manager after every request and singleton repositories pin the manager instance they
+     * were first resolved with, so the second write mutates an untracked object and flush() silently
+     * persists nothing while still returning a success status. Every test below therefore arranges
+     * its precondition on the model and spends its one HTTP write on the endpoint under test.
+     */
+    private function grantWindow(int $hours = 24): void
+    {
+        self::$presentation->reopenSubmission($hours, self::$member);
+        self::$em->flush();
+    }
+
+    public function testAdminCanReopenAClosedSubmission()
+    {
+        $this->reopen(['hours' => 24]);
+        $this->assertResponseStatus(201);
+
+        $reloaded = $this->reloadPresentation();
+        $this->assertTrue($reloaded->isSubmissionReopened());
+        $this->assertEquals(24, $reloaded->getSubmissionReopenedHours());
+        $this->assertGreaterThan(new \DateTime('now', new \DateTimeZone('UTC')), $reloaded->getSubmissionReopenedUntil());
+    }
+
+    /**
+     * 7, not the shipped 24, and asserted as a literal: building the expectation out of the same
+     * Config key the production code reads made this pass against a hardcoded 24 just as happily.
+     * Config::set reaches the dispatched request -- seedCompletionEmailConfig() below relies on
+     * exactly that.
+     */
+    public function testReopenDefaultsToTheConfiguredWindowWhenHoursIsOmitted()
+    {
+        Config::set('cfp.default_reopen_hours', 7);
+
+        $this->reopen([]);
+        $this->assertResponseStatus(201);
+
+        $this->assertEquals(7, $this->reloadPresentation()->getSubmissionReopenedHours());
+    }
+
+    /**
+     * Max 9, not the shipped 168: sending Config::get('cfp.max_reopen_hours')+1 against a ceiling
+     * the service reads from the same key passed against a hardcoded 168 too. The message assertion
+     * is what proves the CEILING refused rather than one of the plan-state guards, all of which also
+     * surface as a bare 412.
+     */
+    public function testHoursAboveMaxIsRejected()
+    {
+        Config::set('cfp.max_reopen_hours', 9);
+
+        $response = $this->reopen(['hours' => 10]);
+        $this->assertResponseStatus(412);
+        $this->assertErrorsContain($response, 'hours must be between 1 and 9.');
+
+        $this->assertNull(
+            $this->reloadPresentation()->getSubmissionReopenedUntil(),
+            'refused with 412 but the grant was written anyway'
+        );
+    }
+
+    /**
+     * The other side of the same boundary, so an off-by-one ceiling cannot pass. Its own test
+     * rather than a second request inside the one above: a BrowserKit test cannot do two
+     * sequential HTTP writes against the same entity (see grantWindow()).
+     */
+    public function testHoursExactlyAtMaxIsAccepted()
+    {
+        Config::set('cfp.max_reopen_hours', 9);
+
+        $this->reopen(['hours' => 9]);
+        $this->assertResponseStatus(201);
+
+        $this->assertEquals(9, $this->reloadPresentation()->getSubmissionReopenedHours());
+    }
+
+    /**
+     * T3: nothing else sends a non-positive window. A2 moved this refusal to the request-validation
+     * layer ('hours' => 'sometimes|integer|min:1'), so the body is the validator's field-keyed shape
+     * -- NOT the service's flat "hours must be between 1 and %s." list. Asserted as what the code
+     * actually returns.
+     */
+    public function testNonPositiveHoursIsRejected()
+    {
+        foreach ([0, -1] as $hours) {
+            $response = $this->reopen(['hours' => $hours]);
+            $this->assertResponseStatus(412);
+
+            $body = json_decode($response->getContent(), true);
+            $this->assertEquals(
+                ['The hours must be at least 1.'],
+                $body['errors']['hours'] ?? null,
+                sprintf('hours=%d was not refused by the min:1 rule: %s', $hours, $response->getContent())
+            );
+        }
+
+        $this->assertNull(
+            $this->reloadPresentation()->getSubmissionReopenedUntil(),
+            'refused but a grant was written anyway'
+        );
+    }
+
+    public function testPresentationFromAnotherSummitReturns404()
+    {
+        // summit2 ships with no event types (InsertSummitTestData:587-602), so it needs one.
+        // Build a DEDICATED type: Summit::addEventType() calls $event_type->setSummit($this)
+        // (Summit.php:2748-2752), so reusing self::$defaultPresentationType would reassign it
+        // away from self::$summit and corrupt the primary fixture mid-test.
+        $foreign_type = new \models\summit\PresentationType();
+        $foreign_type->setType("FOREIGN PRESENTATION TYPE");
+        $foreign_type->setShouldBeAvailableOnCfp(true);
+        self::$summit2->addEventType($foreign_type);
+
+        $foreign = new Presentation();
+        $foreign->setTitle("FOREIGN");
+        $foreign->setType($foreign_type);
+        self::$summit2->addEvent($foreign);
+        self::$em->persist(self::$summit2);
+        self::$em->flush();
+
+        $this->reopen(['hours' => 24], $foreign->getId());
+        $this->assertResponseStatus(404);
+
+        // §8 requires the scoping assertion on BOTH endpoints, not just reopen
+        $this->action(
+            "DELETE", "OAuth2PresentationApiController@closeSubmissionPeriod",
+            ['id' => self::$summit->getId(), 'presentation_id' => $foreign->getId()],
+            [], [], [], $this->getAuthHeaders()
+        );
+        $this->assertResponseStatus(404);
+    }
+
+    public function testCloseNowClearsTheWindow()
+    {
+        // Precondition ("already reopened") set directly via the model rather than through
+        // reopen(), so this test issues exactly one HTTP-simulated write instead of two.
+        // Verified live: the global DoctrineMiddleware (app/Http/Middleware/DoctrineMiddleware.php:38-42)
+        // closes the 'model' entity manager's connection after every request, and container-singleton
+        // repositories (e.g. DoctrineSummitRepository) pin to whichever manager instance existed at
+        // their first resolution -- so a second HTTP write in the same test resolves $summit via that
+        // now-stale repository, mutates a Presentation object the transaction's freshly-reset manager
+        // never tracked, and flush() silently has nothing to persist even though the response is 204.
+        // Raw-SQL-confirmed: with two sequential HTTP writes, SubmissionReopenedHours stayed at the
+        // reopen() value after a "successful" close. That's an orthogonal infra characteristic of
+        // per-request entity-manager closing, not a defect in reopenSubmission()/closeSubmissionNow()
+        // themselves, and out of scope for this test file -- so we avoid triggering it by using the
+        // same "set the precondition directly on the model, then flush" pattern setUp() already uses
+        // for the selection plan dates above.
+        self::$presentation->reopenSubmission(24, self::$member);
+        self::$em->flush();
+
+        $this->closeNow();
+        $this->assertResponseStatus(204);
+
+        $this->assertNull($this->reloadPresentation()->getSubmissionReopenedUntil());
+    }
+
+    public function testReopenIsRefusedWhileTheWindowIsStillOpen()
+    {
+        self::$default_selection_plan->setSubmissionEndDate(
+            (new \DateTime('now', new \DateTimeZone('UTC')))->add(new \DateInterval('P1D'))
+        );
+        self::$em->flush();
+
+        $response = $this->reopen(['hours' => 24]);
+        $this->assertResponseStatus(412);
+        // a DIFFERENT message from assertRefusedBySubmissionWindow()'s: this one is the reopen
+        // service's own "still open" guard, so an unrelated 412 cannot stand in for it
+        $this->assertErrorsContain($response, 'Submission period has not ended yet; nothing to reopen.');
+    }
+
+    public function testReopenFieldsAppearOnDefaultAdminResponseWithoutAFieldsParam()
+    {
+        $this->reopen(['hours' => 24]);
+        $this->assertResponseStatus(201);
+
+        $params = [
+            'id' => self::$summit->getId(),
+            'event_id' => self::$presentation->getId(),
+        ];
+        $headers = $this->getAuthHeaders(); // includes CONTENT_TYPE: application/json
+
+        $response = $this->action(
+            "GET", "OAuth2SummitEventsApiController@getEvent", $params, [], [], [], $headers
+        );
+        $this->assertResponseStatus(200);
+
+        $payload = json_decode($response->getContent(), true);
+        $this->assertFutureEpoch($payload, 'submission_reopened_until', 'admin getEvent response');
+        // the GRANTING member's id, not merely present: a bare new Presentation() serializes
+        // submission_reopened_by_id as 0 (getSubmissionReopenedById() returns 0 when unset),
+        // so a presence-only assertion proves nothing about the grant
+        $this->assertArrayHasKey('submission_reopened_by_id', $payload);
+        $this->assertEquals(self::$member->getId(), $payload['submission_reopened_by_id']);
+        $this->assertArrayHasKey('submission_reopened_by', $payload);
+        $this->assertIsString($payload['submission_reopened_by']);
+    }
+
+    public function testByFieldsAreAbsentFromTheSubmissionSerializer()
+    {
+        $this->reopen(['hours' => 24]);
+
+        $params = [
+            'id' => self::$summit->getId(),
+            'presentation_id' => self::$presentation->getId(),
+        ];
+        $headers = $this->getAuthHeaders(); // includes CONTENT_TYPE: application/json
+
+        $response = $this->action(
+            "GET", "OAuth2PresentationApiController@getPresentationSubmission",
+            $params, [], [], [], $headers
+        );
+        // 201, not 200: getPresentationSubmission returns $this->updated(...)
+        // (OAuth2PresentationApiController.php:457), and JsonController::updated() is 201.
+        $this->assertResponseStatus(201);
+
+        $payload = json_decode($response->getContent(), true);
+        $this->assertFutureEpoch($payload, 'submission_reopened_until', 'submission serializer response');
+        $this->assertArrayNotHasKey('submission_reopened_by_id', $payload);
+        $this->assertArrayNotHasKey('submission_reopened_by', $payload);
+    }
+
+    public function testReopenFieldsNeverAppearOnAPublicSerializedResponse()
+    {
+        $this->reopen(['hours' => 24]);
+
+        $payload = SerializerRegistry::getInstance()->getSerializer(
+            $this->reloadPresentation(), SerializerRegistry::SerializerType_Public
+        )->serialize();
+
+        $this->assertArrayNotHasKey('submission_reopened_until', $payload);
+        $this->assertArrayNotHasKey('submission_reopened_by_id', $payload);
+        $this->assertArrayNotHasKey('submission_reopened_by', $payload);
+    }
+
+    public function testSpeakerPresentationListReturnsTheReopenWindow()
+    {
+        $this->reopen(['hours' => 24]);
+        $this->assertResponseStatus(201);
+
+        $params = [
+            'id' => self::$summit->getId(),
+            'role' => 'creator',
+            'selection_plan_id' => self::$default_selection_plan->getId(),
+        ];
+        $headers = $this->getAuthHeaders(); // includes CONTENT_TYPE: application/json
+
+        $response = $this->action(
+            "GET",
+            "OAuth2SummitSpeakersApiController@getMySpeakerPresentationsByRoleAndBySelectionPlan",
+            $params, [], [], [], $headers
+        );
+        $this->assertResponseStatus(200);
+
+        $page = json_decode($response->getContent(), true);
+        $this->assertNotEmpty($page['data'], 'list returned no rows; the token member did not create the presentation');
+        $this->assertFutureEpoch(
+            $page['data'][0],
+            'submission_reopened_until',
+            'if the key is missing the list is Public-serialized: PagingResponse::toArray() was called without a serializer type'
+        );
+    }
+
+    public function testSummitWideSpeakerListAlsoReturnsTheReopenWindow()
+    {
+        $this->reopen(['hours' => 24]);
+        $this->assertResponseStatus(201);
+
+        // NOTE: this route's param is {summit_id}, not {id} -- it lives under a different
+        // prefix group (routes/api_v1.php:2309) than the selection-plan sibling above.
+        $params = [
+            'summit_id' => self::$summit->getId(),
+            'role' => 'creator',
+        ];
+        $headers = $this->getAuthHeaders(); // includes CONTENT_TYPE: application/json
+
+        $response = $this->action(
+            "GET",
+            "OAuth2SummitSpeakersApiController@getMySpeakerPresentationsByRoleAndBySummit",
+            $params, [], [], [], $headers
+        );
+        $this->assertResponseStatus(200);
+
+        $page = json_decode($response->getContent(), true);
+        $this->assertNotEmpty($page['data']);
+        $this->assertFutureEpoch($page['data'][0], 'submission_reopened_until', 'summit-wide speaker list row');
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Acceptance: an active grant actually lets the speaker edit after the window closed.
+    // The token member is both a global admin AND the presentation's creator with a speaker profile
+    // (InsertMemberTestData.php:144-149, plus setCreatedBy() in setUp above), so one token drives
+    // both roles. canEdit() matches on getCreatedById() == speaker->getMemberId()
+    // (Presentation.php:1264-1270).
+    // ---------------------------------------------------------------------------------------------
+
+    public function testActiveGrantLetsTheSpeakerUpdateAfterTheWindowClosed()
+    {
+        $this->grantWindow(24);
+        // prove the arrange step landed in the DB: without this, a passing refusal sibling and a
+        // failing success case here would be indistinguishable from "the grant was never written"
+        $this->assertTrue(
+            $this->reloadPresentation()->isSubmissionReopened(),
+            'grant did not persist; the assertions below would not be testing the gate'
+        );
+
+        $this->updateSubmission();
+        $this->assertResponseStatus(201);
+        // assert the edit actually landed -- a 201 from an ignored payload must not pass
+        $this->assertEquals('EDITED DURING REOPEN', $this->reloadPresentation()->getTitle());
+    }
+
+    public function testWithoutAGrantTheSameUpdateIsRefused()
+    {
+        // precondition: no grant at all. setUp() never grants one, but assert it rather than assume.
+        $this->assertNull(self::$presentation->getSubmissionReopenedUntil());
+        $this->assertFalse(self::$presentation->isSubmissionReopened());
+
+        $this->assertRefusedBySubmissionWindow($this->updateSubmission());
+    }
+
+    public function testExpiredGrantRefusesTheUpdate()
+    {
+        // a 1h grant whose start is backdated 2h => getSubmissionReopenedUntil() is 1h in the past
+        self::$presentation->reopenSubmission(1, self::$member);
+        self::$presentation->setSubmissionReopenedDate(
+            (new \DateTime('now', new \DateTimeZone('UTC')))->sub(new \DateInterval('PT2H'))
+        );
+        self::$em->flush();
+
+        // precondition: a grant EXISTS (so this is not vacuously the no-grant case) but has expired
+        $reloaded = $this->reloadPresentation();
+        $this->assertNotNull($reloaded->getSubmissionReopenedUntil(), 'grant did not persist');
+        $this->assertLessThan(new \DateTime('now', new \DateTimeZone('UTC')), $reloaded->getSubmissionReopenedUntil());
+        $this->assertFalse($reloaded->isSubmissionReopened());
+
+        $this->assertRefusedBySubmissionWindow($this->updateSubmission());
+    }
+
+    public function testCloseNowImmediatelyRefusesTheUpdate()
+    {
+        // closeSubmissionNow() is invoked on the model, not through the DELETE endpoint: chaining
+        // close + update would be two HTTP writes on the same entity (see grantWindow() above).
+        // testCloseNowClearsTheWindow already proves the endpoint clears the grant; this proves a
+        // cleared grant refuses the edit -- i.e. closing is not a no-op that leaves the window live.
+        self::$presentation->reopenSubmission(24, self::$member);
+        self::$em->flush();
+        $this->assertTrue($this->reloadPresentation()->isSubmissionReopened(), 'grant did not persist');
+
+        self::$presentation = self::$em->getRepository(Presentation::class)->find(self::$presentation->getId());
+        self::$presentation->closeSubmissionNow();
+        self::$em->flush();
+
+        // precondition: the grant is gone
+        $this->assertNull($this->reloadPresentation()->getSubmissionReopenedUntil(), 'close did not persist');
+
+        $this->assertRefusedBySubmissionWindow($this->updateSubmission());
+    }
+
+    public function testDisablingThePlanAfterAGrantRefusesTheUpdate()
+    {
+        $this->grantWindow(24);
+        self::$default_selection_plan->setIsEnabled(false);
+        self::$em->flush();
+
+        // What the 412 below does and does NOT prove. The refusal comes from the PRE-EXISTING
+        // !IsEnabled() guard (PresentationService.php:543-545), which throws the identical
+        // "Submission Period is Closed." one branch before the reopen-aware guard at :547 -- so the
+        // message cannot discriminate the two, and this test does not by itself prove the grant was
+        // overridden rather than merely bypassed. The real proof that isSubmissionReopened() returns
+        // false BECAUSE of IsEnabled() is the model-level test (PresentationReopenModelTest) plus the
+        // preconditions asserted here: the grant is present and still in the future, the plan really
+        // is disabled, and isSubmissionReopened() is nonetheless false. What this test adds is that
+        // the HTTP path refuses too -- i.e. no controller/service layer re-opens the edit.
+        $reloaded = $this->reloadPresentation();
+        $this->assertNotNull($reloaded->getSubmissionReopenedUntil(), 'grant did not persist');
+        $this->assertGreaterThan(new \DateTime('now', new \DateTimeZone('UTC')), $reloaded->getSubmissionReopenedUntil());
+        $this->assertFalse($reloaded->getSelectionPlan()->IsEnabled(), 'plan disable did not persist');
+        $this->assertFalse($reloaded->isSubmissionReopened());
+
+        $this->assertRefusedBySubmissionWindow($this->updateSubmission());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // complete is a SEPARATE gate from update (PresentationService.php:666-672) and runs three more
+    // checks AFTER it, so the fixture must satisfy all three or a failure downstream of the gate
+    // reads as a false negative on the feature. Two are already satisfied; one is not:
+    //  - isSubmitted() (:653 -> Presentation.php:1345): PHASE_COMPLETE && STATUS_RECEIVED. A freshly
+    //    built Presentation is neither, so complete is allowed. No fixture work.
+    //  - fulfilMediaUploadsConditions() (Presentation.php:1290): the 5 media upload types attached
+    //    to defaultPresentationType (InsertSummitTestData.php:438-448) never call
+    //    setMinUploadsQty(), and SummitMediaUploadType::__construct defaults min_uploads_qty to 0
+    //    (SummitMediaUploadType.php:125), so getMandatoryAllowedMediaUploadTypesCount() is 0 and the
+    //    method short-circuits true at :1297. No upload needs to be attached.
+    //  - fulfilSpeakersConditions() (:1305) is the ONE that needs fixture work -> attachSpeaker().
+    //    useModerator=false skips the moderator branch, but useSpeakers=true with minSpeakers=1
+    //    (InsertSummitTestData.php:414-418) refuses an empty presentation at :1322: the fixture's
+    //    setAreSpeakersMandatory(false) (:420) is inert, because
+    //    PresentationType::isAreSpeakersMandatory() ignores that column and returns
+    //    min_speakers > 0 (PresentationType.php:193-196). Verified empirically -- the precondition
+    //    assertion below failed until attachSpeaker() was added. One speaker satisfies
+    //    min 1 <= count 1 <= max 3.
+    // The remaining hazard is the notification email: complete dispatches
+    // PresentationCreatorNotificationEmail, whose constructor throws \InvalidArgumentException (->
+    // 400, NOT 412) when cfp.base_url / idp.base_url / support email are empty. Set them so a config
+    // gap cannot be mistaken for a gate refusal.
+    // ---------------------------------------------------------------------------------------------
+
+    private function seedCompletionEmailConfig(): void
+    {
+        Config::set('cfp.base_url', 'https://testcfp.openstack.org');
+        Config::set('cfp.support_email', 'test@openstack.org');
+        Config::set('idp.base_url', 'https://testidp.openstack.org');
+    }
+
+    /**
+     * self::$speaker is the token member's own speaker profile (InsertMemberTestData.php:144-149),
+     * so this satisfies fulfilSpeakersConditions() without introducing a second identity. canEdit()
+     * already passed via the creator branch, so this changes nothing about authorization.
+     */
+    private function attachSpeaker(): void
+    {
+        self::$presentation->addSpeaker(self::$speaker);
+        self::$em->flush();
+    }
+
+    public function testActiveGrantLetsTheSpeakerCompleteAfterTheWindowClosed()
+    {
+        $this->seedCompletionEmailConfig();
+        $this->attachSpeaker();
+        $this->grantWindow(24);
+
+        $reloaded = $this->reloadPresentation();
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist');
+        // prove the post-gate checks cannot be what fails, so a non-201 below indicts the gate
+        $this->assertFalse($reloaded->isSubmitted());
+        $this->assertTrue($reloaded->fulfilMediaUploadsConditions());
+        $this->assertTrue($reloaded->fulfilSpeakersConditions());
+
+        $this->completeSubmission();
+        $this->assertResponseStatus(201);
+        // the request passed THROUGH the gate rather than never reaching it: complete's only
+        // side effect is progress/status, and isSubmitted() is exactly that pair
+        $this->assertTrue($this->reloadPresentation()->isSubmitted());
+    }
+
+    public function testWithoutAGrantCompleteIsRefused()
+    {
+        $this->seedCompletionEmailConfig();
+        $this->attachSpeaker();
+
+        // precondition: no grant, and the presentation is otherwise completable -- so the 412 below
+        // can only come from the window gate, not from isSubmitted()/media/speaker conditions
+        $this->assertFalse(self::$presentation->isSubmissionReopened());
+        $this->assertFalse(self::$presentation->isSubmitted());
+        $this->assertTrue(self::$presentation->fulfilMediaUploadsConditions());
+        $this->assertTrue(self::$presentation->fulfilSpeakersConditions());
+
+        $this->assertRefusedBySubmissionWindow($this->completeSubmission());
+        $this->assertFalse($this->reloadPresentation()->isSubmitted());
+    }
+}

--- a/tests/PresentationReopenAuthzTest.php
+++ b/tests/PresentationReopenAuthzTest.php
@@ -1,0 +1,560 @@
+<?php namespace Tests;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Models\Foundation\Main\IGroup;
+use App\Models\ResourceServer\IAccessTokenService;
+use Illuminate\Support\Facades\App;
+use LaravelDoctrine\ORM\Facades\Registry;
+use models\summit\Presentation;
+use models\utils\SilverstripeBaseModel;
+
+/**
+ * Everything in the reopen feature that requires a NON-global-admin identity.
+ *
+ * Split from PresentationReopenApiTest rather than shared through a trait on purpose: the fixture
+ * here is materially different (a downgraded identity, plus a second presentation owned by another
+ * member for the authorship test), so a shared trait would need conditionals. The duplicated
+ * helpers below are copies of that class's, deliberately.
+ *
+ * WHY A DOWNGRADED IDENTITY IS THE WHOLE POINT
+ * Member::isAdmin() (Member.php:895-921) consults persisted groups AND the token's IdP groups, and
+ * BOTH default to administrator in this harness. Every guard exercised here short-circuits for a
+ * global admin -- the reopen/close endpoints (OAuth2PresentationApiController.php:578-580, :632-634),
+ * PresentationService::deletePresentation (:590-591) and SummitService::deleteEvent (:1075-1077) --
+ * so an admin-run version of this class would be 403-free and prove nothing. See
+ * assertIdentityIsNotAdmin(), which runs in setUp() for EVERY test in this class, not just the
+ * named canary, so this cannot be silently regressed by deleting one test.
+ *
+ * CHOICE OF PERSISTED GROUP: IGroup::SummitRegistrationAdmins.
+ *  - isAdmin() is false: only SuperAdmins/Administrators satisfy it.
+ *  - hasPermissionForOnGroup($summit, SummitAdministrators) is false: it requires a
+ *    SummitAdministratorPermissionGroup row linking THIS member to THIS summit
+ *    (Member.php:2183-2206), and the fixture's permission group has the summit but no members
+ *    (InsertSummitTestData.php:864-866). So this is exactly "a member with no summit admin
+ *    permission" -- and a stronger persona than a random member, because it also proves the
+ *    per-summit scoping is what refuses, not mere group absence.
+ *  - It is on delete-event's authz_groups list (ApiEndpointsSeeder.php:4504-4513), so the
+ *    'auth.user' middleware (UserAuthEndpoint.php:129-149) lets the request through to the
+ *    SummitService guard under test. IGroup::TrackChairs would have been 403'd by that middleware
+ *    before ever reaching the fold, making Step 4's SummitService half untestable.
+ *
+ * Class PresentationReopenAuthzTest
+ * @package Tests
+ */
+class PresentationReopenAuthzTest extends ProtectedApiTestCase
+{
+    use InsertSummitTestData;
+
+    /**
+     * Created by self::$member (so canEdit()/memberCanEdit() pass) -- used for the reopen/close 403s,
+     * both delete paths, and as the "other presentation carrying a grant" in the create test.
+     * @var Presentation
+     */
+    static $presentation;
+
+    /**
+     * Created by self::$member2 with NO speaker/moderator link to self::$member: the Step 5
+     * authorship fixture.
+     * @var Presentation
+     */
+    static $foreign_presentation;
+
+    protected function setUp(): void
+    {
+        // Lever 1: the persisted group. setCurrentGroup() must precede parent::setUp(), which is
+        // what forwards it to insertMemberTestData() (ProtectedApiTestCase.php:365-375).
+        $this->setCurrentGroup(IGroup::SummitRegistrationAdmins);
+        parent::setUp();
+
+        // Lever 2: the token's IdP groups. AccessTokenServiceStub's constructor DEFAULTS
+        // $idp_user_groups to ['badge-printers','administrators'] (ProtectedApiTestCase.php:38-47)
+        // and createApplication() installs it with no arguments (:327), so isAdmin() returns true
+        // via isOnExternalGroup(Administrators) (Member.php:916-917) no matter what lever 1 says.
+        // Replace the stub AND re-bind it: App::singleton() -> bind() drops any already-resolved
+        // instance, which reassigning the static alone would not do.
+        self::$service = new AccessTokenServiceStub([['slug' => IGroup::BadgePrinters]]);
+        App::singleton(IAccessTokenService::class, function () { return self::$service; });
+        // parent::setUp() seeded the identity onto the OLD stub; re-seed it onto the new one or the
+        // token carries no user and every endpoint 403s on is_null($current_member) instead.
+        self::$service->setUserId(self::$member->getUserExternalId());
+        self::$service->setUserExternalId(self::$member->getUserExternalId());
+        self::$service->setUserEmail(self::$member->getEmail());
+        self::$service->setUserFirstName(self::$member->getFirstName());
+        self::$service->setUserLastName(self::$member->getLastName());
+
+        self::insertSummitTestData();
+
+        self::$presentation = new Presentation();
+        self::$presentation->setTitle("REOPEN AUTHZ TEST");
+        self::$presentation->setType(self::$defaultPresentationType);
+        self::$presentation->setSelectionPlan(self::$default_selection_plan);
+        self::$presentation->setCreatedBy(self::$member);
+        self::$presentation->setCategory(self::$defaultTrack);
+        self::$summit->addEvent(self::$presentation);
+
+        // Step 5's fixture: same summit/plan/type/track, but created by a DIFFERENT member and with
+        // no speaker or moderator link to the token member, so canEdit() is false for it.
+        self::$foreign_presentation = new Presentation();
+        self::$foreign_presentation->setTitle("OWNED BY SOMEONE ELSE");
+        self::$foreign_presentation->setType(self::$defaultPresentationType);
+        self::$foreign_presentation->setSelectionPlan(self::$default_selection_plan);
+        self::$foreign_presentation->setCreatedBy(self::$member2);
+        self::$foreign_presentation->setCategory(self::$defaultTrack);
+        self::$summit->addEvent(self::$foreign_presentation);
+
+        // the feature only applies once the window has ended
+        self::$default_selection_plan->setIsEnabled(true);
+        self::$default_selection_plan->setSubmissionBeginDate(
+            (new \DateTime('now', new \DateTimeZone('UTC')))->sub(new \DateInterval('P10D'))
+        );
+        self::$default_selection_plan->setSubmissionEndDate(
+            (new \DateTime('now', new \DateTimeZone('UTC')))->sub(new \DateInterval('P1D'))
+        );
+
+        self::$em->persist(self::$summit);
+        self::$em->flush();
+
+        $this->assertIdentityIsNotAdmin();
+    }
+
+    protected function tearDown(): void
+    {
+        self::clearSummitTestData();
+        parent::tearDown();
+    }
+
+    /**
+     * Both admin levers, asserted separately so a regression names which one came back.
+     *
+     * isAdmin(true) skips the external check, which isolates lever 1 (a real DB read).
+     * Lever 2 cannot be isolated through isAdmin(): isOnExternalGroup() (Member.php:987-1006) reads
+     * the request-scoped resource-server context, which is empty outside a dispatched request, so
+     * isAdmin() would report false here even with the admin-defaulted stub still installed -- a
+     * false negative. So assert on the token the container actually hands the middleware instead.
+     *
+     * Called from setUp(), i.e. it guards every test in this class, and separately as the named
+     * canary test below.
+     */
+    private function assertIdentityIsNotAdmin(): void
+    {
+        // lever 1: persisted groups
+        $this->assertNull(
+            self::$member->getGroupByCode(IGroup::Administrators),
+            'fixture member is persisted into the administrators group'
+        );
+        $this->assertNull(
+            self::$member->getGroupByCode(IGroup::SuperAdmins),
+            'fixture member is persisted into the super-admins group'
+        );
+        $this->assertFalse(
+            self::$member->isAdmin(true),
+            'fixture is still a global admin by persisted group; 403 tests here are meaningless'
+        );
+
+        // lever 2: the IdP groups on the token the container is serving
+        $slugs = array_column(
+            App::make(IAccessTokenService::class)->get($this->access_token)->getUserGroups(),
+            'slug'
+        );
+        $this->assertNotContains(
+            IGroup::Administrators,
+            $slugs,
+            'the access-token stub still reports the administrators IdP group; isAdmin() will be '
+            . 'true inside a request and every 403 test here is meaningless'
+        );
+        $this->assertNotContains(IGroup::SuperAdmins, $slugs);
+
+        $this->assertFalse(self::$member->isAdmin(), 'fixture is still a global admin');
+    }
+
+    /**
+     * Same manager-refresh dance as PresentationReopenApiTest::reloadPresentation(): self::$em is
+     * the 'model' manager, the bare EntityManager facade resolves to 'config'/api_config where
+     * Presentation does not exist, and each dispatched request closes 'model' on the way out
+     * (DoctrineMiddleware::handle), so re-fetch from Registry before reading.
+     */
+    private function reload(int $id): ?Presentation
+    {
+        self::$em = Registry::getManager(SilverstripeBaseModel::EntityManager);
+        if (!self::$em->isOpen()) {
+            self::$em = Registry::resetManager(SilverstripeBaseModel::EntityManager);
+        }
+        self::$em->clear();
+        return self::$em->getRepository(Presentation::class)->find($id);
+    }
+
+    /**
+     * buildForSubmission() marks exactly title/type_id/track_id/selection_plan_id required
+     * (SummitEventValidationRulesFactory.php:139-157). A partial payload 400s before any gate runs.
+     */
+    private function validUpdatePayload(): array
+    {
+        return [
+            'title' => 'EDITED DURING REOPEN',
+            'type_id' => self::$defaultPresentationType->getId(),
+            'track_id' => self::$defaultTrack->getId(),
+            'selection_plan_id' => self::$default_selection_plan->getId(),
+        ];
+    }
+
+    /**
+     * Arrange the grant on the model, never through the reopen endpoint: a BrowserKit test cannot
+     * do two sequential HTTP writes against the same entity (DoctrineMiddleware::handle closes the
+     * 'model' EM after every request and singleton repositories pin the manager they were first
+     * resolved with, so the second write mutates an untracked object and flush() silently persists
+     * nothing while still returning success). Every test below spends its one HTTP write on the
+     * endpoint under test. This identity could not call the admin endpoint anyway.
+     */
+    private function grantWindow(Presentation $presentation, int $hours = 24): void
+    {
+        $presentation->reopenSubmission($hours, self::$member2);
+        self::$em->flush();
+    }
+
+    private function assertRefusedByDeleteGuard($response, int $presentation_id): void
+    {
+        $this->assertResponseStatus(412);
+        $body = json_decode($response->getContent(), true);
+        $this->assertIsArray($body['errors'] ?? null, $response->getContent());
+        $this->assertContains(
+            sprintf("Presentation %s can not be deleted because the submission is closed.", $presentation_id),
+            $body['errors'],
+            'refused with 412, but NOT by the closed-submission delete guard: ' . $response->getContent()
+        );
+    }
+
+    private function assertErrorsContain($response, string $needle): void
+    {
+        $body = json_decode($response->getContent(), true);
+        $this->assertIsArray($body['errors'] ?? null, $response->getContent());
+        $this->assertContains($needle, $body['errors'], $response->getContent());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Canary
+    // ---------------------------------------------------------------------------------------------
+
+    public function testFixtureIdentityIsGenuinelyNotAdmin()
+    {
+        $this->assertFalse(self::$member->isAdmin(), 'fixture is still a global admin; 403 tests below are meaningless');
+        // and the full two-lever check, in case isAdmin() alone ever stops covering both
+        $this->assertIdentityIsNotAdmin();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Step 3: a non-admin can neither reopen nor close.
+    //
+    // 403-vs-201 is self-validating against the admin trap: a global admin would get 201/204 here,
+    // so these cannot pass because the identity is too privileged. The other way to get a spurious
+    // 403 is the token failing to resolve to a member at all
+    // (OAuth2PresentationApiController.php:575-576) -- ruled out class-wide by the delete tests
+    // below, which 204 only because the token resolves to self::$member, the presentation's creator
+    // with a speaker profile. Each test also asserts the grant state is UNCHANGED, so a refusal
+    // that somehow still mutated would fail.
+    // ---------------------------------------------------------------------------------------------
+
+    public function testMemberWithNoSummitAdminPermissionCannotReopen()
+    {
+        // precondition: no grant, and the window really has closed (so 403 is not standing in for
+        // the service's "nothing to reopen" 412)
+        $this->assertNull(self::$presentation->getSubmissionReopenedUntil());
+        $this->assertFalse(self::$default_selection_plan->isSubmissionOpen());
+
+        $this->action(
+            "PUT", "OAuth2PresentationApiController@reopenSubmissionPeriod",
+            ['id' => self::$summit->getId(), 'presentation_id' => self::$presentation->getId()],
+            [], [], [], $this->getAuthHeaders(), json_encode(['hours' => 24])
+        );
+        $this->assertResponseStatus(403);
+
+        $this->assertNull(
+            $this->reload(self::$presentation->getId())->getSubmissionReopenedUntil(),
+            'refused with 403 but the grant was written anyway'
+        );
+    }
+
+    public function testMemberWithNoSummitAdminPermissionCannotClose()
+    {
+        $this->grantWindow(self::$presentation);
+        // precondition: there IS a grant to clear, so a 403 cannot be a no-op passing vacuously
+        $this->assertTrue(
+            $this->reload(self::$presentation->getId())->isSubmissionReopened(),
+            'grant did not persist; this test would not be exercising the close endpoint'
+        );
+
+        $this->action(
+            "DELETE", "OAuth2PresentationApiController@closeSubmissionPeriod",
+            ['id' => self::$summit->getId(), 'presentation_id' => self::$presentation->getId()],
+            [], [], [], $this->getAuthHeaders()
+        );
+        $this->assertResponseStatus(403);
+
+        $this->assertTrue(
+            $this->reload(self::$presentation->getId())->isSubmissionReopened(),
+            'refused with 403 but the grant was cleared anyway'
+        );
+    }
+
+    /**
+     * Persona (b): being a speaker ON the presentation is deliberately not a fallback -- §4 gives no
+     * speaker path to the reopen controls. This is the strongest form: the member is the creator AND
+     * an assigned speaker, i.e. memberCanEdit() is true, and it is still refused.
+     */
+    public function testSpeakerOnThePresentationStillCannotReopen()
+    {
+        self::$presentation->addSpeaker(self::$speaker);
+        self::$em->flush();
+
+        $reloaded = $this->reload(self::$presentation->getId());
+        $this->assertTrue($reloaded->memberCanEdit(self::$member), 'speaker/creator link did not persist');
+        $this->assertNull($reloaded->getSubmissionReopenedUntil());
+
+        $this->action(
+            "PUT", "OAuth2PresentationApiController@reopenSubmissionPeriod",
+            ['id' => self::$summit->getId(), 'presentation_id' => self::$presentation->getId()],
+            [], [], [], $this->getAuthHeaders(), json_encode(['hours' => 24])
+        );
+        $this->assertResponseStatus(403);
+
+        $this->assertNull(
+            $this->reload(self::$presentation->getId())->getSubmissionReopenedUntil(),
+            'refused with 403 but the grant was written anyway'
+        );
+    }
+
+    public function testSpeakerOnThePresentationStillCannotClose()
+    {
+        self::$presentation->addSpeaker(self::$speaker);
+        $this->grantWindow(self::$presentation);
+
+        $reloaded = $this->reload(self::$presentation->getId());
+        $this->assertTrue($reloaded->memberCanEdit(self::$member), 'speaker/creator link did not persist');
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist');
+
+        $this->action(
+            "DELETE", "OAuth2PresentationApiController@closeSubmissionPeriod",
+            ['id' => self::$summit->getId(), 'presentation_id' => self::$presentation->getId()],
+            [], [], [], $this->getAuthHeaders()
+        );
+        $this->assertResponseStatus(403);
+
+        $this->assertTrue(
+            $this->reload(self::$presentation->getId())->isSubmissionReopened(),
+            'refused with 403 but the grant was cleared anyway'
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // The _by fields are admin-only ON THE WIRE.
+    //
+    // PresentationReopenApiTest's Public-serializer test asserts this by calling SerializerRegistry
+    // directly, which bypasses the thing that actually decides the type on a real read:
+    // OAuth2SummitEventsApiController::getSerializerType() (:117-133) returns Private only for an
+    // ApplicationType_Service token or a current user who isAdmin()/isSummitAdmin(), and Public
+    // otherwise. This class holds the only genuinely non-admin identity in the feature's tests
+    // (SummitRegistrationAdmins satisfies neither predicate -- Member::isSummitAdmin() :923-931 keys
+    // on SummitAdministrators, and the harness token is WEB_APPLICATION, not SERVICE), so this is
+    // where that branch can be exercised end to end. getEvent carries no 'auth.user' middleware
+    // (routes/api_v1.php:698), so the request reaches the controller.
+    // ---------------------------------------------------------------------------------------------
+
+    public function testNonAdminEventReadDoesNotExposeTheByFields()
+    {
+        $this->grantWindow(self::$presentation);
+        $this->assertTrue(
+            $this->reload(self::$presentation->getId())->isSubmissionReopened(),
+            'grant did not persist; an absent field would prove nothing'
+        );
+
+        $response = $this->action(
+            "GET", "OAuth2SummitEventsApiController@getEvent",
+            ['id' => self::$summit->getId(), 'event_id' => self::$presentation->getId()],
+            [], [], [], $this->getAuthHeaders()
+        );
+        $this->assertResponseStatus(200);
+
+        $payload = json_decode($response->getContent(), true);
+        // the assertions below are not vacuous on an empty/error body
+        $this->assertEquals(self::$presentation->getId(), $payload['id'] ?? null, $response->getContent());
+        $this->assertEquals('REOPEN AUTHZ TEST', $payload['title'] ?? null, $response->getContent());
+
+        $this->assertArrayNotHasKey('submission_reopened_by', $payload, $response->getContent());
+        $this->assertArrayNotHasKey('submission_reopened_by_id', $payload, $response->getContent());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Step 4: both delete paths honor a reopen, with no change at either call site.
+    //
+    // Path A: DELETE /summits/{id}/presentations/{presentation_id}
+    //         -> OAuth2PresentationApiController@deletePresentation -> PresentationService::deletePresentation
+    //         guard at PresentationService.php:590-591.
+    // Path B: DELETE /summits/{id}/events/{event_id}
+    //         -> OAuth2SummitEventsApiController@deleteEvent -> SummitService::deleteEvent
+    //         guard at SummitService.php:1076-1077.
+    // Both guards read Presentation::isSubmissionClosed(), which Task 1 folded the reopen check
+    // into -- that fold is the only reason the reopened cases below can pass.
+    // ---------------------------------------------------------------------------------------------
+
+    public function testReopenedPresentationCanBeDeletedByANonAdminCreator()
+    {
+        $this->grantWindow(self::$presentation);
+
+        $reloaded = $this->reload(self::$presentation->getId());
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist');
+        $this->assertFalse($reloaded->isSubmissionClosed(), 'the fold did not treat the grant as re-opening');
+
+        $id = self::$presentation->getId();
+        $this->action(
+            "DELETE", "OAuth2PresentationApiController@deletePresentation",
+            ['id' => self::$summit->getId(), 'presentation_id' => $id],
+            [], [], [], $this->getAuthHeaders()
+        );
+        $this->assertResponseStatus(204);
+        $this->assertNull($this->reload($id), '204 returned but the presentation is still there');
+    }
+
+    public function testMerelyClosedPresentationCannotBeDeletedByANonAdminCreator()
+    {
+        // precondition: no grant, window ended => isSubmissionClosed() is true
+        $reloaded = $this->reload(self::$presentation->getId());
+        $this->assertNull($reloaded->getSubmissionReopenedUntil());
+        $this->assertTrue($reloaded->isSubmissionClosed(), 'fixture window is not actually closed');
+
+        $id = self::$presentation->getId();
+        $response = $this->action(
+            "DELETE", "OAuth2PresentationApiController@deletePresentation",
+            ['id' => self::$summit->getId(), 'presentation_id' => $id],
+            [], [], [], $this->getAuthHeaders()
+        );
+        $this->assertRefusedByDeleteGuard($response, $id);
+        $this->assertNotNull($this->reload($id), 'refused with 412 but the presentation was deleted anyway');
+    }
+
+    public function testReopenedPresentationCanBeDeletedViaTheEventDeletePath()
+    {
+        $this->grantWindow(self::$presentation);
+
+        $reloaded = $this->reload(self::$presentation->getId());
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist');
+        $this->assertFalse($reloaded->isSubmissionClosed(), 'the fold did not treat the grant as re-opening');
+
+        $id = self::$presentation->getId();
+        $this->action(
+            "DELETE", "OAuth2SummitEventsApiController@deleteEvent",
+            ['id' => self::$summit->getId(), 'event_id' => $id],
+            [], [], [], $this->getAuthHeaders()
+        );
+        // a 403 here would mean the auth.user middleware refused before SummitService ran
+        $this->assertResponseStatus(204);
+        $this->assertNull($this->reload($id), '204 returned but the presentation is still there');
+    }
+
+    public function testMerelyClosedPresentationCannotBeDeletedViaTheEventDeletePath()
+    {
+        $reloaded = $this->reload(self::$presentation->getId());
+        $this->assertNull($reloaded->getSubmissionReopenedUntil());
+        $this->assertTrue($reloaded->isSubmissionClosed(), 'fixture window is not actually closed');
+
+        $id = self::$presentation->getId();
+        $response = $this->action(
+            "DELETE", "OAuth2SummitEventsApiController@deleteEvent",
+            ['id' => self::$summit->getId(), 'event_id' => $id],
+            [], [], [], $this->getAuthHeaders()
+        );
+        $this->assertRefusedByDeleteGuard($response, $id);
+        $this->assertNotNull($this->reload($id), 'refused with 412 but the presentation was deleted anyway');
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Step 5: reopen relaxes TIMING, never WHO.
+    //
+    // updatePresentationSubmission checks canEdit() (PresentationService.php:530-534) BEFORE the
+    // window gate (:543-548), so the refusal message discriminates authorship from timing: this
+    // must be the canEdit message, NOT "Submission Period is Closed." -- otherwise the grant would
+    // not actually be active and the test would prove nothing about authorship.
+    // ---------------------------------------------------------------------------------------------
+
+    public function testNonEditorStillCannotUpdateAReopenedPresentation()
+    {
+        $this->grantWindow(self::$foreign_presentation);
+
+        $reloaded = $this->reload(self::$foreign_presentation->getId());
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist; timing would refuse first');
+        $this->assertFalse(
+            $reloaded->memberCanEdit(self::$member),
+            'fixture member CAN edit this presentation; the test is not exercising the authorship gate'
+        );
+
+        $response = $this->action(
+            "PUT", "OAuth2PresentationApiController@updatePresentationSubmission",
+            ['id' => self::$summit->getId(), 'presentation_id' => self::$foreign_presentation->getId()],
+            [], [], [], $this->getAuthHeaders(), json_encode($this->validUpdatePayload())
+        );
+        $this->assertResponseStatus(412);
+        $this->assertErrorsContain(
+            $response,
+            sprintf('Current Speaker can not edit %s presentation', self::$foreign_presentation->getId())
+        );
+
+        $this->assertEquals(
+            'OWNED BY SOMEONE ELSE',
+            $this->reload(self::$foreign_presentation->getId())->getTitle(),
+            'refused with 412 but the edit landed anyway'
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Step 6: creation is untouched by a reopen.
+    //
+    // submitPresentation gates on the PLAN only (PresentationService.php:277-306) and never consults
+    // any presentation, so a live grant on a sibling presentation must not leak into it.
+    // ---------------------------------------------------------------------------------------------
+
+    public function testCreateIsStillBlockedWhileAnotherPresentationOnThePlanHasAnActiveGrant()
+    {
+        $this->grantWindow(self::$presentation);
+
+        $reloaded = $this->reload(self::$presentation->getId());
+        $this->assertTrue($reloaded->isSubmissionReopened(), 'grant did not persist; nothing could leak');
+        $this->assertTrue($reloaded->getSelectionPlan()->IsEnabled());
+        $this->assertFalse($reloaded->getSelectionPlan()->isSubmissionOpen(), 'plan window is not actually closed');
+
+        $before = self::$em->getRepository(Presentation::class)
+            ->count(['summit' => self::$summit->getId()]);
+
+        $response = $this->action(
+            "POST", "OAuth2PresentationApiController@submitPresentation",
+            ['id' => self::$summit->getId()],
+            [], [], [], $this->getAuthHeaders(),
+            json_encode([
+                'title' => 'SHOULD NOT BE CREATED',
+                'type_id' => self::$defaultPresentationType->getId(),
+                'track_id' => self::$defaultTrack->getId(),
+                'selection_plan_id' => self::$default_selection_plan->getId(),
+            ])
+        );
+        $this->assertResponseStatus(412);
+        $this->assertErrorsContain($response, 'Submission Period is Closed.');
+
+        self::$em = Registry::getManager(SilverstripeBaseModel::EntityManager);
+        if (!self::$em->isOpen()) {
+            self::$em = Registry::resetManager(SilverstripeBaseModel::EntityManager);
+        }
+        $this->assertEquals(
+            $before,
+            self::$em->getRepository(Presentation::class)->count(['summit' => self::$summit->getId()]),
+            'refused with 412 but a presentation was created anyway'
+        );
+    }
+}

--- a/tests/PresentationReopenModelTest.php
+++ b/tests/PresentationReopenModelTest.php
@@ -1,0 +1,169 @@
+<?php namespace Tests;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Models\Foundation\Main\IGroup;
+use models\summit\Presentation;
+
+/**
+ * Class PresentationReopenModelTest
+ * @package Tests
+ */
+class PresentationReopenModelTest extends BrowserKitTestCase
+{
+    use InsertMemberTestData;
+    use InsertSummitTestData;
+
+    /**
+     * @var Presentation
+     */
+    static $presentation;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // insertMemberTestData takes a required group slug (tests/InsertMemberTestData.php:96)
+        self::insertMemberTestData(IGroup::SummitAdministrators);
+        // summit fixtures read self::$defaultMember when building orders/attendees
+        self::$defaultMember = self::$member;
+        self::insertSummitTestData();
+
+        self::$presentation = new Presentation();
+        self::$presentation->setTitle("REOPEN MODEL TEST");
+        self::$presentation->setType(self::$defaultPresentationType);
+        self::$presentation->setSelectionPlan(self::$default_selection_plan);
+        self::$summit->addEvent(self::$presentation);
+
+        self::$em->persist(self::$summit);
+        self::$em->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        self::clearSummitTestData();
+        self::clearMemberTestData();
+        parent::tearDown();
+    }
+
+    private function endSubmissionWindow(): void
+    {
+        $plan = self::$default_selection_plan;
+        $plan->setIsEnabled(true);
+        $plan->setSubmissionBeginDate((new \DateTime('now', new \DateTimeZone('UTC')))->sub(new \DateInterval('P10D')));
+        $plan->setSubmissionEndDate((new \DateTime('now', new \DateTimeZone('UTC')))->sub(new \DateInterval('P1D')));
+    }
+
+    public function testNoGrantMeansNotReopenedAndDeadlineIsNull()
+    {
+        $this->endSubmissionWindow();
+
+        $this->assertNull(self::$presentation->getSubmissionReopenedUntil());
+        $this->assertFalse(self::$presentation->isSubmissionReopened());
+        $this->assertTrue(self::$presentation->isSubmissionClosed());
+    }
+
+    public function testActiveGrantOnEndedPlanFoldsIntoIsSubmissionClosed()
+    {
+        $this->endSubmissionWindow();
+        self::$presentation->reopenSubmission(24, self::$member);
+
+        $this->assertNotNull(self::$presentation->getSubmissionReopenedUntil());
+        $this->assertTrue(self::$presentation->isSubmissionReopened());
+        $this->assertFalse(self::$presentation->isSubmissionClosed());
+        $this->assertEquals(24, self::$presentation->getSubmissionReopenedHours());
+        $this->assertEquals(self::$member->getId(), self::$presentation->getSubmissionReopenedById());
+        $this->assertStringContainsString(self::$member->getEmail(), self::$presentation->getSubmissionReopenedByNice());
+    }
+
+    public function testExpiredGrantIsNotReopened()
+    {
+        $this->endSubmissionWindow();
+        self::$presentation->reopenSubmission(1, self::$member);
+        self::$presentation->setSubmissionReopenedDate(
+            (new \DateTime('now', new \DateTimeZone('UTC')))->sub(new \DateInterval('PT2H'))
+        );
+
+        $this->assertFalse(self::$presentation->isSubmissionReopened());
+        $this->assertTrue(self::$presentation->isSubmissionClosed());
+    }
+
+    public function testGrantIsIgnoredWhilePlanWindowHasNotEndedYet()
+    {
+        $plan = self::$default_selection_plan;
+        $plan->setIsEnabled(true);
+        $plan->setSubmissionBeginDate((new \DateTime('now', new \DateTimeZone('UTC')))->sub(new \DateInterval('P1D')));
+        $plan->setSubmissionEndDate((new \DateTime('now', new \DateTimeZone('UTC')))->add(new \DateInterval('P1D')));
+
+        self::$presentation->reopenSubmission(24, self::$member);
+
+        $this->assertFalse(self::$presentation->isSubmissionReopened());
+    }
+
+    public function testGrantIsIgnoredOnDisabledPlan()
+    {
+        $this->endSubmissionWindow();
+        self::$presentation->reopenSubmission(24, self::$member);
+        $this->assertTrue(self::$presentation->isSubmissionReopened());
+
+        self::$default_selection_plan->setIsEnabled(false);
+
+        $this->assertFalse(self::$presentation->isSubmissionReopened());
+        // and the delete guard closes again, which is the whole point of the invariant
+        $this->assertTrue(self::$presentation->isSubmissionClosed());
+    }
+
+    public function testCloseSubmissionNowClearsTheGrantRegardlessOfPlanState()
+    {
+        $this->endSubmissionWindow();
+        self::$presentation->reopenSubmission(24, self::$member);
+        self::$default_selection_plan->setIsEnabled(false);
+
+        self::$presentation->closeSubmissionNow();
+
+        $this->assertNull(self::$presentation->getSubmissionReopenedHours());
+        $this->assertNull(self::$presentation->getSubmissionReopenedDate());
+        $this->assertNull(self::$presentation->getSubmissionReopenedUntil());
+        $this->assertFalse(self::$presentation->isSubmissionReopened());
+    }
+
+    public function testReopenReStampsRatherThanAccumulating()
+    {
+        $this->endSubmissionWindow();
+
+        self::$presentation->reopenSubmission(24, self::$member);
+        $first = self::$presentation->getSubmissionReopenedUntil();
+
+        self::$presentation->reopenSubmission(48, self::$member);
+
+        $this->assertEquals(48, self::$presentation->getSubmissionReopenedHours());
+        $this->assertGreaterThan($first, self::$presentation->getSubmissionReopenedUntil());
+    }
+
+    public function testReviewStatusIsUnaffectedByAReopen()
+    {
+        $this->endSubmissionWindow();
+
+        // A PHASE_NEW presentation returns NotSubmitted either way (Presentation.php:2490-2493),
+        // so asserting on the default fixture would compare a constant to itself and prove
+        // nothing. Drive it to a status that actually flows through the date logic first.
+        self::$presentation->setProgress(Presentation::PHASE_COMPLETE);
+        self::$presentation->setStatus(Presentation::STATUS_RECEIVED);
+
+        $before = self::$presentation->getReviewStatus();
+        $this->assertNotEquals(Presentation::ReviewStatusNoSubmitted, $before, 'fixture is not exercising the date logic');
+
+        self::$presentation->reopenSubmission(24, self::$member);
+
+        $this->assertEquals($before, self::$presentation->getReviewStatus());
+    }
+}

--- a/tests/PresentationReopenModelTest.php
+++ b/tests/PresentationReopenModelTest.php
@@ -82,7 +82,8 @@ class PresentationReopenModelTest extends BrowserKitTestCase
         $this->assertFalse(self::$presentation->isSubmissionClosed());
         $this->assertEquals(24, self::$presentation->getSubmissionReopenedHours());
         $this->assertEquals(self::$member->getId(), self::$presentation->getSubmissionReopenedById());
-        $this->assertStringContainsString(self::$member->getEmail(), self::$presentation->getSubmissionReopenedByNice());
+        $this->assertTrue(self::$presentation->hasSubmissionReopenedBy());
+        $this->assertEquals(self::$member->getEmail(), self::$presentation->getSubmissionReopenedBy()->getEmail());
     }
 
     public function testExpiredGrantIsNotReopened()

--- a/tests/Unit/Models/PresentationSubmissionReopenTest.php
+++ b/tests/Unit/Models/PresentationSubmissionReopenTest.php
@@ -1,0 +1,423 @@
+<?php namespace Tests\Unit\Models;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Models\Foundation\Summit\SelectionPlan;
+use Mockery;
+use models\main\Member;
+use models\summit\Presentation;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class PresentationSubmissionReopenTest
+ *
+ * Pure unit tests for the per-activity CFP reopen predicate and its derived deadline:
+ * {@see Presentation::getSubmissionReopenedUntil}, {@see Presentation::isSubmissionReopened},
+ * {@see Presentation::isSubmissionClosed}, {@see Presentation::reopenSubmission},
+ * {@see Presentation::closeSubmissionNow} and the two Show-Admin display getters.
+ *
+ * No database, no framework boot: the Presentation under test is a real object (so the logic
+ * exercised is the production logic) and only the collaborators it interrogates -- the
+ * SelectionPlan and the actor Member -- are mocks.
+ *
+ * The full state matrix lives here rather than in the integration suite because each case
+ * costs a DB fixture there and nothing here.
+ *
+ * @package Tests\Unit\Models
+ */
+class PresentationSubmissionReopenTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function utc(string $modifier): \DateTime
+    {
+        return new \DateTime($modifier, new \DateTimeZone('UTC'));
+    }
+
+    /**
+     * @param \DateTime|null $submission_end_date null models a plan with no submission end date
+     */
+    private function plan(?\DateTime $submission_end_date, bool $enabled = true): SelectionPlan
+    {
+        $plan = Mockery::mock(SelectionPlan::class);
+        $plan->shouldReceive('IsEnabled')->andReturn($enabled);
+        $plan->shouldReceive('getSubmissionEndDate')->andReturn($submission_end_date);
+        // setSelectionPlan() reads getId() only when replacing an existing plan
+        $plan->shouldReceive('getId')->andReturn(1);
+        return $plan;
+    }
+
+    private function member(int $id = 42, ?string $first = 'Jane', ?string $last = 'Doe', ?string $email = 'jane@example.com'): Member
+    {
+        $member = Mockery::mock(Member::class);
+        $member->shouldReceive('getId')->andReturn($id);
+        $member->shouldReceive('getFullName')->andReturn(trim($first . ' ' . $last));
+        $member->shouldReceive('getEmail')->andReturn($email);
+        return $member;
+    }
+
+    private function presentation(?SelectionPlan $plan = null): Presentation
+    {
+        $presentation = new Presentation();
+        if (!is_null($plan)) $presentation->setSelectionPlan($plan);
+        return $presentation;
+    }
+
+    /**
+     * A plan whose submission window closed an hour ago -- the only shape on which a grant
+     * can ever be honored.
+     */
+    private function endedPlan(bool $enabled = true): SelectionPlan
+    {
+        return $this->plan($this->utc('-1 hour'), $enabled);
+    }
+
+    /**
+     * Stamps a grant of $hours and then backdates the stamp to $stamp, which is the only way
+     * to reach an arbitrary (hours, date) pair through the public API -- reopenSubmission()
+     * always stamps "now" and there is no public setter for hours.
+     */
+    private function grant(Presentation $presentation, int $hours, ?\DateTime $stamp = null): void
+    {
+        $presentation->reopenSubmission($hours, $this->member());
+        if (!is_null($stamp)) $presentation->setSubmissionReopenedDate($stamp);
+    }
+
+    // -------------------------------------------------------------------------
+    // The state matrix
+    // -------------------------------------------------------------------------
+
+    public function testNoGrantAtAllYieldsNoDeadlineAndIsNotReopened(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+
+        $this->assertNull($presentation->getSubmissionReopenedUntil());
+        $this->assertNull($presentation->getSubmissionReopenedDate());
+        $this->assertNull($presentation->getSubmissionReopenedHours());
+        $this->assertFalse($presentation->isSubmissionReopened());
+    }
+
+    public function testLiveGrantOnEndedWindowIsReopened(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        $this->grant($presentation, 24);
+
+        $this->assertTrue($presentation->isSubmissionReopened());
+        $this->assertGreaterThan($this->utc('now'), $presentation->getSubmissionReopenedUntil());
+    }
+
+    public function testExpiredGrantIsNotReopened(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        // stamped 5h ago for 2h => expired 3h ago
+        $this->grant($presentation, 2, $this->utc('-5 hours'));
+
+        $this->assertFalse($presentation->isSubmissionReopened());
+        $this->assertLessThan($this->utc('now'), $presentation->getSubmissionReopenedUntil());
+    }
+
+    public function testGrantWhileWindowStillOpenIsNotReopened(): void
+    {
+        // window closes in an hour: nothing has ended, so there is nothing to reopen
+        $presentation = $this->presentation($this->plan($this->utc('+1 hour')));
+        $this->grant($presentation, 24);
+
+        $this->assertFalse($presentation->isSubmissionReopened());
+        // the deadline itself is still computed -- it is the predicate that refuses
+        $this->assertNotNull($presentation->getSubmissionReopenedUntil());
+    }
+
+    public function testGrantBeforeWindowEverOpensIsNotReopened(): void
+    {
+        // Pre-open and still-open fold into the same guard: isSubmissionReopened() consults
+        // only getSubmissionEndDate(), never the begin date. Kept as its own case because it
+        // is the scenario the guard exists to prevent (edits granted before the CFP opened).
+        $presentation = $this->presentation($this->plan($this->utc('+30 days')));
+        $this->grant($presentation, 24);
+
+        $this->assertFalse($presentation->isSubmissionReopened());
+    }
+
+    public function testGrantOnDisabledPlanIsNotReopened(): void
+    {
+        $presentation = $this->presentation($this->endedPlan(false));
+        $this->grant($presentation, 24);
+
+        $this->assertFalse($presentation->isSubmissionReopened());
+    }
+
+    public function testGrantWithNoSelectionPlanAssignedIsNotReopened(): void
+    {
+        $presentation = $this->presentation();
+        $this->grant($presentation, 24);
+
+        $this->assertNull($presentation->getSelectionPlan());
+        $this->assertFalse($presentation->isSubmissionReopened());
+    }
+
+    public function testGrantOnPlanWithNullSubmissionEndDateIsNotReopened(): void
+    {
+        $presentation = $this->presentation($this->plan(null));
+        $this->grant($presentation, 24);
+
+        $this->assertFalse($presentation->isSubmissionReopened());
+    }
+
+    // -------------------------------------------------------------------------
+    // Half-states: hours and date must both be present or the grant does not exist
+    // -------------------------------------------------------------------------
+
+    public function testHoursSetWithNullDateYieldsNullDeadlineAndFalsePredicate(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        $this->grant($presentation, 24, null);
+        $presentation->setSubmissionReopenedDate(null);
+
+        $this->assertSame(24, $presentation->getSubmissionReopenedHours());
+        $this->assertNull($presentation->getSubmissionReopenedDate());
+        $this->assertNull($presentation->getSubmissionReopenedUntil());
+        $this->assertFalse($presentation->isSubmissionReopened());
+    }
+
+    public function testDateSetWithNullHoursYieldsNullDeadlineAndFalsePredicate(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        $this->grant($presentation, 24);
+        $presentation->closeSubmissionNow();
+        $presentation->setSubmissionReopenedDate($this->utc('now'));
+
+        $this->assertNull($presentation->getSubmissionReopenedHours());
+        $this->assertNotNull($presentation->getSubmissionReopenedDate());
+        $this->assertNull($presentation->getSubmissionReopenedUntil());
+        $this->assertFalse($presentation->isSubmissionReopened());
+    }
+
+    // -------------------------------------------------------------------------
+    // Deadline arithmetic and boundaries
+    // -------------------------------------------------------------------------
+
+    public function testDeadlineIsExactlyStampPlusGrantedHours(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        $this->grant($presentation, 24, new \DateTime('2026-01-01 10:00:00', new \DateTimeZone('UTC')));
+
+        $this->assertEquals(
+            new \DateTime('2026-01-02 10:00:00', new \DateTimeZone('UTC')),
+            $presentation->getSubmissionReopenedUntil()
+        );
+    }
+
+    public function testDeadlineArithmeticCrossesDstAndMonthBoundariesInUtc(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        // 168h == the shipped ceiling; stamped so the window crosses a month end
+        $this->grant($presentation, 168, new \DateTime('2026-01-28 23:30:00', new \DateTimeZone('UTC')));
+
+        $this->assertEquals(
+            new \DateTime('2026-02-04 23:30:00', new \DateTimeZone('UTC')),
+            $presentation->getSubmissionReopenedUntil()
+        );
+    }
+
+    public function testGetSubmissionReopenedUntilDoesNotMutateTheStoredStamp(): void
+    {
+        $stamp = new \DateTime('2026-03-10 08:00:00', new \DateTimeZone('UTC'));
+        $presentation = $this->presentation($this->endedPlan());
+        $this->grant($presentation, 6, $stamp);
+
+        $first = $presentation->getSubmissionReopenedUntil();
+        $second = $presentation->getSubmissionReopenedUntil();
+
+        // idempotent: it clones on purpose, so repeated reads agree
+        $this->assertEquals($first, $second);
+        // and the stamp itself is untouched, both as stored and as the caller's own object
+        $this->assertEquals(
+            new \DateTime('2026-03-10 08:00:00', new \DateTimeZone('UTC')),
+            $presentation->getSubmissionReopenedDate()
+        );
+        $this->assertEquals(new \DateTime('2026-03-10 08:00:00', new \DateTimeZone('UTC')), $stamp);
+    }
+
+    public function testGrantExpiringExactlyNowIsNotReopened(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        // stamped exactly one hour ago for one hour => until == the instant of setup, which is
+        // strictly before the clock isSubmissionReopened() reads. Pins the `now < until` bound.
+        $this->grant($presentation, 1, $this->utc('-1 hour'));
+
+        $this->assertFalse($presentation->isSubmissionReopened());
+    }
+
+    public function testGrantOneMinuteBeforeExpiryIsStillReopened(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        $this->grant($presentation, 1, $this->utc('-59 minutes'));
+
+        $this->assertTrue($presentation->isSubmissionReopened());
+    }
+
+    // -------------------------------------------------------------------------
+    // Mutators
+    // -------------------------------------------------------------------------
+
+    public function testReopenSubmissionRestampsRatherThanAccumulating(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+
+        $presentation->reopenSubmission(2, $this->member());
+        $presentation->setSubmissionReopenedDate($this->utc('-30 minutes'));
+        $first_until = $presentation->getSubmissionReopenedUntil();
+
+        $second_actor = $this->member(99, 'Ada', 'Lovelace', 'ada@example.com');
+        $presentation->reopenSubmission(5, $second_actor);
+
+        // hours replaced, not summed
+        $this->assertSame(5, $presentation->getSubmissionReopenedHours());
+        // stamp re-taken, so the deadline moved rather than extending from the old stamp
+        $this->assertGreaterThan($first_until, $presentation->getSubmissionReopenedUntil());
+        $this->assertEquals(
+            (clone $presentation->getSubmissionReopenedDate())->add(new \DateInterval('PT5H')),
+            $presentation->getSubmissionReopenedUntil()
+        );
+        $this->assertSame(99, $presentation->getSubmissionReopenedById());
+    }
+
+    public function testCloseSubmissionNowClearsAllThreeColumnsOnAnEnabledPlan(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        $this->grant($presentation, 24);
+        $this->assertTrue($presentation->isSubmissionReopened());
+
+        $presentation->closeSubmissionNow();
+
+        $this->assertNull($presentation->getSubmissionReopenedHours());
+        $this->assertNull($presentation->getSubmissionReopenedDate());
+        $this->assertNull($presentation->getSubmissionReopenedBy());
+        $this->assertNull($presentation->getSubmissionReopenedUntil());
+        $this->assertFalse($presentation->isSubmissionReopened());
+    }
+
+    public function testCloseSubmissionNowClearsTheGrantOnADisabledPlan(): void
+    {
+        $presentation = $this->presentation($this->endedPlan(false));
+        $this->grant($presentation, 24);
+
+        $presentation->closeSubmissionNow();
+
+        $this->assertNull($presentation->getSubmissionReopenedHours());
+        $this->assertNull($presentation->getSubmissionReopenedDate());
+        $this->assertNull($presentation->getSubmissionReopenedBy());
+    }
+
+    public function testCloseSubmissionNowClearsTheGrantWithNoSelectionPlan(): void
+    {
+        $presentation = $this->presentation();
+        $this->grant($presentation, 24);
+
+        $presentation->closeSubmissionNow();
+
+        $this->assertNull($presentation->getSubmissionReopenedHours());
+        $this->assertNull($presentation->getSubmissionReopenedDate());
+        $this->assertNull($presentation->getSubmissionReopenedBy());
+    }
+
+    // -------------------------------------------------------------------------
+    // Show Admin display getters
+    // -------------------------------------------------------------------------
+
+    public function testGetSubmissionReopenedByIdReturnsZeroWithoutAnActor(): void
+    {
+        $this->assertSame(0, $this->presentation()->getSubmissionReopenedById());
+    }
+
+    public function testGetSubmissionReopenedByIdReturnsTheActorId(): void
+    {
+        $presentation = $this->presentation();
+        $presentation->reopenSubmission(24, $this->member(7));
+
+        $this->assertSame(7, $presentation->getSubmissionReopenedById());
+    }
+
+    public function testGetSubmissionReopenedByNiceReturnsNullWithoutAnActor(): void
+    {
+        $this->assertNull($this->presentation()->getSubmissionReopenedByNice());
+    }
+
+    public function testGetSubmissionReopenedByNiceFormatsFullNameAndEmail(): void
+    {
+        $presentation = $this->presentation();
+        $presentation->reopenSubmission(24, $this->member(7, 'Ada', 'Lovelace', 'ada@example.com'));
+
+        $this->assertSame('Ada Lovelace (ada@example.com)', $presentation->getSubmissionReopenedByNice());
+    }
+
+    // -------------------------------------------------------------------------
+    // The isSubmissionClosed() fold, both directions
+    // -------------------------------------------------------------------------
+
+    public function testIsSubmissionClosedIsFalseWhileReopened(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        $this->grant($presentation, 24);
+
+        $this->assertTrue($presentation->isSubmissionReopened());
+        $this->assertFalse($presentation->isSubmissionClosed());
+    }
+
+    public function testIsSubmissionClosedIsTrueWhenMerelyClosed(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+
+        $this->assertFalse($presentation->isSubmissionReopened());
+        $this->assertTrue($presentation->isSubmissionClosed());
+    }
+
+    public function testIsSubmissionClosedIsTrueOnceTheGrantExpires(): void
+    {
+        $presentation = $this->presentation($this->endedPlan());
+        $this->grant($presentation, 2, $this->utc('-5 hours'));
+
+        $this->assertTrue($presentation->isSubmissionClosed());
+    }
+
+    public function testIsSubmissionClosedIsFalseWithNoSelectionPlan(): void
+    {
+        $this->assertFalse($this->presentation()->isSubmissionClosed());
+    }
+
+    public function testIsSubmissionClosedIsFalseWhileTheWindowIsStillOpen(): void
+    {
+        $presentation = $this->presentation($this->plan($this->utc('+1 hour')));
+
+        $this->assertFalse($presentation->isSubmissionClosed());
+    }
+
+    public function testIsSubmissionClosedIsTrueOnADisabledPlanWithAnEndedWindow(): void
+    {
+        // a grant does NOT rescue a disabled plan: isSubmissionReopened() refuses, so the fold
+        // falls through to the plain closed check, which does not consult IsEnabled()
+        $presentation = $this->presentation($this->endedPlan(false));
+        $this->grant($presentation, 24);
+
+        $this->assertFalse($presentation->isSubmissionReopened());
+        $this->assertTrue($presentation->isSubmissionClosed());
+    }
+}

--- a/tests/Unit/Models/PresentationSubmissionReopenTest.php
+++ b/tests/Unit/Models/PresentationSubmissionReopenTest.php
@@ -340,7 +340,7 @@ class PresentationSubmissionReopenTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
-    // Show Admin display getters
+    // Actor accessors, resolved through One2ManyPropertyTrait::__call
     // -------------------------------------------------------------------------
 
     public function testGetSubmissionReopenedByIdReturnsZeroWithoutAnActor(): void
@@ -356,17 +356,29 @@ class PresentationSubmissionReopenTest extends TestCase
         $this->assertSame(7, $presentation->getSubmissionReopenedById());
     }
 
-    public function testGetSubmissionReopenedByNiceReturnsNullWithoutAnActor(): void
+    public function testHasSubmissionReopenedByTracksTheActor(): void
     {
-        $this->assertNull($this->presentation()->getSubmissionReopenedByNice());
+        $this->assertFalse($this->presentation()->hasSubmissionReopenedBy());
+
+        $presentation = $this->presentation();
+        $presentation->reopenSubmission(24, $this->member(7));
+
+        $this->assertTrue($presentation->hasSubmissionReopenedBy());
     }
 
-    public function testGetSubmissionReopenedByNiceFormatsFullNameAndEmail(): void
+    /**
+     * The trait resolves these through __call, which returns null for an unmapped name rather
+     * than raising -- so a typo in $getIdMappings degrades silently. This pins the inherited
+     * pair, which Presentation's own $getIdMappings would otherwise shadow away.
+     */
+    public function testInheritedCreatedByAccessorsStillResolve(): void
     {
         $presentation = $this->presentation();
-        $presentation->reopenSubmission(24, $this->member(7, 'Ada', 'Lovelace', 'ada@example.com'));
 
-        $this->assertSame('Ada Lovelace (ada@example.com)', $presentation->getSubmissionReopenedByNice());
+        $this->assertSame(0, $presentation->getCreatedById());
+        $this->assertSame(0, $presentation->getUpdatedById());
+        $this->assertFalse($presentation->hasCreatedBy());
+        $this->assertFalse($presentation->hasUpdatedBy());
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Unit/Services/PresentationSubmissionReopenServiceTest.php
+++ b/tests/Unit/Services/PresentationSubmissionReopenServiceTest.php
@@ -203,6 +203,26 @@ class PresentationSubmissionReopenServiceTest extends TestCase
         $this->assertClosureRan();
     }
 
+    /**
+     * A deployment that sets default_reopen_hours above max_reopen_hours would otherwise reject
+     * every request that omits hours, which is a config error the caller can neither see nor fix.
+     * The resolved default is clamped to the ceiling; an explicit out-of-range hours is still
+     * refused (see testReopenAboveTheConfiguredMaxThrowsValidation).
+     */
+    public function testMisconfiguredDefaultAboveMaxIsClampedRatherThanRefused(): void
+    {
+        $this->config->set('cfp.default_reopen_hours', 500);
+        $this->config->set('cfp.max_reopen_hours', 48);
+
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+
+        $result = $service->reopen($this->summit($presentation), 1234, null, $this->member());
+
+        $this->assertSame(48, $result->getSubmissionReopenedHours());
+        $this->assertClosureRan();
+    }
+
     public function testReopenAboveTheConfiguredMaxThrowsValidation(): void
     {
         $service = $this->makeService();

--- a/tests/Unit/Services/PresentationSubmissionReopenServiceTest.php
+++ b/tests/Unit/Services/PresentationSubmissionReopenServiceTest.php
@@ -26,6 +26,7 @@ use models\summit\Summit;
 use models\summit\SummitEvent;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Log\LoggerInterface;
 use services\model\PresentationSubmissionReopenService;
 
 /**
@@ -58,6 +59,11 @@ class PresentationSubmissionReopenServiceTest extends TestCase
     private Repository $config;
 
     /**
+     * Spy bound as the Log facade root; see setUp().
+     */
+    private $log;
+
+    /**
      * Number of times the mocked transaction closure actually executed.
      */
     private int $tx_invocations = 0;
@@ -74,6 +80,12 @@ class PresentationSubmissionReopenServiceTest extends TestCase
             ],
         ]);
         $this->app->instance('config', $this->config);
+
+        // closeNow() logs the revocation before clearing the grant, so 'log' has to be bound or
+        // the Log facade has no root. The spy doubles as the assertion surface for that line.
+        $this->log = Mockery::spy(LoggerInterface::class);
+        $this->app->instance('log', $this->log);
+
         Container::setInstance($this->app);
         Facade::setFacadeApplication($this->app);
         $this->tx_invocations = 0;
@@ -145,6 +157,7 @@ class PresentationSubmissionReopenServiceTest extends TestCase
     {
         $summit = Mockery::mock(Summit::class);
         $summit->shouldReceive('getEvent')->with(1234)->andReturn($event);
+        $summit->shouldReceive('getId')->andReturn(99);
         return $summit;
     }
 
@@ -404,6 +417,28 @@ class PresentationSubmissionReopenServiceTest extends TestCase
         $this->assertNull($presentation->getSubmissionReopenedHours());
         $this->assertNull($presentation->getSubmissionReopenedDate());
         $this->assertNull($presentation->getSubmissionReopenedBy());
+        $this->assertClosureRan();
+    }
+
+    /**
+     * The revoking actor is only observable through this log line, since closeSubmissionNow()
+     * nulls the actor column. It is also the only thing that catches $actor being dropped from
+     * the transaction closure's use list, which is how it was inert to begin with.
+     */
+    public function testCloseNowLogsTheRevocationWithBothActors(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+        $presentation->reopenSubmission(24, $this->member(7));
+
+        $service->closeNow($this->summit($presentation), 1234, $this->member(11));
+
+        $this->log->shouldHaveReceived('info')->once()->withArgs(function (string $message) {
+            return str_contains($message, 'summit 99')
+                && str_contains($message, 'presentation 1234')
+                && str_contains($message, 'revoked by member 11')
+                && str_contains($message, 'granted by member 7');
+        });
         $this->assertClosureRan();
     }
 

--- a/tests/Unit/Services/PresentationSubmissionReopenServiceTest.php
+++ b/tests/Unit/Services/PresentationSubmissionReopenServiceTest.php
@@ -1,0 +1,482 @@
+<?php namespace Tests\Unit\Services;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Models\Foundation\Summit\SelectionPlan;
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use libs\utils\ITransactionService;
+use Mockery;
+use models\exceptions\EntityNotFoundException;
+use models\exceptions\ValidationException;
+use models\main\Member;
+use models\summit\Presentation;
+use models\summit\Summit;
+use models\summit\SummitEvent;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use services\model\PresentationSubmissionReopenService;
+
+/**
+ * Class PresentationSubmissionReopenServiceTest
+ *
+ * Unit tests for every validation branch of {@see PresentationSubmissionReopenService::reopen}
+ * and {@see PresentationSubmissionReopenService::closeNow}.
+ *
+ * Two collaborators have to be stood up for this to be a real unit test:
+ *
+ *  - the Config facade (the service resolves cfp.default_reopen_hours / cfp.max_reopen_hours).
+ *    A bare Illuminate container with a real Config\Repository bound to 'config' is wired as
+ *    the facade root, mirroring CompanyFileProcessingTest -- no Laravel app, no .env, and the
+ *    configured values are set per test so the guards are proven to read config rather than
+ *    their hardcoded fallbacks.
+ *  - ITransactionService, mocked so it actually invokes the closure and returns its value.
+ *    Every test asserts the callback ran exactly once; a mock that swallowed the closure would
+ *    make all of these pass vacuously.
+ *
+ * The hours < 1 branch is unreachable over HTTP -- the endpoint validates
+ * 'hours' => 'sometimes|integer|min:1' and refuses first -- so this file is the only coverage
+ * it will ever have.
+ *
+ * @package Tests\Unit\Services
+ */
+class PresentationSubmissionReopenServiceTest extends TestCase
+{
+    private Container $app;
+
+    private Repository $config;
+
+    /**
+     * Number of times the mocked transaction closure actually executed.
+     */
+    private int $tx_invocations = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Facade::clearResolvedInstances();
+        $this->app = new Container();
+        $this->config = new Repository([
+            'cfp' => [
+                'max_reopen_hours' => 48,
+                'default_reopen_hours' => 5,
+            ],
+        ]);
+        $this->app->instance('config', $this->config);
+        Container::setInstance($this->app);
+        Facade::setFacadeApplication($this->app);
+        $this->tx_invocations = 0;
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::setFacadeApplication(null);
+        Facade::clearResolvedInstances();
+        Container::setInstance(null);
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function utc(string $modifier): \DateTime
+    {
+        return new \DateTime($modifier, new \DateTimeZone('UTC'));
+    }
+
+    /**
+     * Transaction service that really runs the closure, so the code under test executes.
+     */
+    private function makeService(): PresentationSubmissionReopenService
+    {
+        $tx_service = Mockery::mock(ITransactionService::class);
+        $tx_service->shouldReceive('transaction')
+            ->once()
+            ->andReturnUsing(function (\Closure $callback) {
+                $this->tx_invocations++;
+                return $callback();
+            });
+
+        return new PresentationSubmissionReopenService($tx_service);
+    }
+
+    private function plan(?\DateTime $submission_end_date, bool $enabled = true): SelectionPlan
+    {
+        $plan = Mockery::mock(SelectionPlan::class);
+        $plan->shouldReceive('IsEnabled')->andReturn($enabled);
+        $plan->shouldReceive('getSubmissionEndDate')->andReturn($submission_end_date);
+        $plan->shouldReceive('getId')->andReturn(1);
+        return $plan;
+    }
+
+    private function member(int $id = 42): Member
+    {
+        $member = Mockery::mock(Member::class);
+        $member->shouldReceive('getId')->andReturn($id);
+        $member->shouldReceive('getFullName')->andReturn('Jane Doe');
+        $member->shouldReceive('getEmail')->andReturn('jane@example.com');
+        return $member;
+    }
+
+    private function presentation(?SelectionPlan $plan = null): Presentation
+    {
+        $presentation = new Presentation();
+        if (!is_null($plan)) $presentation->setSelectionPlan($plan);
+        return $presentation;
+    }
+
+    /**
+     * @param Presentation|SummitEvent|null $event what getEvent() hands back
+     */
+    private function summit($event): Summit
+    {
+        $summit = Mockery::mock(Summit::class);
+        $summit->shouldReceive('getEvent')->with(1234)->andReturn($event);
+        return $summit;
+    }
+
+    private function assertClosureRan(): void
+    {
+        $this->assertSame(1, $this->tx_invocations, 'the transaction closure never executed');
+    }
+
+    // -------------------------------------------------------------------------
+    // reopen(): entity resolution
+    // -------------------------------------------------------------------------
+
+    public function testReopenThrowsEntityNotFoundWhenTheEventDoesNotExistInTheSummit(): void
+    {
+        $service = $this->makeService();
+
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage('Presentation 1234 not found.');
+
+        try {
+            $service->reopen($this->summit(null), 1234, 24, $this->member());
+        } finally {
+            $this->assertClosureRan();
+        }
+    }
+
+    public function testReopenThrowsEntityNotFoundWhenTheEventIsNotAPresentation(): void
+    {
+        $service = $this->makeService();
+        $event = Mockery::mock(SummitEvent::class);
+
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage('Presentation 1234 not found.');
+
+        try {
+            $service->reopen($this->summit($event), 1234, 24, $this->member());
+        } finally {
+            $this->assertClosureRan();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // reopen(): the hours guard
+    // -------------------------------------------------------------------------
+
+    public function testReopenWithNullHoursResolvesTheConfiguredDefaultAndStampsIt(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+        $actor = $this->member();
+
+        $result = $service->reopen($this->summit($presentation), 1234, null, $actor);
+
+        // 5, not the hardcoded 24 fallback -- proof the default comes from config
+        $this->assertSame(5, $result->getSubmissionReopenedHours());
+        $this->assertClosureRan();
+    }
+
+    public function testReopenAboveTheConfiguredMaxThrowsValidation(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+
+        $this->expectException(ValidationException::class);
+        // 48 is the configured ceiling, not the hardcoded 168 fallback
+        $this->expectExceptionMessage('hours must be between 1 and 48.');
+
+        try {
+            $service->reopen($this->summit($presentation), 1234, 49, $this->member());
+        } finally {
+            $this->assertClosureRan();
+            // nothing stamped
+            $this->assertNull($presentation->getSubmissionReopenedHours());
+            $this->assertNull($presentation->getSubmissionReopenedDate());
+        }
+    }
+
+    public function testReopenAtExactlyTheConfiguredMaxIsAccepted(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+
+        $result = $service->reopen($this->summit($presentation), 1234, 48, $this->member());
+
+        $this->assertSame(48, $result->getSubmissionReopenedHours());
+        $this->assertClosureRan();
+    }
+
+    /**
+     * The lower bound. Unreachable over HTTP (the endpoint validates min:1 first), so these are
+     * the only assertions that will ever cover it.
+     */
+    #[DataProvider('belowMinimumHoursProvider')]
+    public function testReopenBelowOneHourThrowsValidation(int $hours): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('hours must be between 1 and 48.');
+
+        try {
+            $service->reopen($this->summit($presentation), 1234, $hours, $this->member());
+        } finally {
+            $this->assertClosureRan();
+            $this->assertNull($presentation->getSubmissionReopenedHours());
+        }
+    }
+
+    public static function belowMinimumHoursProvider(): array
+    {
+        return [
+            'zero' => [0],
+            'negative' => [-1],
+            // a negative interval would make getSubmissionReopenedUntil() throw on every read
+            'large negative' => [-168],
+        ];
+    }
+
+    public function testReopenAtExactlyOneHourIsAccepted(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+
+        $result = $service->reopen($this->summit($presentation), 1234, 1, $this->member());
+
+        $this->assertSame(1, $result->getSubmissionReopenedHours());
+        $this->assertClosureRan();
+    }
+
+    // -------------------------------------------------------------------------
+    // reopen(): plan-state guards
+    // -------------------------------------------------------------------------
+
+    public function testReopenWithNoSelectionPlanAssignedThrowsValidation(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Presentation is not assigned to any selection plan.');
+
+        try {
+            $service->reopen($this->summit($presentation), 1234, 24, $this->member());
+        } finally {
+            $this->assertClosureRan();
+            $this->assertNull($presentation->getSubmissionReopenedHours());
+        }
+    }
+
+    public function testReopenOnADisabledPlanThrowsValidation(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour'), false));
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Selection plan is not enabled.');
+
+        try {
+            $service->reopen($this->summit($presentation), 1234, 24, $this->member());
+        } finally {
+            $this->assertClosureRan();
+            $this->assertNull($presentation->getSubmissionReopenedHours());
+        }
+    }
+
+    public function testReopenOnAPlanWithNoSubmissionEndDateThrowsValidation(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan(null));
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Selection plan has no submission end date.');
+
+        try {
+            $service->reopen($this->summit($presentation), 1234, 24, $this->member());
+        } finally {
+            $this->assertClosureRan();
+            $this->assertNull($presentation->getSubmissionReopenedHours());
+        }
+    }
+
+    public function testReopenWhenTheSubmissionWindowHasNotEndedThrowsValidation(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('+1 hour')));
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Submission period has not ended yet; nothing to reopen.');
+
+        try {
+            $service->reopen($this->summit($presentation), 1234, 24, $this->member());
+        } finally {
+            $this->assertClosureRan();
+            $this->assertNull($presentation->getSubmissionReopenedHours());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // reopen(): happy path
+    // -------------------------------------------------------------------------
+
+    public function testReopenStampsHoursDateAndActorAndReturnsThePresentation(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+        $actor = $this->member(77);
+        $before = $this->utc('now');
+
+        $result = $service->reopen($this->summit($presentation), 1234, 12, $actor);
+
+        $this->assertSame($presentation, $result);
+        $this->assertSame(12, $result->getSubmissionReopenedHours());
+        $this->assertSame($actor, $result->getSubmissionReopenedBy());
+        $this->assertSame(77, $result->getSubmissionReopenedById());
+        $this->assertGreaterThanOrEqual($before, $result->getSubmissionReopenedDate());
+        $this->assertEquals(
+            (clone $result->getSubmissionReopenedDate())->add(new \DateInterval('PT12H')),
+            $result->getSubmissionReopenedUntil()
+        );
+        $this->assertTrue($result->isSubmissionReopened());
+        $this->assertClosureRan();
+    }
+
+    // -------------------------------------------------------------------------
+    // closeNow(): clears the grant, and deliberately applies no plan-state validation
+    // -------------------------------------------------------------------------
+
+    public function testCloseNowClearsTheGrant(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+        $presentation->reopenSubmission(24, $this->member());
+
+        $service->closeNow($this->summit($presentation), 1234, $this->member());
+
+        $this->assertNull($presentation->getSubmissionReopenedHours());
+        $this->assertNull($presentation->getSubmissionReopenedDate());
+        $this->assertNull($presentation->getSubmissionReopenedBy());
+        $this->assertClosureRan();
+    }
+
+    public function testCloseNowSucceedsOnADisabledPlan(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour'), false));
+        $presentation->reopenSubmission(24, $this->member());
+
+        $service->closeNow($this->summit($presentation), 1234, $this->member());
+
+        $this->assertNull($presentation->getSubmissionReopenedHours());
+        $this->assertClosureRan();
+    }
+
+    public function testCloseNowSucceedsWithNoSelectionPlanAssigned(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation();
+        $presentation->reopenSubmission(24, $this->member());
+
+        $service->closeNow($this->summit($presentation), 1234, $this->member());
+
+        $this->assertNull($presentation->getSubmissionReopenedHours());
+        $this->assertClosureRan();
+    }
+
+    public function testCloseNowSucceedsWhileTheSubmissionWindowIsStillOpen(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('+1 hour')));
+        $presentation->reopenSubmission(24, $this->member());
+
+        $service->closeNow($this->summit($presentation), 1234, $this->member());
+
+        $this->assertNull($presentation->getSubmissionReopenedHours());
+        $this->assertClosureRan();
+    }
+
+    public function testCloseNowIsIdempotentWhenThereIsNoGrant(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+
+        $service->closeNow($this->summit($presentation), 1234, $this->member());
+
+        $this->assertNull($presentation->getSubmissionReopenedHours());
+        $this->assertClosureRan();
+    }
+
+    public function testCloseNowThrowsEntityNotFoundWhenTheEventDoesNotExistInTheSummit(): void
+    {
+        $service = $this->makeService();
+
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage('Presentation 1234 not found.');
+
+        try {
+            $service->closeNow($this->summit(null), 1234, $this->member());
+        } finally {
+            $this->assertClosureRan();
+        }
+    }
+
+    public function testCloseNowThrowsEntityNotFoundWhenTheEventIsNotAPresentation(): void
+    {
+        $service = $this->makeService();
+        $event = Mockery::mock(SummitEvent::class);
+
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage('Presentation 1234 not found.');
+
+        try {
+            $service->closeNow($this->summit($event), 1234, $this->member());
+        } finally {
+            $this->assertClosureRan();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Guard on the harness itself
+    // -------------------------------------------------------------------------
+
+    public function testTheMockedTransactionServiceReallyExecutesTheClosure(): void
+    {
+        // Without this, a transaction mock that returned a canned value would let every test
+        // above pass without running a single line of the service.
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+
+        $this->assertSame(0, $this->tx_invocations);
+        $service->reopen($this->summit($presentation), 1234, 3, $this->member());
+        $this->assertSame(1, $this->tx_invocations);
+        $this->assertSame(3, $presentation->getSubmissionReopenedHours());
+    }
+}

--- a/tests/Unit/Services/PresentationSubmissionReopenServiceTest.php
+++ b/tests/Unit/Services/PresentationSubmissionReopenServiceTest.php
@@ -422,8 +422,7 @@ class PresentationSubmissionReopenServiceTest extends TestCase
 
     /**
      * The revoking actor is only observable through this log line, since closeSubmissionNow()
-     * nulls the actor column. It is also the only thing that catches $actor being dropped from
-     * the transaction closure's use list, which is how it was inert to begin with.
+     * nulls the actor column.
      */
     public function testCloseNowLogsTheRevocationWithBothActors(): void
     {
@@ -440,6 +439,44 @@ class PresentationSubmissionReopenServiceTest extends TestCase
                 && str_contains($message, 'granted by member 7');
         });
         $this->assertClosureRan();
+    }
+
+    /**
+     * getSubmissionReopenedById() returns 0 rather than null for an absent relation, and closing
+     * with nothing granted is a supported no-op, so the audit line must not name "member 0".
+     */
+    public function testCloseNowWithNoGrantLogsNoActiveGrantRatherThanMemberZero(): void
+    {
+        $service = $this->makeService();
+        $presentation = $this->presentation($this->plan($this->utc('-1 hour')));
+
+        $service->closeNow($this->summit($presentation), 1234, $this->member(11));
+
+        $this->log->shouldHaveReceived('info')->once()->withArgs(function (string $message) {
+            return str_contains($message, 'granted by no active grant')
+                && !str_contains($message, 'member 0')
+                && str_contains($message, 'ran until n/a');
+        });
+        $this->assertClosureRan();
+    }
+
+    /**
+     * The line claims a completed revocation, so it must not be emitted for a transaction that
+     * threw: flush and commit run after the closure, and a retryable failure re-runs it.
+     */
+    public function testCloseNowDoesNotLogWhenTheTransactionFails(): void
+    {
+        $tx_service = Mockery::mock(ITransactionService::class);
+        $tx_service->shouldReceive('transaction')->once()->andThrow(new \RuntimeException('deadlock'));
+        $service = new PresentationSubmissionReopenService($tx_service);
+
+        $this->expectException(\RuntimeException::class);
+
+        try {
+            $service->closeNow($this->summit($this->presentation()), 1234, $this->member(11));
+        } finally {
+            $this->log->shouldNotHaveReceived('info');
+        }
     }
 
     public function testCloseNowSucceedsOnADisabledPlan(): void


### PR DESCRIPTION
ref: https://app.clickup.com/t/86bba82ch

Spec: `sds/per-activity-cfp-reopen.md` in the ftn-docsnsklz vault, on `main` (merged `bd2c2c3`), sections 3, 4 and 7.

## What this does

A summit admin can reopen CFP submission for a single presentation for a chosen window (default 24h, ceiling 168h), so the speaker can edit that one talk through the existing submission flow after the selection plan's window has closed. Expiry is passive: no cron, no cleanup job.

This is step 1 of 3. The call-for-presentations and summit-admin work are ClickUp `86bba82ph` and `86bba82y3`. Until step 2 ships, nothing a speaker can see changes.

## How it works

Three nullable columns on `Presentation` store the grant: raw hours, stamp date, granting member. **The deadline is derived on read and never stored**, so the granted duration and the window end cannot drift out of lockstep.

A new `isSubmissionReopened()` predicate gates on that derived deadline plus plan invariants (assigned plan, enabled, submission window already ended). It is folded into `isSubmissionClosed()` as an early return, which covers both delete guards with no change at either call site, and it is OR'd into the two `isSubmissionOpen()` checks on update and complete. Two admin-only endpoints stamp and clear the grant.

The plan invariants are not optional. A deadline-only check would grant edits before the CFP ever opened, and via the `isSubmissionClosed()` fold it would open speaker deletes on a plan disabled after the grant, because the delete path never re-checks `IsEnabled()` itself.

## Notes for reviewers

Seven things in this diff look like defects but are deliberate. Each cost a review round to establish, so they are recorded here rather than rediscovered.

1. **Both routes carry `auth.user`, and both endpoint registrations carry authz groups**: `SuperAdmins`, `Administrators`, `SummitAdministrators`, mirroring `update-event` minus the track chair roles. The middleware is a coarse global group check and the summit scoped admin check still runs in the controller. It narrows nothing, because `Member::hasPermissionForOnGroup()` already ends in `&& isOnGroup($slug)`, so every caller that passes the controller check passes the middleware; a client credentials token with no member passes the middleware and is still refused by the controller. The groups are what make the middleware usable at all: `UserAuthEndpoint::handle()` returns 403 when an endpoint's required group list is empty.

2. **Serialization uses `SerializerType_Private`, not `_Admin`.** Presentation has no `Admin` key, and an unknown type silently falls back to Public, which would strip every field these endpoints exist to set.

3. **Scopes are the OR trio `WriteSummitData`, `WriteEventData`, `WritePresentationData`.** Validation is any of, so the trio admits existing Show Admin tokens. Narrowing to `WritePresentationData` alone would 403 every current caller.

4. **`submission_reopened_by` is an expandable relation, declared on `AdminPresentationSerializer` rather than on the base.** The payload carries `submission_reopened_by_id`, and `?expand=submission_reopened_by` replaces it with the serialized member. The mapping is deliberately subclass local: `AbstractSerializer::getExpandsMappings()` merges lineage parent to child only, and `SubmissionPresentationSerializer` is a sibling of `AdminPresentationSerializer`, so the relation is unreachable from the Submission and Public variants. A case in the base expand switch would not be, which is the leak the Admin-only design prevents and the reason the SDS rejected id plus expand when a base class switch was the only mechanism considered. The expand serializes the member as Private, matching how `created_by` is already serialized on this class. Show Admin therefore asks for the expand; that ticket is not yet started, so nothing downstream changes.

5. **The two speaker presentation-list endpoints previously serialized Public and now serialize Submission**, which also selects Admin serializers for the nested `created_by`, `updated_by`, `moderator` and `speakers` relations. This grants no new access: `getPresentationSubmission` already serializes the same fields for the same audience, gated by the same `memberCanEdit` check (creator, moderator, or assigned speaker). The switch itself is what the SDS mandates, since `PagingResponse::toArray()` defaults to Public and the CFP portal table would otherwise never receive the new field.

6. **The service's `$hours < 1` check is unreachable over HTTP**, because the endpoint validates `sometimes|integer|min:1` and refuses first. It is kept deliberately: it is the only guard for a non HTTP caller, and a persisted non positive value would make `getSubmissionReopenedUntil()` throw on every read, since `new \DateInterval('PT-1H')` is invalid.

7. **A misconfigured default is clamped, while an explicit out of range value is refused.** If `default_reopen_hours` is configured above `max_reopen_hours`, the resolved default is clamped down to the ceiling rather than rejected. An explicitly supplied `hours` above the ceiling still gets a 412. The asymmetry is deliberate: a configuration error the caller can neither see nor fix should not surface to an admin as an unexplainable refusal of a request that supplied nothing, whereas a caller who names an out of range value should be told. Covered by `testMisconfiguredDefaultAboveMaxIsClampedRatherThanRefused`.

Two further points on the design:

- **The model schema change is split across two migrations, mirroring `Version2026061500000{0,1}`.** Within one migration every `addSql()` statement runs before the `Builder` schema diff, so a single migration doing both would execute the foreign key against a column that did not exist yet. `Version20260807120000` carries the three nullable columns and the index, entirely through `Builder`. `Version20260807120001` carries the foreign key as its single `addSql()` statement and only reads the schema, so it emits no diff and the hazard cannot reappear. Both guard per component, so an interrupted run repairs on retry. Confirmed against a scratch database: the resulting schema has one index named `SubmissionReopenedByID` and unchanged column types.
- **Both the seeder entry and the config migration are needed and are not redundant.** The deploy flow does not re-run seeders, and an unregistered route returns 400 before the controller runs.

## Deploy notes

1. **The foreign key addition copies the table.** On MySQL 8.0 an in place foreign key addition requires `foreign_key_checks` to be disabled; otherwise it rebuilds. `Presentation` is a large production table, so run this migration in a low traffic window and monitor lock time. The three nullable columns are combined into a single `ALTER`, and the explicit index on the FK column is the index MySQL would create anyway.

2. **A model migration that fails partway is safe to re-run.** The DDL statements commit separately, so a failure at the index or foreign key step leaves the added columns in place with the migration unrecorded. Both model migrations guard each component on itself rather than on the column, so a retry adds only what is missing instead of failing on duplicate schema objects.

3. **Migrations use `--em=config` and `--em=model_write`.** There is no `model` entity manager; `--em=model` silently finds zero migrations and reports "already at latest".

4. **Safe rollback is application only.** The columns are additive and inert when null. Rolling the schema back destroys live grants and the actor and date audit trail, so prefer rolling back the application. If a schema rollback is unavoidable, confirm all serving instances run the old application first.

5. **Two new optional config values, and no `.env` change is required to deploy.** `CFP_MAX_REOPEN_HOURS` (ceiling on an admin granted window, default 168, seven days) and `CFP_DEFAULT_REOPEN_HOURS` (window used when the caller sends no `hours`, default 24). Both are documented in `.env.example`, and both defaults live in `config/cfp.php`, so an environment that sets neither behaves as specified. Set them per environment only if a show needs a different ceiling. A `CFP_DEFAULT_REOPEN_HOURS` configured above the ceiling is clamped down rather than rejected, per reviewer note 7 above, so a typo there raises no error anywhere.

    On k8s specifically: neither key has to be added to the configmap for this to deploy, because the fallbacks in `config/cfp.php` are the intended values. They only need adding where an environment wants a non-default ceiling or default. If they are added, they have to be present in the pod environment **before the container's entrypoint runs `php artisan config:cache`**, which `fn-docker/summit-api/php-entry-point.sh` does on every start: `config/cfp.php` resolves `env()` at cache build time, so a value injected into the pod after that point is baked out and reads back as the default.

6. **Run both migrations with or before the application deploy.** The entity maps the three new columns, which only `Version20260807120000` and `Version20260807120001` (`--em=model_write`) create, and the routes read their authz groups from the config database, which only `Version20260807130000` (`--em=config`) populates. Application code live ahead of either one fails: presentation reads hit missing columns, and the reopen routes answer 400 for an unregistered endpoint.

## Endpoint registration evidence

Against the config database, before the migration:

```sql
SELECT name FROM api_endpoints WHERE name LIKE '%presentation-submission-period%';
-- 0 rows
```

After `php artisan doctrine:migrations:migrate --em=config`:

```
reopen-presentation-submission-period   PUT     /api/v1/summits/{id}/presentations/{presentation_id}/submission-period/reopen
close-presentation-submission-period    DELETE  /api/v1/summits/{id}/presentations/{presentation_id}/submission-period/reopen
-- 2 rows, each carrying summits/write, summits/write-event, summits/write-presentation
-- each also carrying authz_groups super-admins, administrators, summit-front-end-administrators
```

Both route strings byte match the Laravel routes as printed by `route:list`.

## Testing

97 new tests across five files, 45 integration and 52 unit:

| File | Tests | Kind | Covers |
|---|---|---|---|
| `tests/PresentationReopenModelTest.php` | 8 | integration | predicates, derived deadline, the `isSubmissionClosed()` fold |
| `tests/PresentationReopenApiTest.php` | 25 | integration | endpoints, serialization, CFP table feeds, acceptance under an active grant, open-window parity |
| `tests/PresentationReopenAuthzTest.php` | 12 | integration | non-admin 403s, both delete paths, authorship, the create gate |
| `tests/Unit/Models/PresentationSubmissionReopenTest.php` | 29 | unit | the full deadline and predicate matrix, including half-states and boundaries |
| `tests/Unit/Services/PresentationSubmissionReopenServiceTest.php` | 23 | unit | every validation branch of the reopen service |

Integration shard: `OK (59 tests, 385 assertions)`. Unit files: `OK (29 tests, 59 assertions)` and `OK (23 tests, 77 assertions)`.

**All five files are registered in the `push.yml` matrix.** No CI job covers the `tests/` root, and `tests/Unit/Models/` was not previously sharded either, so a test in either location runs nowhere unless it is named.

The two unit files are genuinely database-free and framework-free: they extend plain `PHPUnit\Framework\TestCase`, bind a real config repository into a bare container for the facade, and mock `ITransactionService` so the transaction callback still executes. **52 tests run in about 120ms**, against roughly 50 seconds for the integration shard. They exist because several cases are impractical or impossible to reach otherwise: the expiry boundary, the half-states where hours is set with a null date or the reverse, and the service's `$hours < 1` guard, which the endpoint's `min:1` rule makes unreachable over HTTP so the unit test is its only coverage.

Two notes on test rigour, both of which changed how these were written:

- **The authz tests run against a genuinely non-admin identity.** `ProtectedApiTestCase` produces a global admin through two independent levers, the persisted group and the access token stub's default IdP groups, and both delete guards short circuit for a global admin. Both levers are defeated and a canary asserts it, because an admin run 403 suite proves nothing.
- **Several tests arrange their precondition directly on the model rather than through the reopen endpoint.** A BrowserKit test cannot perform two sequential HTTP writes against the same entity: `DoctrineMiddleware` closes the model entity manager after every request and singleton repositories pin the manager they were first resolved with, so the second write is silently dropped while still returning success. Each affected test asserts its precondition landed in the database before issuing the request under test.

The full suite is green in CI, including the `tests/oauth2/` shard at 1069 tests. Local full-suite runs need two setup steps that CI does for itself: freshly created test databases (`php artisan db:create_initial_db` for both schemas, as `push.yml` does), and `max_connections` above MySQL's default of 151, which the suite exceeds. Without those, a local run reports failures that are entirely environmental.

## Not in scope

- Cache key work, already shipped in #577.
- The delete bypass role narrowness, ClickUp `86bba832v`.
- A window guard on media and speaker subresource mutations, ClickUp `86bba8388`.
- Presentation creation under a closed plan. A test asserts creation stays blocked.

Three pre-existing defects were found while implementing this and deliberately left untouched, so they are not mistaken for regressions or for oversights:

- `SelectionPlan::areFieldsEqual` compares its first argument to itself, so the scalar branch always reports equal and the allowed editable question guard never fires for scalar fields.
- `PresentationType::isAreSpeakersMandatory()` ignores the `are_speakers_mandatory` column and returns `min_speakers > 0`, so calling the setter has no effect.
- `getPresentationMediaUploads` is registered twice in `routes/api_v1.php`.

## Scope compatibility with Show Admin, checked

Scope validation is any of, and the endpoints accept `WriteSummitData` (`summits/write`), `WriteEventData` (`summits/write-event`) or `WritePresentationData` (`summits/write-presentation`). summit-admin's requested scopes, per its `.env.example`, are:

```
summits/read
summits/read/all
summits/write                          <- WriteSummitData
summits/write-event                    <- WriteEventData
summits/write-presentation-materials   <- note: NOT write-presentation
```

Two of the three, so Show Admin is admitted without any client change.

This is also why the trio matters rather than being belt and braces. summit-admin holds `write-presentation-materials`, not `write-presentation`, so registering `WritePresentationData` alone would have returned 403 to every Show Admin caller in production while passing every test here, because the test token does carry it.

One residual check for whoever deploys: `.env.example` is the template, and a deployed `.env` can drift from it. Worth confirming the deployed summit-admin `.env` still lists `summits/write` before the control in `86bba82y3` goes live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can reopen closed presentation submission periods for a configurable duration.
  * Administrators can immediately close reopened submission periods.
  * Reopening details, deadlines, and administrator information are visible where applicable.
  * Configurable default and maximum reopening windows are now supported.

* **Bug Fixes**
  * Validly reopened presentations can be updated and completed during their reopening window, while existing permissions remain enforced.

* **Tests**
  * Added comprehensive coverage for reopening, closing, authorization, validation, serialization, and configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




