### PR TITLE
fix(promo-codes): persist quantity_available for generic SUMMIT_PROMO_CODE class

### DIFF
--- a/app/Models/Foundation/Summit/Factories/SummitPromoCodeFactory.php
+++ b/app/Models/Foundation/Summit/Factories/SummitPromoCodeFactory.php
@@ -190,6 +190,11 @@ final class SummitPromoCodeFactory
             $promo_code->setAllowsToReassign(boolval($data['allows_to_reassign']));
 
         switch ($data['class_name']){
+            case SummitRegistrationPromoCode::ClassName:{
+                if(isset($data['quantity_available']))
+                    $promo_code->setQuantityAvailable(intval($data['quantity_available']));
+            }
+            break;
             case SummitRegistrationDiscountCode::ClassName:
             case PrePaidSummitRegistrationDiscountCode::ClassName:{
                 if(isset($data['amount']))

--- a/tests/Unit/Services/SummitPromoCodeFactoryTest.php
+++ b/tests/Unit/Services/SummitPromoCodeFactoryTest.php
@@ -14,6 +14,7 @@
 
 use App\Models\Foundation\Summit\Factories\SummitPromoCodeFactory;
 use models\summit\Summit;
+use models\summit\SummitRegistrationPromoCode;
 use models\summit\SummitRegistrationDiscountCode;
 use models\summit\SummitRegistrationDiscountCodeTicketTypeRule;
 use models\summit\SummitTicketType;
@@ -92,5 +93,28 @@ class SummitPromoCodeFactoryTest extends TestCase
 
         $this->assertEquals(25.0, $code->getRate(),
             'flat rate must be applied when the payload carries no ticket_types_rules');
+    }
+
+    /**
+     * Regression: populate()'s per-class switch had no case for the generic
+     * SUMMIT_PROMO_CODE class, so quantity_available was silently dropped on
+     * create and update - codes meant to be limited (one-off, N uses) ended up
+     * with 0 (= unlimited) in the DB.
+     */
+    public function testPopulatePersistsQuantityAvailableForGenericSummitPromoCode(): void
+    {
+        $summit = $this->createMock(Summit::class);
+
+        $code = new SummitRegistrationPromoCode();
+
+        $data = [
+            'class_name'         => SummitRegistrationPromoCode::ClassName,
+            'quantity_available' => 24,
+        ];
+
+        SummitPromoCodeFactory::populate($code, $summit, $data);
+
+        $this->assertEquals(24, $code->getQuantityAvailable(),
+            'quantity_available must be persisted for the generic SUMMIT_PROMO_CODE class');
     }
 }


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bbebyex
## Problem

`SummitPromoCodeFactory::populate()` applies `quantity_available` for every promo code class (member, speaker, sponsor, discount, domain-authorized) **except the generic `SummitRegistrationPromoCode` (`SUMMIT_PROMO_CODE`)** — the per-class `switch` has no case for it, so the field is silently dropped on both create and update (both paths go through `populate()`).

Request validation accepts the field (`PromoCodesValidationRulesFactory`, `sometimes|integer|min:0`) and show-admin sends it, so admins believe the limit was saved. Since `quantity_available = 0` means **unlimited use**, codes intended to be one-off / N-uses end up with no usage cap at all.

Found while investigating ClickUp [86bbebyex](https://app.clickup.com/t/86bbebyex): two prod promo codes for summit 73 (`HP31BS1`, intended 1 use; `26GLOSTAFF`, intended 24 uses) were stored with `QuantityAvailable = 0` — i.e. effectively unlimited. Data was corrected manually; this PR fixes the root cause.

## Fix

Add the missing `SummitRegistrationPromoCode::ClassName` case to the `populate()` switch, applying `quantity_available` the same way every other class already does. `setQuantityAvailable()` already validates the value.

Deliberately **not** included: `PrePaidSummitRegistrationPromoCode` (the other class without a case) — its `quantity_available` is managed by the prepaid purchase flow, and making it admin-editable is a separate product decision.

## Test

`tests/Unit/Services/SummitPromoCodeFactoryTest::testPopulatePersistsQuantityAvailableForGenericSummitPromoCode` — red/green verified: fails with `0 !== 24` without the fix, passes with it. Full test class 3/3 green inside the Docker stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Summit registration promo codes now correctly save the available quantity when provided.
  * Quantity values are consistently stored as whole numbers.

* **Tests**
  * Added coverage to verify available quantities persist correctly for summit promo codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->